### PR TITLE
Refactor error types for proper error chaining

### DIFF
--- a/crates/changeset-core/src/error.rs
+++ b/crates/changeset-core/src/error.rs
@@ -1,18 +1,31 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ChangesetError {
-    #[error("IO error: {0}")]
+    #[error("IO error")]
     Io(#[from] std::io::Error),
 
-    #[error("Parse error: {0}")]
-    Parse(String),
+    #[error("failed to parse JSON")]
+    JsonParse(#[from] serde_json::Error),
+
+    #[error("failed to parse changeset file '{path}'")]
+    ChangesetParse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("failed to parse version '{input}'")]
+    VersionParse {
+        input: String,
+        #[source]
+        source: semver::Error,
+    },
 
     #[error("Git error: {0}")]
     Git(String),
-
-    #[error("Version error: {0}")]
-    Version(String),
 }
 
 pub type Result<T> = std::result::Result<T, ChangesetError>;

--- a/crates/changeset-parse/src/lib.rs
+++ b/crates/changeset-parse/src/lib.rs
@@ -1,8 +1,7 @@
-use changeset_core::{Changeset, ChangesetError, Result};
+use changeset_core::{Changeset, Result};
 
 pub fn parse_changeset(content: &str) -> Result<Changeset> {
-    serde_json::from_str(content)
-        .map_err(|e| ChangesetError::Parse(format!("Failed to parse changeset: {}", e)))
+    Ok(serde_json::from_str(content)?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Resolves #1

Replace String-based error variants with proper error types that preserve the error chain. This allows the ? operator to work seamlessly without map_err() in business logic.

- Add JsonParse variant with #[from] for automatic conversion
- Add ChangesetParse variant with #[source] for file path context
- Add VersionParse variant with #[source] for version input context
- Remove Parse and Version String variants
- Simplify parse_changeset to use ? operator directly