### PR TITLE
Implement release command with version calculation

### DIFF
--- a/crates/cargo-changeset/src/commands/mod.rs
+++ b/crates/cargo-changeset/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod add;
 mod init;
+mod release;
 mod status;
 mod verify;
 
@@ -18,8 +19,8 @@ pub(crate) enum Commands {
     Verify(VerifyArgs),
     /// Show pending changesets and projected version bumps
     Status,
-    /// Bump versions based on changesets
-    Version,
+    /// Calculate version bumps and prepare releases based on pending changesets
+    Release(ReleaseArgs),
     /// Initialize changeset directory in the project
     Init,
 }
@@ -70,6 +71,13 @@ pub(crate) struct VerifyArgs {
     pub allow_deleted_changesets: bool,
 }
 
+#[derive(Args)]
+pub(crate) struct ReleaseArgs {
+    /// Preview changes without modifying any files
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
 pub(crate) struct ExecuteResult {
     pub quiet: bool,
 }
@@ -83,10 +91,10 @@ impl Commands {
                 (verify::run(args, start_path), ExecuteResult { quiet })
             }
             Self::Status => (status::run(start_path), ExecuteResult { quiet: false }),
-            Self::Version => {
-                println!("Version command not yet implemented");
-                (Ok(()), ExecuteResult { quiet: false })
-            }
+            Self::Release(args) => (
+                release::run(args, start_path),
+                ExecuteResult { quiet: false },
+            ),
             Self::Init => (init::run(start_path), ExecuteResult { quiet: false }),
         }
     }

--- a/crates/cargo-changeset/src/commands/release.rs
+++ b/crates/cargo-changeset/src/commands/release.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+use changeset_operations::operations::{
+    ReleaseInput, ReleaseOperation, ReleaseOutcome, ReleaseOutput,
+};
+use changeset_operations::providers::{FileSystemChangesetIO, FileSystemProjectProvider};
+use changeset_operations::traits::ProjectProvider;
+
+use super::ReleaseArgs;
+use crate::error::Result;
+
+pub(crate) fn run(args: ReleaseArgs, start_path: &Path) -> Result<()> {
+    let project_provider = FileSystemProjectProvider::new();
+    let project = project_provider.discover_project(start_path)?;
+    let changeset_reader = FileSystemChangesetIO::new(&project.root);
+
+    let operation = ReleaseOperation::new(project_provider, changeset_reader);
+    let input = ReleaseInput {
+        dry_run: args.dry_run,
+    };
+    let outcome = operation.execute(start_path, &input)?;
+
+    print_outcome(&outcome);
+
+    Ok(())
+}
+
+fn print_outcome(outcome: &ReleaseOutcome) {
+    match outcome {
+        ReleaseOutcome::NoChangesets => {
+            println!("No pending changesets to release.");
+        }
+        ReleaseOutcome::DryRun(output) => {
+            println!("Dry run - no changes will be made.\n");
+            print_release_output(output);
+        }
+        ReleaseOutcome::Executed(output) => {
+            print_release_output(output);
+            println!("\nRelease complete.");
+        }
+    }
+}
+
+fn print_release_output(output: &ReleaseOutput) {
+    if output.planned_releases.is_empty() {
+        println!("No packages to release.");
+        return;
+    }
+
+    println!("Planned releases:");
+    for release in &output.planned_releases {
+        println!(
+            "  {} {} -> {} ({:?})",
+            release.name, release.current_version, release.new_version, release.bump_type
+        );
+    }
+
+    if !output.unchanged_packages.is_empty() {
+        println!("\nUnchanged packages:");
+        for name in &output.unchanged_packages {
+            println!("  {name}");
+        }
+    }
+
+    println!(
+        "\nChangesets to consume: {}",
+        output.changesets_consumed.len()
+    );
+}

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -4,12 +4,41 @@ use clap::ValueEnum;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BumpType {
-    Major,
-    Minor,
     Patch,
+    Minor,
+    Major,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bump_type_ordering_patch_is_smallest() {
+        assert!(BumpType::Patch < BumpType::Minor);
+        assert!(BumpType::Patch < BumpType::Major);
+    }
+
+    #[test]
+    fn bump_type_ordering_minor_is_middle() {
+        assert!(BumpType::Minor > BumpType::Patch);
+        assert!(BumpType::Minor < BumpType::Major);
+    }
+
+    #[test]
+    fn bump_type_ordering_major_is_largest() {
+        assert!(BumpType::Major > BumpType::Patch);
+        assert!(BumpType::Major > BumpType::Minor);
+    }
+
+    #[test]
+    fn bump_type_max_returns_largest() {
+        let bumps = [BumpType::Patch, BumpType::Minor, BumpType::Major];
+        assert_eq!(bumps.iter().max(), Some(&BumpType::Major));
+    }
 }
 
 #[derive(

