### PR TITLE
fix: support both cargo dispatch and direct invocation modes

### DIFF
--- a/.changeset/changesets/richly-exalting-elephant.md
+++ b/.changeset/changesets/richly-exalting-elephant.md
@@ -1,0 +1,5 @@
+---
+category: fixed
+cargo-changeset: patch
+---
+Fix cargo subcommand dispatch by supporting both 'cargo changeset <cmd>' and direct 'cargo-changeset <cmd>' invocation modes

--- a/crates/cargo-changeset/src/main.rs
+++ b/crates/cargo-changeset/src/main.rs
@@ -13,11 +13,16 @@ use crate::commands::Commands;
 use crate::error::CliError;
 
 #[derive(Parser)]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+enum CargoCli {
+    Changeset(ChangesetCli),
+}
+
+#[derive(Parser)]
 #[command(name = "cargo-changeset")]
-#[command(bin_name = "cargo-changeset")]
 #[command(about = "Manage changesets for Cargo projects", long_about = None)]
-struct Cli {
-    /// Path to start project discovery from (default: current directory)
+struct ChangesetCli {
     #[arg(long = "path", short = 'C', global = true)]
     path: Option<PathBuf>,
 
@@ -26,7 +31,11 @@ struct Cli {
 }
 
 fn main() -> ExitCode {
-    let cli = Cli::parse();
+    let cli = match CargoCli::try_parse() {
+        Ok(CargoCli::Changeset(cli)) => cli,
+        Err(e) if !e.use_stderr() => e.exit(),
+        Err(_) => ChangesetCli::parse(),
+    };
 
     let start_path = match resolve_start_path(cli.path) {
         Ok(path) => path,

--- a/crates/cargo-changeset/tests/cargo_dispatch.rs
+++ b/crates/cargo-changeset/tests/cargo_dispatch.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn init_git_repo(dir: &TempDir) {
+    Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to init git repo");
+
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to configure git email");
+
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to configure git name");
+}
+
+fn git_add_and_commit(dir: &TempDir, message: &str) {
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to git add");
+
+    Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to git commit");
+}
+
+fn create_single_package_project() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    init_git_repo(&dir);
+
+    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write Cargo.toml");
+
+    fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
+
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+#[test]
+fn cargo_dispatch_verify_succeeds_with_changeset_prefix() {
+    let workspace = create_single_package_project();
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn cargo_dispatch_help_succeeds_with_changeset_prefix() {
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("changeset")
+        .arg("--help")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
- Fixes #50

Introduce a CargoCli wrapping enum so clap recognises the "changeset" token Cargo injects when the binary is invoked as a cargo subcommand, while falling back to direct ChangesetCli parsing for all other cases. Add cargo_dispatch integration tests verifying both invocation paths.