### PR TITLE
Add Cargo.toml version updates to release command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ changeset-version = { path = "crates/changeset-version" }
 changeset-project = { path = "crates/changeset-project" }
 changeset-changelog = { path = "crates/changeset-changelog" }
 changeset-operations = { path = "crates/changeset-operations" }
+changeset-manifest = { path = "crates/changeset-manifest" }
 
 # External dependencies
 indexmap = { version = "2.7.1", features = ["serde"] }
@@ -38,3 +39,4 @@ glob = "0.3.3"
 git2 = "0.20"
 dialoguer = "0.12.0"
 petname = "2.0.2"
+toml_edit = "0.25.0"

--- a/crates/cargo-changeset/src/commands/mod.rs
+++ b/crates/cargo-changeset/src/commands/mod.rs
@@ -76,6 +76,10 @@ pub(crate) struct ReleaseArgs {
     /// Preview changes without modifying any files
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Convert inherited versions (version.workspace = true) to explicit versions
+    #[arg(long)]
+    pub convert: bool,
 }
 
 pub(crate) struct ExecuteResult {

--- a/crates/cargo-changeset/src/commands/release.rs
+++ b/crates/cargo-changeset/src/commands/release.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use changeset_operations::operations::{
     ReleaseInput, ReleaseOperation, ReleaseOutcome, ReleaseOutput,
 };
-use changeset_operations::providers::{FileSystemChangesetIO, FileSystemProjectProvider};
+use changeset_operations::providers::{
+    FileSystemChangesetIO, FileSystemManifestWriter, FileSystemProjectProvider,
+};
 use changeset_operations::traits::ProjectProvider;
 
 use super::ReleaseArgs;
@@ -13,10 +15,12 @@ pub(crate) fn run(args: ReleaseArgs, start_path: &Path) -> Result<()> {
     let project_provider = FileSystemProjectProvider::new();
     let project = project_provider.discover_project(start_path)?;
     let changeset_reader = FileSystemChangesetIO::new(&project.root);
+    let manifest_writer = FileSystemManifestWriter::new();
 
-    let operation = ReleaseOperation::new(project_provider, changeset_reader);
+    let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
     let input = ReleaseInput {
         dry_run: args.dry_run,
+        convert_inherited: args.convert,
     };
     let outcome = operation.execute(start_path, &input)?;
 

--- a/crates/changeset-manifest/Cargo.toml
+++ b/crates/changeset-manifest/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "changeset-manifest"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Format-preserving Cargo.toml read/write operations"
+
+[dependencies]
+semver = { workspace = true }
+thiserror = { workspace = true }
+toml_edit = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.25"
+
+[lints]
+workspace = true

--- a/crates/changeset-manifest/src/error.rs
+++ b/crates/changeset-manifest/src/error.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("failed to read manifest at '{path}'")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to write manifest at '{path}'")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse TOML at '{path}'")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml_edit::TomlError,
+    },
+
+    #[error("missing required field '{field}' in '{path}'")]
+    MissingField { path: PathBuf, field: String },
+
+    #[error("expected version '{expected}' but found '{actual}' in '{path}'")]
+    VerificationFailed {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("invalid version string '{version}' in '{path}'")]
+    InvalidVersion {
+        path: PathBuf,
+        version: String,
+        #[source]
+        source: semver::Error,
+    },
+}

--- a/crates/changeset-manifest/src/lib.rs
+++ b/crates/changeset-manifest/src/lib.rs
@@ -1,0 +1,9 @@
+mod error;
+mod reader;
+mod writer;
+
+pub use error::ManifestError;
+pub use reader::{
+    has_inherited_version, has_workspace_package_version, read_document, read_version,
+};
+pub use writer::{remove_workspace_version, verify_version, write_version};