--- a/crates/changeset-operations/Cargo.toml
+++ b/crates/changeset-operations/Cargo.toml
@@ -13,7 +13,9 @@ changeset-core = { workspace = true }
 changeset-parse = { workspace = true }
 changeset-project = { workspace = true }
 changeset-git = { workspace = true }
+changeset-version = { workspace = true }
 indexmap = { workspace = true }
+semver = { workspace = true }
 thiserror = { workspace = true }
 petname = { workspace = true }
 

--- a/crates/changeset-operations/src/operations/mod.rs
+++ b/crates/changeset-operations/src/operations/mod.rs
@@ -1,9 +1,11 @@
 mod add;
 mod init;
+mod release;
 mod status;
 mod verify;
 
 pub use add::{AddInput, AddOperation, AddResult};
 pub use init::{InitOperation, InitOutput};
+pub use release::{PackageVersion, ReleaseInput, ReleaseOperation, ReleaseOutcome, ReleaseOutput};
 pub use status::{StatusOperation, StatusOutput};
 pub use verify::{VerifyInput, VerifyOperation, VerifyOutcome};

--- a/crates/changeset-operations/src/operations/release.rs
+++ b/crates/changeset-operations/src/operations/release.rs
@@ -1,0 +1,313 @@
+use std::path::{Path, PathBuf};
+
+use changeset_core::BumpType;
+use changeset_version::{bump_version, max_bump_type};
+use indexmap::IndexMap;
+use semver::Version;
+
+use crate::Result;
+use crate::traits::{ChangesetReader, ProjectProvider};
+
+pub struct ReleaseInput {
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageVersion {
+    pub name: String,
+    pub current_version: Version,
+    pub new_version: Version,
+    pub bump_type: BumpType,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseOutput {
+    pub planned_releases: Vec<PackageVersion>,
+    pub unchanged_packages: Vec<String>,
+    pub changesets_consumed: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub enum ReleaseOutcome {
+    DryRun(ReleaseOutput),
+    Executed(ReleaseOutput),
+    NoChangesets,
+}
+
+pub struct ReleaseOperation<P, R> {
+    project_provider: P,
+    changeset_reader: R,
+}
+
+impl<P, R> ReleaseOperation<P, R>
+where
+    P: ProjectProvider,
+    R: ChangesetReader,
+{
+    pub fn new(project_provider: P, changeset_reader: R) -> Self {
+        Self {
+            project_provider,
+            changeset_reader,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered or if changeset files
+    /// cannot be read.
+    pub fn execute(&self, start_path: &Path, input: &ReleaseInput) -> Result<ReleaseOutcome> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let changeset_dir = project.root.join(root_config.changeset_dir());
+        let changeset_files = self.changeset_reader.list_changesets(&changeset_dir)?;
+
+        if changeset_files.is_empty() {
+            return Ok(ReleaseOutcome::NoChangesets);
+        }
+
+        let mut bumps_by_package: IndexMap<String, Vec<BumpType>> = IndexMap::new();
+
+        for path in &changeset_files {
+            let changeset = self.changeset_reader.read_changeset(path)?;
+            for release in &changeset.releases {
+                bumps_by_package
+                    .entry(release.name.clone())
+                    .or_default()
+                    .push(release.bump_type);
+            }
+        }
+
+        let package_versions: IndexMap<_, _> = project
+            .packages
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect();
+
+        let mut planned_releases = Vec::new();
+
+        for (name, bumps) in &bumps_by_package {
+            if let Some(bump_type) = max_bump_type(bumps) {
+                if let Some(current_version) = package_versions.get(name) {
+                    let new_version = bump_version(current_version, bump_type);
+                    planned_releases.push(PackageVersion {
+                        name: name.clone(),
+                        current_version: current_version.clone(),
+                        new_version,
+                        bump_type,
+                    });
+                }
+            }
+        }
+
+        let packages_with_releases: std::collections::HashSet<_> =
+            planned_releases.iter().map(|r| r.name.clone()).collect();
+
+        let unchanged_packages: Vec<String> = project
+            .packages
+            .iter()
+            .filter(|p| !packages_with_releases.contains(&p.name))
+            .map(|p| p.name.clone())
+            .collect();
+
+        let output = ReleaseOutput {
+            planned_releases,
+            unchanged_packages,
+            changesets_consumed: changeset_files,
+        };
+
+        if input.dry_run {
+            Ok(ReleaseOutcome::DryRun(output))
+        } else {
+            Ok(ReleaseOutcome::Executed(output))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{MockChangesetReader, MockProjectProvider, make_changeset};
+
+    #[test]
+    fn returns_no_changesets_when_empty() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        assert!(matches!(result, ReleaseOutcome::NoChangesets));
+    }
+
+    #[test]
+    fn calculates_single_patch_bump() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix a bug");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        let ReleaseOutcome::DryRun(output) = result else {
+            panic!("expected DryRun outcome");
+        };
+
+        assert_eq!(output.planned_releases.len(), 1);
+        let release = &output.planned_releases[0];
+        assert_eq!(release.name, "my-crate");
+        assert_eq!(release.current_version.to_string(), "1.0.0");
+        assert_eq!(release.new_version.to_string(), "1.0.1");
+        assert_eq!(release.bump_type, BumpType::Patch);
+    }
+
+    #[test]
+    fn takes_maximum_bump_from_multiple_changesets() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.2.3");
+        let changeset1 = make_changeset("my-crate", BumpType::Patch, "Fix bug");
+        let changeset2 = make_changeset("my-crate", BumpType::Minor, "Add feature");
+
+        let changeset_reader = MockChangesetReader::new().with_changesets(vec![
+            (PathBuf::from(".changeset/fix.md"), changeset1),
+            (PathBuf::from(".changeset/feature.md"), changeset2),
+        ]);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        let ReleaseOutcome::DryRun(output) = result else {
+            panic!("expected DryRun outcome");
+        };
+
+        assert_eq!(output.planned_releases.len(), 1);
+        let release = &output.planned_releases[0];
+        assert_eq!(release.new_version.to_string(), "1.3.0");
+        assert_eq!(release.bump_type, BumpType::Minor);
+    }
+
+    #[test]
+    fn handles_workspace_with_multiple_packages() {
+        let project_provider =
+            MockProjectProvider::workspace(vec![("crate-a", "1.0.0"), ("crate-b", "2.0.0")]);
+
+        let changeset1 = make_changeset("crate-a", BumpType::Minor, "Add feature to A");
+        let changeset2 = make_changeset("crate-b", BumpType::Major, "Breaking change in B");
+
+        let changeset_reader = MockChangesetReader::new().with_changesets(vec![
+            (PathBuf::from(".changeset/feature-a.md"), changeset1),
+            (PathBuf::from(".changeset/breaking-b.md"), changeset2),
+        ]);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        let ReleaseOutcome::DryRun(output) = result else {
+            panic!("expected DryRun outcome");
+        };
+
+        assert_eq!(output.planned_releases.len(), 2);
+        assert!(output.unchanged_packages.is_empty());
+
+        let crate_a = output
+            .planned_releases
+            .iter()
+            .find(|r| r.name == "crate-a")
+            .expect("crate-a should be in releases");
+        assert_eq!(crate_a.new_version.to_string(), "1.1.0");
+
+        let crate_b = output
+            .planned_releases
+            .iter()
+            .find(|r| r.name == "crate-b")
+            .expect("crate-b should be in releases");
+        assert_eq!(crate_b.new_version.to_string(), "3.0.0");
+    }
+
+    #[test]
+    fn identifies_unchanged_packages() {
+        let project_provider = MockProjectProvider::workspace(vec![
+            ("crate-a", "1.0.0"),
+            ("crate-b", "2.0.0"),
+            ("crate-c", "3.0.0"),
+        ]);
+
+        let changeset = make_changeset("crate-a", BumpType::Patch, "Fix crate-a");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        let ReleaseOutcome::DryRun(output) = result else {
+            panic!("expected DryRun outcome");
+        };
+
+        assert_eq!(output.planned_releases.len(), 1);
+        assert_eq!(output.unchanged_packages.len(), 2);
+        assert!(output.unchanged_packages.contains(&"crate-b".to_string()));
+        assert!(output.unchanged_packages.contains(&"crate-c".to_string()));
+    }
+
+    #[test]
+    fn tracks_consumed_changeset_files() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset1 = make_changeset("my-crate", BumpType::Patch, "Fix 1");
+        let changeset2 = make_changeset("my-crate", BumpType::Patch, "Fix 2");
+
+        let changeset_reader = MockChangesetReader::new().with_changesets(vec![
+            (PathBuf::from(".changeset/fix1.md"), changeset1),
+            (PathBuf::from(".changeset/fix2.md"), changeset2),
+        ]);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: true };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        let ReleaseOutcome::DryRun(output) = result else {
+            panic!("expected DryRun outcome");
+        };
+
+        assert_eq!(output.changesets_consumed.len(), 2);
+    }
+
+    #[test]
+    fn returns_executed_when_not_dry_run() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader);
+        let input = ReleaseInput { dry_run: false };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed");
+
+        assert!(matches!(result, ReleaseOutcome::Executed(_)));
+    }
+}

