### PR TITLE
feat: add --version flag with build metadata

### DIFF
--- a/.changeset/changesets/obviously-especial-anteater.md
+++ b/.changeset/changesets/obviously-especial-anteater.md
@@ -1,0 +1,5 @@
+---
+category: added
+cargo-changeset: minor
+---
+`--version` parameter on base command now prints version information

--- a/crates/cargo-changeset/Cargo.toml
+++ b/crates/cargo-changeset/Cargo.toml
@@ -28,6 +28,9 @@ dialoguer = { workspace = true }
 tempfile = "3.25"
 thiserror = { workspace = true }
 
+[build-dependencies]
+chrono = { version = "0.4.44", features = ["clock"], default-features = false }
+
 [dev-dependencies]
 assert_cmd = "2.1"
 predicates = "3.1"

--- a/crates/cargo-changeset/build.rs
+++ b/crates/cargo-changeset/build.rs
@@ -1,0 +1,54 @@
+use std::process::Command;
+
+use chrono::Utc;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/");
+
+    let version = env!("CARGO_PKG_VERSION");
+    let git_hash = git_short_hash().unwrap_or_else(|| "unknown".to_owned());
+    let build_date = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let is_release = is_release_commit(version, &git_hash);
+
+    let version_string = if is_release {
+        version.to_owned()
+    } else {
+        format!("{version}+{git_hash}.{build_date}")
+    };
+
+    println!("cargo:rustc-env=CARGO_CHANGESET_VERSION={version_string}");
+}
+
+fn git_short_hash() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8(output.stdout).ok()?.trim().to_owned())
+    } else {
+        None
+    }
+}
+
+fn is_release_commit(version: &str, git_hash: &str) -> bool {
+    if git_hash == "unknown" {
+        return false;
+    }
+
+    let expected_tag = format!("cargo-changeset@v{version}");
+
+    let output = Command::new("git")
+        .args(["tag", "--points-at", "HEAD"])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let tags = String::from_utf8(out.stdout).unwrap_or_default();
+            tags.lines().any(|line| line.trim() == expected_tag)
+        }
+        _ => false,
+    }
+}

--- a/crates/cargo-changeset/src/main.rs
+++ b/crates/cargo-changeset/src/main.rs
@@ -21,6 +21,7 @@ enum CargoCli {
 
 #[derive(Parser)]
 #[command(name = "cargo-changeset")]
+#[command(version = env!("CARGO_CHANGESET_VERSION"))]
 #[command(about = "Manage changesets for Cargo projects", long_about = None)]
 struct ChangesetCli {
     #[arg(long = "path", short = 'C', global = true)]

--- a/crates/cargo-changeset/tests/cargo_dispatch.rs
+++ b/crates/cargo-changeset/tests/cargo_dispatch.rs
@@ -84,3 +84,22 @@ fn cargo_dispatch_help_succeeds_with_changeset_prefix() {
         .assert()
         .success();
 }
+
+#[test]
+fn version_flag_succeeds() {
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn cargo_dispatch_version_succeeds_with_changeset_prefix() {
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("changeset")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
- Resolves #45

Adds build.rs that embeds the git commit hash and UTC build timestamp into the binary at compile time. For tagged release commits the output is the bare semver version; for all other builds it includes semver build metadata (hash + timestamp).