--- a/crates/changeset-manifest/src/reader.rs
+++ b/crates/changeset-manifest/src/reader.rs
@@ -1,0 +1,188 @@
+use std::path::Path;
+
+use semver::Version;
+use toml_edit::DocumentMut;
+
+use crate::error::ManifestError;
+
+/// # Errors
+///
+/// Returns `ManifestError::Read` if the file cannot be read, or
+/// `ManifestError::Parse` if the TOML is malformed.
+pub fn read_document(path: &Path) -> Result<DocumentMut, ManifestError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    content
+        .parse::<DocumentMut>()
+        .map_err(|source| ManifestError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// # Errors
+///
+/// Returns `ManifestError::MissingField` if required fields are absent, or
+/// `ManifestError::InvalidVersion` if the version string is not valid semver.
+pub fn read_version(path: &Path) -> Result<Version, ManifestError> {
+    let doc = read_document(path)?;
+
+    let package = doc
+        .get("package")
+        .ok_or_else(|| ManifestError::MissingField {
+            path: path.to_path_buf(),
+            field: "package".to_string(),
+        })?;
+
+    let version_item = package
+        .get("version")
+        .ok_or_else(|| ManifestError::MissingField {
+            path: path.to_path_buf(),
+            field: "package.version".to_string(),
+        })?;
+
+    let version_str = version_item
+        .as_str()
+        .ok_or_else(|| ManifestError::MissingField {
+            path: path.to_path_buf(),
+            field: "package.version (as string)".to_string(),
+        })?;
+
+    Version::parse(version_str).map_err(|source| ManifestError::InvalidVersion {
+        path: path.to_path_buf(),
+        version: version_str.to_string(),
+        source,
+    })
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read or parsed.
+pub fn has_inherited_version(path: &Path) -> Result<bool, ManifestError> {
+    let doc = read_document(path)?;
+
+    let Some(package) = doc.get("package") else {
+        return Ok(false);
+    };
+
+    let Some(version) = package.get("version") else {
+        return Ok(false);
+    };
+
+    if let Some(table) = version.as_inline_table() {
+        return Ok(table
+            .get("workspace")
+            .and_then(toml_edit::Value::as_bool)
+            .unwrap_or(false));
+    }
+
+    if let Some(table) = version.as_table() {
+        return Ok(table
+            .get("workspace")
+            .and_then(toml_edit::Item::as_bool)
+            .unwrap_or(false));
+    }
+
+    Ok(false)
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read or parsed.
+pub fn has_workspace_package_version(path: &Path) -> Result<bool, ManifestError> {
+    let doc = read_document(path)?;
+
+    let Some(workspace) = doc.get("workspace") else {
+        return Ok(false);
+    };
+
+    let Some(package) = workspace.get("package") else {
+        return Ok(false);
+    };
+
+    Ok(package.get("version").is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_version_extracts_semver() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version = "1.2.3"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        let version = read_version(&path).expect("read version");
+        assert_eq!(version, Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn has_inherited_version_detects_workspace_true() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version.workspace = true
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        assert!(has_inherited_version(&path).expect("check inherited"));
+    }
+
+    #[test]
+    fn has_inherited_version_returns_false_for_literal() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version = "1.0.0"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        assert!(!has_inherited_version(&path).expect("check inherited"));
+    }
+
+    #[test]
+    fn has_workspace_package_version_detects_root_version() {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        assert!(has_workspace_package_version(&path).expect("check workspace version"));
+    }
+
+    #[test]
+    fn has_workspace_package_version_returns_false_when_missing() {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+edition = "2021"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        assert!(!has_workspace_package_version(&path).expect("check workspace version"));
+    }
+}

--- a/crates/changeset-manifest/src/writer.rs
+++ b/crates/changeset-manifest/src/writer.rs
@@ -1,0 +1,223 @@
+use std::path::Path;
+
+use semver::Version;
+use toml_edit::value;
+
+use crate::error::ManifestError;
+use crate::reader::{read_document, read_version};
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read, parsed, or written.
+pub fn write_version(path: &Path, version: &Version) -> Result<(), ManifestError> {
+    let mut doc = read_document(path)?;
+
+    let package = doc
+        .get_mut("package")
+        .ok_or_else(|| ManifestError::MissingField {
+            path: path.to_path_buf(),
+            field: "package".to_string(),
+        })?;
+
+    let package_table = package
+        .as_table_like_mut()
+        .ok_or_else(|| ManifestError::MissingField {
+            path: path.to_path_buf(),
+            field: "package (as table)".to_string(),
+        })?;
+
+    package_table.insert("version", value(version.to_string()));
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read, parsed, or written.
+pub fn remove_workspace_version(path: &Path) -> Result<(), ManifestError> {
+    let mut doc = read_document(path)?;
+
+    let Some(workspace) = doc.get_mut("workspace") else {
+        return Ok(());
+    };
+
+    let Some(workspace_table) = workspace.as_table_like_mut() else {
+        return Ok(());
+    };
+
+    let Some(package) = workspace_table.get_mut("package") else {
+        return Ok(());
+    };
+
+    let Some(package_table) = package.as_table_like_mut() else {
+        return Ok(());
+    };
+
+    package_table.remove("version");
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// # Errors
+///
+/// Returns `ManifestError::VerificationFailed` if the version in the manifest
+/// does not match the expected version.
+pub fn verify_version(path: &Path, expected: &Version) -> Result<(), ManifestError> {
+    let actual = read_version(path)?;
+
+    if actual != *expected {
+        return Err(ManifestError::VerificationFailed {
+            path: path.to_path_buf(),
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_version_updates_package_version() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version = "1.0.0"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        write_version(&path, &Version::new(2, 0, 0)).expect("write version");
+
+        let result = read_version(&path).expect("read version");
+        assert_eq!(result, Version::new(2, 0, 0));
+    }
+
+    #[test]
+    fn write_version_converts_inherited_to_literal() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version.workspace = true
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        write_version(&path, &Version::new(1, 5, 0)).expect("write version");
+
+        let result = read_version(&path).expect("read version");
+        assert_eq!(result, Version::new(1, 5, 0));
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"version = "1.5.0""#));
+        assert!(!content.contains("version.workspace"));
+    }
+
+    #[test]
+    fn write_version_preserves_comments() {
+        let toml = r#"# Package configuration
+[package]
+name = "test-crate"
+# Version comment
+version = "1.0.0"
+# After version comment
+edition = "2021"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        write_version(&path, &Version::new(2, 0, 0)).expect("write version");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("# Package configuration"));
+        assert!(content.contains("# After version comment"));
+    }
+
+    #[test]
+    fn remove_workspace_version_removes_field() {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        remove_workspace_version(&path).expect("remove workspace version");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(!content.contains(r#"version = "1.0.0""#));
+        assert!(content.contains(r#"edition = "2021""#));
+    }
+
+    #[test]
+    fn remove_workspace_version_preserves_other_fields() {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+license = "MIT"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        remove_workspace_version(&path).expect("remove workspace version");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"edition = "2021""#));
+        assert!(content.contains(r#"license = "MIT""#));
+        assert!(content.contains(r#"members = ["crates/*"]"#));
+    }
+
+    #[test]
+    fn verify_version_succeeds_when_matching() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version = "1.2.3"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        verify_version(&path, &Version::new(1, 2, 3)).expect("verify version");
+    }
+
+    #[test]
+    fn verify_version_fails_when_mismatched() {
+        let toml = r#"
+[package]
+name = "test-crate"
+version = "1.0.0"
+"#;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, toml).expect("write test file");
+
+        let result = verify_version(&path, &Version::new(2, 0, 0));
+        assert!(matches!(
+            result,
+            Err(ManifestError::VerificationFailed { .. })
+        ));
+    }
+}

--- a/crates/changeset-operations/Cargo.toml
+++ b/crates/changeset-operations/Cargo.toml
@@ -13,6 +13,7 @@ changeset-core = { workspace = true }
 changeset-parse = { workspace = true }
 changeset-project = { workspace = true }
 changeset-git = { workspace = true }
+changeset-manifest = { workspace = true }
 changeset-version = { workspace = true }
 indexmap = { workspace = true }
 semver = { workspace = true }

--- a/crates/changeset-operations/src/error.rs
+++ b/crates/changeset-operations/src/error.rs
@@ -16,6 +16,9 @@ pub enum OperationError {
     #[error(transparent)]
     Parse(#[from] changeset_parse::FormatError),
 
+    #[error(transparent)]
+    Manifest(#[from] changeset_manifest::ManifestError),
+
     #[error("failed to read changeset file '{path}'")]
     ChangesetFileRead {
         path: PathBuf,
@@ -66,6 +69,9 @@ pub enum OperationError {
 
     #[error("IO error")]
     Io(#[from] std::io::Error),
+
+    #[error("packages with inherited versions require --convert flag: {}", packages.join(", "))]
+    InheritedVersionsRequireConvert { packages: Vec<String> },
 }
 
 pub type Result<T> = std::result::Result<T, OperationError>;

--- a/crates/changeset-operations/src/operations/release.rs
+++ b/crates/changeset-operations/src/operations/release.rs
@@ -1,15 +1,17 @@
 use std::path::{Path, PathBuf};
 
-use changeset_core::BumpType;
+use changeset_core::{BumpType, PackageInfo};
 use changeset_version::{bump_version, max_bump_type};
 use indexmap::IndexMap;
 use semver::Version;
 
 use crate::Result;
-use crate::traits::{ChangesetReader, ProjectProvider};
+use crate::error::OperationError;
+use crate::traits::{ChangesetReader, ManifestWriter, ProjectProvider};
 
 pub struct ReleaseInput {
     pub dry_run: bool,
+    pub convert_inherited: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,27 +36,44 @@ pub enum ReleaseOutcome {
     NoChangesets,
 }
 
-pub struct ReleaseOperation<P, R> {
+pub struct ReleaseOperation<P, R, M> {
     project_provider: P,
     changeset_reader: R,
+    manifest_writer: M,
 }
 
-impl<P, R> ReleaseOperation<P, R>
+impl<P, R, M> ReleaseOperation<P, R, M>
 where
     P: ProjectProvider,
     R: ChangesetReader,
+    M: ManifestWriter,
 {
-    pub fn new(project_provider: P, changeset_reader: R) -> Self {
+    pub fn new(project_provider: P, changeset_reader: R, manifest_writer: M) -> Self {
         Self {
             project_provider,
             changeset_reader,
+            manifest_writer,
         }
+    }
+
+    fn find_packages_with_inherited_versions(
+        &self,
+        packages: &[PackageInfo],
+    ) -> Result<Vec<String>> {
+        let mut inherited = Vec::new();
+        for pkg in packages {
+            let manifest_path = pkg.path.join("Cargo.toml");
+            if self.manifest_writer.has_inherited_version(&manifest_path)? {
+                inherited.push(pkg.name.clone());
+            }
+        }
+        Ok(inherited)
     }
 
     /// # Errors
     ///
-    /// Returns an error if the project cannot be discovered or if changeset files
-    /// cannot be read.
+    /// Returns an error if the project cannot be discovered, changeset files
+    /// cannot be read, or manifest updates fail.
     pub fn execute(&self, start_path: &Path, input: &ReleaseInput) -> Result<ReleaseOutcome> {
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
@@ -64,6 +83,13 @@ where
 
         if changeset_files.is_empty() {
             return Ok(ReleaseOutcome::NoChangesets);
+        }
+
+        let inherited_packages = self.find_packages_with_inherited_versions(&project.packages)?;
+        if !inherited_packages.is_empty() && !input.convert_inherited {
+            return Err(OperationError::InheritedVersionsRequireConvert {
+                packages: inherited_packages,
+            });
         }
 
         let mut bumps_by_package: IndexMap<String, Vec<BumpType>> = IndexMap::new();
@@ -78,21 +104,21 @@ where
             }
         }
 
-        let package_versions: IndexMap<_, _> = project
+        let package_lookup: IndexMap<_, _> = project
             .packages
             .iter()
-            .map(|p| (p.name.clone(), p.version.clone()))
+            .map(|p| (p.name.clone(), p.clone()))
             .collect();
 
         let mut planned_releases = Vec::new();
 
         for (name, bumps) in &bumps_by_package {
             if let Some(bump_type) = max_bump_type(bumps) {
-                if let Some(current_version) = package_versions.get(name) {
-                    let new_version = bump_version(current_version, bump_type);
+                if let Some(pkg) = package_lookup.get(name) {
+                    let new_version = bump_version(&pkg.version, bump_type);
                     planned_releases.push(PackageVersion {
                         name: name.clone(),
-                        current_version: current_version.clone(),
+                        current_version: pkg.version.clone(),
                         new_version,
                         bump_type,
                     });
@@ -111,34 +137,59 @@ where
             .collect();
 
         let output = ReleaseOutput {
-            planned_releases,
+            planned_releases: planned_releases.clone(),
             unchanged_packages,
             changesets_consumed: changeset_files,
         };
 
         if input.dry_run {
-            Ok(ReleaseOutcome::DryRun(output))
-        } else {
-            Ok(ReleaseOutcome::Executed(output))
+            return Ok(ReleaseOutcome::DryRun(output));
         }
+
+        if !inherited_packages.is_empty() {
+            let root_manifest = project.root.join("Cargo.toml");
+            self.manifest_writer
+                .remove_workspace_version(&root_manifest)?;
+        }
+
+        for release in &planned_releases {
+            if let Some(pkg) = package_lookup.get(&release.name) {
+                let manifest_path = pkg.path.join("Cargo.toml");
+                self.manifest_writer
+                    .write_version(&manifest_path, &release.new_version)?;
+                self.manifest_writer
+                    .verify_version(&manifest_path, &release.new_version)?;
+            }
+        }
+
+        Ok(ReleaseOutcome::Executed(output))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::{MockChangesetReader, MockProjectProvider, make_changeset};
+    use crate::testing::{
+        MockChangesetReader, MockManifestWriter, MockProjectProvider, make_changeset,
+    };
+
+    fn default_input() -> ReleaseInput {
+        ReleaseInput {
+            dry_run: true,
+            convert_inherited: false,
+        }
+    }
 
     #[test]
     fn returns_no_changesets_when_empty() {
         let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
         let changeset_reader = MockChangesetReader::new();
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         assert!(matches!(result, ReleaseOutcome::NoChangesets));
@@ -150,12 +201,12 @@ mod tests {
         let changeset = make_changeset("my-crate", BumpType::Patch, "Fix a bug");
         let changeset_reader = MockChangesetReader::new()
             .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         let ReleaseOutcome::DryRun(output) = result else {
@@ -180,12 +231,12 @@ mod tests {
             (PathBuf::from(".changeset/fix.md"), changeset1),
             (PathBuf::from(".changeset/feature.md"), changeset2),
         ]);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         let ReleaseOutcome::DryRun(output) = result else {
@@ -210,12 +261,12 @@ mod tests {
             (PathBuf::from(".changeset/feature-a.md"), changeset1),
             (PathBuf::from(".changeset/breaking-b.md"), changeset2),
         ]);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         let ReleaseOutcome::DryRun(output) = result else {
@@ -251,12 +302,12 @@ mod tests {
         let changeset = make_changeset("crate-a", BumpType::Patch, "Fix crate-a");
         let changeset_reader = MockChangesetReader::new()
             .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         let ReleaseOutcome::DryRun(output) = result else {
@@ -279,12 +330,12 @@ mod tests {
             (PathBuf::from(".changeset/fix1.md"), changeset1),
             (PathBuf::from(".changeset/fix2.md"), changeset2),
         ]);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: true };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
 
         let result = operation
-            .execute(Path::new("/any"), &input)
+            .execute(Path::new("/any"), &default_input())
             .expect("execute failed");
 
         let ReleaseOutcome::DryRun(output) = result else {
@@ -300,14 +351,133 @@ mod tests {
         let changeset = make_changeset("my-crate", BumpType::Patch, "Fix");
         let changeset_reader = MockChangesetReader::new()
             .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = MockManifestWriter::new();
 
-        let operation = ReleaseOperation::new(project_provider, changeset_reader);
-        let input = ReleaseInput { dry_run: false };
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
+        let input = ReleaseInput {
+            dry_run: false,
+            convert_inherited: false,
+        };
 
         let result = operation
             .execute(Path::new("/any"), &input)
             .expect("execute failed");
 
         assert!(matches!(result, ReleaseOutcome::Executed(_)));
+    }
+
+    #[test]
+    fn writes_versions_when_not_dry_run() {
+        use std::sync::Arc;
+
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Minor, "Add feature");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/feature.md"), changeset);
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+
+        let operation = ReleaseOperation::new(
+            project_provider,
+            changeset_reader,
+            Arc::clone(&manifest_writer),
+        );
+        let input = ReleaseInput {
+            dry_run: false,
+            convert_inherited: false,
+        };
+
+        let ReleaseOutcome::Executed(output) = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed")
+        else {
+            panic!("expected Executed outcome");
+        };
+
+        assert_eq!(output.planned_releases.len(), 1);
+        assert_eq!(output.planned_releases[0].new_version.to_string(), "1.1.0");
+
+        let written = manifest_writer.written_versions();
+        assert_eq!(written.len(), 1);
+        assert_eq!(written[0].0, PathBuf::from("/mock/project/Cargo.toml"));
+        assert_eq!(written[0].1.to_string(), "1.1.0");
+    }
+
+    #[test]
+    fn returns_error_when_inherited_without_convert_flag() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = MockManifestWriter::new()
+            .with_inherited(vec![PathBuf::from("/mock/project/Cargo.toml")]);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
+        let input = ReleaseInput {
+            dry_run: false,
+            convert_inherited: false,
+        };
+
+        let result = operation.execute(Path::new("/any"), &input);
+
+        assert!(matches!(
+            result,
+            Err(OperationError::InheritedVersionsRequireConvert { .. })
+        ));
+    }
+
+    #[test]
+    fn allows_inherited_with_convert_flag() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = MockManifestWriter::new()
+            .with_inherited(vec![PathBuf::from("/mock/project/Cargo.toml")]);
+
+        let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
+        let input = ReleaseInput {
+            dry_run: false,
+            convert_inherited: true,
+        };
+
+        let result = operation.execute(Path::new("/any"), &input);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn removes_workspace_version_when_converting_inherited() {
+        use std::sync::Arc;
+
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/fix.md"), changeset);
+        let manifest_writer = Arc::new(
+            MockManifestWriter::new()
+                .with_inherited(vec![PathBuf::from("/mock/project/Cargo.toml")]),
+        );
+
+        let operation = ReleaseOperation::new(
+            project_provider,
+            changeset_reader,
+            Arc::clone(&manifest_writer),
+        );
+        let input = ReleaseInput {
+            dry_run: false,
+            convert_inherited: true,
+        };
+
+        let ReleaseOutcome::Executed(_) = operation
+            .execute(Path::new("/any"), &input)
+            .expect("execute failed")
+        else {
+            panic!("expected Executed outcome");
+        };
+
+        assert!(
+            manifest_writer.workspace_version_removed(),
+            "workspace version should be removed"
+        );
     }
 }

--- a/crates/changeset-operations/src/providers/manifest.rs
+++ b/crates/changeset-operations/src/providers/manifest.rs
@@ -1,0 +1,42 @@
+use std::path::Path;
+
+use semver::Version;
+
+use crate::Result;
+use crate::traits::ManifestWriter;
+
+pub struct FileSystemManifestWriter;
+
+impl FileSystemManifestWriter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for FileSystemManifestWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ManifestWriter for FileSystemManifestWriter {
+    fn write_version(&self, manifest_path: &Path, new_version: &Version) -> Result<()> {
+        Ok(changeset_manifest::write_version(
+            manifest_path,
+            new_version,
+        )?)
+    }
+
+    fn remove_workspace_version(&self, manifest_path: &Path) -> Result<()> {
+        Ok(changeset_manifest::remove_workspace_version(manifest_path)?)
+    }
+
+    fn verify_version(&self, manifest_path: &Path, expected: &Version) -> Result<()> {
+        Ok(changeset_manifest::verify_version(manifest_path, expected)?)
+    }
+
+    fn has_inherited_version(&self, manifest_path: &Path) -> Result<bool> {
+        Ok(changeset_manifest::has_inherited_version(manifest_path)?)
+    }
+}

--- a/crates/changeset-operations/src/providers/mod.rs
+++ b/crates/changeset-operations/src/providers/mod.rs
@@ -1,7 +1,9 @@
 mod changeset_io;
 mod git;
+mod manifest;
 mod project;
 
 pub use changeset_io::FileSystemChangesetIO;
 pub use git::Git2Provider;
+pub use manifest::FileSystemManifestWriter;
 pub use project::FileSystemProjectProvider;

--- a/crates/changeset-operations/src/traits/manifest_writer.rs
+++ b/crates/changeset-operations/src/traits/manifest_writer.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+use semver::Version;
+
+use crate::Result;
+
+pub trait ManifestWriter: Send + Sync {
+    /// # Errors
+    ///
+    /// Returns an error if the manifest cannot be read or written.
+    fn write_version(&self, manifest_path: &Path, new_version: &Version) -> Result<()>;
+
+    /// # Errors
+    ///
+    /// Returns an error if the manifest cannot be read or written.
+    fn remove_workspace_version(&self, manifest_path: &Path) -> Result<()>;
+
+    /// # Errors
+    ///
+    /// Returns an error if the version does not match the expected value.
+    fn verify_version(&self, manifest_path: &Path, expected: &Version) -> Result<()>;
+
+    /// # Errors
+    ///
+    /// Returns an error if the manifest cannot be read.
+    fn has_inherited_version(&self, manifest_path: &Path) -> Result<bool>;
+}

--- a/crates/changeset-operations/src/traits/mod.rs
+++ b/crates/changeset-operations/src/traits/mod.rs
@@ -1,6 +1,7 @@
 mod changeset_io;
 mod git_provider;
 mod interaction;
+mod manifest_writer;
 mod project_provider;
 
 pub use changeset_io::{ChangesetReader, ChangesetWriter};
@@ -8,4 +9,5 @@ pub use git_provider::GitProvider;
 pub use interaction::{
     BumpSelection, CategorySelection, DescriptionInput, InteractionProvider, PackageSelection,
 };
+pub use manifest_writer::ManifestWriter;
 pub use project_provider::ProjectProvider;

--- a/crates/changeset-operations/tests/release_integration.rs
+++ b/crates/changeset-operations/tests/release_integration.rs
@@ -1,0 +1,339 @@
+use std::fs;
+use std::path::Path;
+
+use changeset_operations::OperationError;
+use changeset_operations::operations::{ReleaseInput, ReleaseOperation, ReleaseOutcome};
+use changeset_operations::providers::{
+    FileSystemChangesetIO, FileSystemManifestWriter, FileSystemProjectProvider,
+};
+use tempfile::TempDir;
+
+fn create_single_package_project() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[package]
+name = "my-crate"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("write Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(dir.path().join("src/lib.rs"), "").expect("write lib.rs");
+
+    fs::create_dir_all(dir.path().join(".changeset")).expect("create .changeset dir");
+
+    dir
+}
+
+fn create_workspace_project() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("write workspace Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("write crate-a Cargo.toml");
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write lib.rs");
+
+    fs::create_dir_all(dir.path().join("crates/crate-b/src")).expect("create crate-b dir");
+    fs::write(
+        dir.path().join("crates/crate-b/Cargo.toml"),
+        r#"[package]
+name = "crate-b"
+version = "2.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("write crate-b Cargo.toml");
+    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "").expect("write lib.rs");
+
+    fs::create_dir_all(dir.path().join(".changeset")).expect("create .changeset dir");
+
+    dir
+}
+
+fn create_workspace_with_inherited_versions() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("write workspace Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version.workspace = true
+edition.workspace = true
+"#,
+    )
+    .expect("write crate-a Cargo.toml");
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write lib.rs");
+
+    fs::create_dir_all(dir.path().join("crates/crate-b/src")).expect("create crate-b dir");
+    fs::write(
+        dir.path().join("crates/crate-b/Cargo.toml"),
+        r#"[package]
+name = "crate-b"
+version.workspace = true
+edition.workspace = true
+"#,
+    )
+    .expect("write crate-b Cargo.toml");
+    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "").expect("write lib.rs");
+
+    fs::create_dir_all(dir.path().join(".changeset")).expect("create .changeset dir");
+
+    dir
+}
+
+fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
+    let content = format!(
+        r#"---
+"{package}": {bump}
+---
+
+{summary}
+"#
+    );
+    fs::write(dir.path().join(".changeset").join(filename), content).expect("write changeset");
+}
+
+fn read_version(path: &Path) -> String {
+    let content = fs::read_to_string(path).expect("read file");
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("version") && line.contains('=') && !line.contains("workspace") {
+            let version = line
+                .split('=')
+                .nth(1)
+                .expect("version value")
+                .trim()
+                .trim_matches('"');
+            return version.to_string();
+        }
+    }
+    panic!("version not found in {}", path.display());
+}
+
+fn run_release(
+    dir: &TempDir,
+    dry_run: bool,
+    convert_inherited: bool,
+) -> Result<ReleaseOutcome, OperationError> {
+    let project_provider = FileSystemProjectProvider::new();
+    let changeset_reader = FileSystemChangesetIO::new(dir.path());
+    let manifest_writer = FileSystemManifestWriter::new();
+
+    let operation = ReleaseOperation::new(project_provider, changeset_reader, manifest_writer);
+    let input = ReleaseInput {
+        dry_run,
+        convert_inherited,
+    };
+
+    operation.execute(dir.path(), &input)
+}
+
+#[test]
+fn single_package_version_update() {
+    let dir = create_single_package_project();
+    write_changeset(&dir, "fix.md", "my-crate", "patch", "Fix a bug");
+
+    let result = run_release(&dir, false, false).expect("release should succeed");
+
+    let ReleaseOutcome::Executed(output) = result else {
+        panic!("expected Executed outcome");
+    };
+
+    assert_eq!(output.planned_releases.len(), 1);
+    assert_eq!(output.planned_releases[0].name, "my-crate");
+    assert_eq!(output.planned_releases[0].new_version.to_string(), "1.0.1");
+
+    let version = read_version(&dir.path().join("Cargo.toml"));
+    assert_eq!(version, "1.0.1");
+}
+
+#[test]
+fn workspace_with_multiple_packages() {
+    let dir = create_workspace_project();
+    write_changeset(&dir, "feature-a.md", "crate-a", "minor", "Add feature to A");
+    write_changeset(
+        &dir,
+        "breaking-b.md",
+        "crate-b",
+        "major",
+        "Breaking change in B",
+    );
+
+    let result = run_release(&dir, false, false).expect("release should succeed");
+
+    let ReleaseOutcome::Executed(output) = result else {
+        panic!("expected Executed outcome");
+    };
+
+    assert_eq!(output.planned_releases.len(), 2);
+
+    let version_a = read_version(&dir.path().join("crates/crate-a/Cargo.toml"));
+    assert_eq!(version_a, "1.1.0");
+
+    let version_b = read_version(&dir.path().join("crates/crate-b/Cargo.toml"));
+    assert_eq!(version_b, "3.0.0");
+}
+
+#[test]
+fn inherited_version_requires_convert_flag() {
+    let dir = create_workspace_with_inherited_versions();
+    write_changeset(&dir, "fix.md", "crate-a", "patch", "Fix something");
+
+    let result = run_release(&dir, false, false);
+
+    assert!(matches!(
+        result,
+        Err(OperationError::InheritedVersionsRequireConvert { .. })
+    ));
+}
+
+#[test]
+fn inherited_version_conversion_with_convert_flag() {
+    let dir = create_workspace_with_inherited_versions();
+    write_changeset(&dir, "fix.md", "crate-a", "patch", "Fix something");
+
+    let result = run_release(&dir, false, true).expect("release should succeed");
+
+    let ReleaseOutcome::Executed(output) = result else {
+        panic!("expected Executed outcome");
+    };
+
+    assert_eq!(output.planned_releases.len(), 1);
+    assert_eq!(output.planned_releases[0].name, "crate-a");
+    assert_eq!(output.planned_releases[0].new_version.to_string(), "1.0.1");
+
+    let crate_a_content =
+        fs::read_to_string(dir.path().join("crates/crate-a/Cargo.toml")).expect("read crate-a");
+    assert!(
+        crate_a_content.contains(r#"version = "1.0.1""#),
+        "crate-a should have explicit version: {crate_a_content}"
+    );
+    assert!(
+        !crate_a_content.contains("version.workspace"),
+        "crate-a should not have inherited version"
+    );
+
+    let root_content =
+        fs::read_to_string(dir.path().join("Cargo.toml")).expect("read root Cargo.toml");
+    assert!(
+        !root_content.contains("version ="),
+        "workspace.package.version should be removed: {root_content}"
+    );
+}
+
+#[test]
+fn dry_run_skips_file_modifications() {
+    let dir = create_single_package_project();
+    write_changeset(&dir, "fix.md", "my-crate", "patch", "Fix a bug");
+
+    let result = run_release(&dir, true, false).expect("release should succeed");
+
+    let ReleaseOutcome::DryRun(output) = result else {
+        panic!("expected DryRun outcome");
+    };
+
+    assert_eq!(output.planned_releases.len(), 1);
+    assert_eq!(output.planned_releases[0].new_version.to_string(), "1.0.1");
+
+    let version = read_version(&dir.path().join("Cargo.toml"));
+    assert_eq!(
+        version, "1.0.0",
+        "version should not be modified in dry run"
+    );
+}
+
+#[test]
+fn format_preservation_comments_preserved() {
+    let dir = TempDir::new().expect("create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"# This is my crate configuration
+[package]
+name = "my-crate"
+# The current version
+version = "1.0.0"
+# Edition matters
+edition = "2021"
+"#,
+    )
+    .expect("write Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(dir.path().join("src/lib.rs"), "").expect("write lib.rs");
+    fs::create_dir_all(dir.path().join(".changeset")).expect("create .changeset dir");
+
+    write_changeset(&dir, "fix.md", "my-crate", "minor", "Add feature");
+
+    let _ = run_release(&dir, false, false).expect("release should succeed");
+
+    let content = fs::read_to_string(dir.path().join("Cargo.toml")).expect("read Cargo.toml");
+
+    assert!(
+        content.contains("# This is my crate configuration"),
+        "header comment should be preserved: {content}"
+    );
+    assert!(
+        content.contains("# Edition matters"),
+        "edition comment should be preserved: {content}"
+    );
+    assert!(
+        content.contains(r#"version = "1.1.0""#),
+        "version should be updated: {content}"
+    );
+}
+
+#[test]
+fn multiple_changesets_aggregate_correctly() {
+    let dir = create_single_package_project();
+    write_changeset(&dir, "fix1.md", "my-crate", "patch", "Fix bug 1");
+    write_changeset(&dir, "fix2.md", "my-crate", "patch", "Fix bug 2");
+    write_changeset(&dir, "feature.md", "my-crate", "minor", "Add feature");
+
+    let result = run_release(&dir, false, false).expect("release should succeed");
+
+    let ReleaseOutcome::Executed(output) = result else {
+        panic!("expected Executed outcome");
+    };
+
+    assert_eq!(output.changesets_consumed.len(), 3);
+    assert_eq!(
+        output.planned_releases[0].new_version.to_string(),
+        "1.1.0",
+        "minor should win over patches"
+    );
+}


### PR DESCRIPTION
- Resolves #11 

Implements format-preserving Cargo.toml updates as part of the release workflow. Key changes:

- Create new changeset-manifest crate for format-preserving TOML read/write using toml_edit
- Add ManifestWriter trait and FileSystemManifestWriter provider
- Update ReleaseOperation to write version updates when not in dry-run mode
- Add --convert flag to handle inherited versions (version.workspace = true)
  - Requires explicit opt-in to convert inherited to explicit versions
  - Removes workspace.package.version from root when converting
- Add verification step that re-reads and confirms written versions
- Add MockManifestWriter for testing