--- a/crates/changeset-version/src/lib.rs
+++ b/crates/changeset-version/src/lib.rs
@@ -1,6 +1,11 @@
 use changeset_core::BumpType;
 use semver::Version;
 
+#[must_use]
+pub fn max_bump_type(bumps: &[BumpType]) -> Option<BumpType> {
+    bumps.iter().max().copied()
+}
+
 pub fn bump_version(version: &Version, bump_type: BumpType) -> Version {
     let mut new_version = version.clone();
 
@@ -45,5 +50,61 @@ mod tests {
         let version = Version::parse("1.2.3").unwrap();
         let bumped = bump_version(&version, BumpType::Major);
         assert_eq!(bumped, Version::parse("2.0.0").unwrap());
+    }
+
+    mod max_bump_type_tests {
+        use super::*;
+
+        #[test]
+        fn returns_none_for_empty_slice() {
+            assert_eq!(max_bump_type(&[]), None);
+        }
+
+        #[test]
+        fn returns_single_element() {
+            assert_eq!(max_bump_type(&[BumpType::Patch]), Some(BumpType::Patch));
+            assert_eq!(max_bump_type(&[BumpType::Minor]), Some(BumpType::Minor));
+            assert_eq!(max_bump_type(&[BumpType::Major]), Some(BumpType::Major));
+        }
+
+        #[test]
+        fn returns_minor_for_patch_and_minor() {
+            assert_eq!(
+                max_bump_type(&[BumpType::Patch, BumpType::Minor]),
+                Some(BumpType::Minor)
+            );
+        }
+
+        #[test]
+        fn returns_major_for_minor_and_major() {
+            assert_eq!(
+                max_bump_type(&[BumpType::Minor, BumpType::Major]),
+                Some(BumpType::Major)
+            );
+        }
+
+        #[test]
+        fn returns_major_for_all_three() {
+            assert_eq!(
+                max_bump_type(&[BumpType::Patch, BumpType::Minor, BumpType::Major]),
+                Some(BumpType::Major)
+            );
+        }
+
+        #[test]
+        fn handles_duplicates() {
+            assert_eq!(
+                max_bump_type(&[BumpType::Patch, BumpType::Patch, BumpType::Minor]),
+                Some(BumpType::Minor)
+            );
+        }
+
+        #[test]
+        fn order_does_not_matter() {
+            assert_eq!(
+                max_bump_type(&[BumpType::Major, BumpType::Patch, BumpType::Minor]),
+                Some(BumpType::Major)
+            );
+        }
     }
 }


### PR DESCRIPTION
- Resolves #10 

Add the release command that calculates version bumps by aggregating pending changesets. The command computes the maximum bump type per package and calculates new versions using semantic versioning rules.

- Add `PartialOrd`/`Ord` to `BumpType` (Patch < Minor < Major)
- Add `max_bump_type` function to `changeset-version`
- Create `ReleaseOperation` with dry-run support
- Wire up CLI command replacing stub `Version` variant