### PR TITLE
fix: use @ separator in crate-prefixed tag format

### DIFF
--- a/.changeset/changesets/genuinely-thriving-diamondback.md
+++ b/.changeset/changesets/genuinely-thriving-diamondback.md
@@ -1,0 +1,5 @@
+---
+category: fixed
+cargo-changeset: patch
+---
+Tags created with the crate-prefixed format now use @ as the separator (e.g., my-crate@v1.2.3) instead of - (e.g., my-crate-v1.2.3).

--- a/crates/cargo-changeset/tests/saga_error_display.rs
+++ b/crates/cargo-changeset/tests/saga_error_display.rs
@@ -237,7 +237,7 @@ fn release_saga_failure_multi_package_shows_proper_error_format() {
 
     create_tag(
         &workspace,
-        "crate-b-v2.0.1",
+        "crate-b@v2.0.1",
         "Pre-existing conflicting tag for crate-b",
     );
 

--- a/crates/changeset-git/src/repository/tag.rs
+++ b/crates/changeset-git/src/repository/tag.rs
@@ -64,11 +64,11 @@ mod tests {
     fn create_tag_with_crate_prefix() -> anyhow::Result<()> {
         let (_dir, repo) = setup_test_repo()?;
 
-        let tag_info = repo.create_tag("my-crate-v0.1.0", "Release my-crate version 0.1.0")?;
+        let tag_info = repo.create_tag("my-crate@v0.1.0", "Release my-crate version 0.1.0")?;
 
-        assert_eq!(tag_info.name, "my-crate-v0.1.0");
+        assert_eq!(tag_info.name, "my-crate@v0.1.0");
 
-        let tag = repo.inner.find_reference("refs/tags/my-crate-v0.1.0")?;
+        let tag = repo.inner.find_reference("refs/tags/my-crate@v0.1.0")?;
         assert!(tag.peel_to_tag().is_ok());
 
         Ok(())

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -1288,7 +1288,7 @@ mod tests {
 
         let git_result = output.git_result.expect("should have git result");
         let commit = git_result.commit.expect("should have commit");
-        assert!(commit.message.contains("my-crate-v1.1.0"));
+        assert!(commit.message.contains("my-crate@v1.1.0"));
         assert!(commit.message.contains("my-crate 1.0.0 -> 1.1.0"));
     }
 
@@ -1338,8 +1338,8 @@ mod tests {
         assert_eq!(git_result.tags_created.len(), 2);
 
         let tag_names: Vec<_> = git_result.tags_created.iter().map(|t| &t.name).collect();
-        assert!(tag_names.contains(&&"crate-a-v1.0.1".to_string()));
-        assert!(tag_names.contains(&&"crate-b-v2.0.1".to_string()));
+        assert!(tag_names.contains(&&"crate-a@v1.0.1".to_string()));
+        assert!(tag_names.contains(&&"crate-b@v2.0.1".to_string()));
     }
 
     #[test]
@@ -1621,7 +1621,7 @@ mod tests {
             commit.message
         );
         assert!(
-            commit.message.contains("my-crate-v1.1.0"),
+            commit.message.contains("my-crate@v1.1.0"),
             "commit message should contain version info"
         );
     }

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -522,7 +522,7 @@ impl<G, M, RW, S, C> CreateCommitStep<G, M, RW, S, C> {
     fn build_commit_message(&self, planned_releases: &[crate::types::PackageVersion]) -> String {
         let version_list: Vec<String> = planned_releases
             .iter()
-            .map(|r| format!("{}-v{}", r.name, r.new_version))
+            .map(|r| format!("{}@v{}", r.name, r.new_version))
             .collect();
         let new_version = version_list.join(", ");
 
@@ -642,7 +642,7 @@ where
 
         for release in &input.planned_releases {
             let tag_name = if use_prefix {
-                format!("{}-v{}", release.name, release.new_version)
+                format!("{}@v{}", release.name, release.new_version)
             } else {
                 format!("v{}", release.new_version)
             };
@@ -685,7 +685,7 @@ where
         let mut failed_tags = Vec::new();
         for release in &input.planned_releases {
             let tag_name = if use_prefix {
-                format!("{}-v{}", release.name, release.new_version)
+                format!("{}@v{}", release.name, release.new_version)
             } else {
                 format!("v{}", release.new_version)
             };
@@ -1210,7 +1210,7 @@ mod tests {
         );
         assert_eq!(
             git_provider.deleted_tags()[0],
-            "pkg-a-v1.0.1",
+            "pkg-a@v1.0.1",
             "deleted tag should be the first tag that was created"
         );
     }
@@ -1290,11 +1290,11 @@ mod tests {
 
         let deleted = git_provider.deleted_tags();
         assert!(
-            deleted.contains(&"pkg-a-v1.0.1".to_string()),
+            deleted.contains(&"pkg-a@v1.0.1".to_string()),
             "first tag should be in deleted list"
         );
         assert!(
-            deleted.contains(&"pkg-b-v2.0.1".to_string()),
+            deleted.contains(&"pkg-b@v2.0.1".to_string()),
             "second tag should be in deleted list"
         );
     }

--- a/crates/changeset-operations/tests/release_integration.rs
+++ b/crates/changeset-operations/tests/release_integration.rs
@@ -673,17 +673,17 @@ fn release_workspace_creates_prefixed_tags() {
 
     let tag_names: Vec<_> = git_result.tags_created.iter().map(|t| &t.name).collect();
     assert!(
-        tag_names.contains(&&"crate-a-v1.1.0".to_string()),
+        tag_names.contains(&&"crate-a@v1.1.0".to_string()),
         "should have crate-a tag"
     );
     assert!(
-        tag_names.contains(&&"crate-b-v2.0.1".to_string()),
+        tag_names.contains(&&"crate-b@v2.0.1".to_string()),
         "should have crate-b tag"
     );
 
     let tags = git_tags(&dir);
-    assert!(tags.contains(&"crate-a-v1.1.0".to_string()));
-    assert!(tags.contains(&"crate-b-v2.0.1".to_string()));
+    assert!(tags.contains(&"crate-a@v1.1.0".to_string()));
+    assert!(tags.contains(&"crate-b@v2.0.1".to_string()));
 }
 
 #[test]

--- a/crates/changeset-operations/tests/saga_system_tests.rs
+++ b/crates/changeset-operations/tests/saga_system_tests.rs
@@ -296,8 +296,8 @@ fn system_test_successful_release_workspace() {
     assert_eq!(version_b, "2.0.1");
 
     let tags = git_tags(&dir);
-    assert!(tags.contains(&"crate-a-v1.1.0".to_string()));
-    assert!(tags.contains(&"crate-b-v2.0.1".to_string()));
+    assert!(tags.contains(&"crate-a@v1.1.0".to_string()));
+    assert!(tags.contains(&"crate-b@v2.0.1".to_string()));
 }
 
 // =============================================================================
@@ -356,7 +356,7 @@ fn system_test_multi_package_rollback_on_second_tag_conflict() {
     git_add_all(&dir);
     git_commit(&dir, "Add changesets");
 
-    create_tag(&dir, "crate-b-v2.0.1");
+    create_tag(&dir, "crate-b@v2.0.1");
 
     let initial_version_a = read_version(&dir.path().join("crates/crate-a/Cargo.toml"));
     let initial_version_b = read_version(&dir.path().join("crates/crate-b/Cargo.toml"));
@@ -389,7 +389,7 @@ fn system_test_multi_package_rollback_on_second_tag_conflict() {
     // The pre-existing conflicting tag should still exist
     let tags = git_tags(&dir);
     assert!(
-        tags.contains(&"crate-b-v2.0.1".to_string()),
+        tags.contains(&"crate-b@v2.0.1".to_string()),
         "pre-existing conflicting tag should still exist"
     );
 


### PR DESCRIPTION
Tags for the CratePrefixed format now follow the `<crate>@v<version>` convention (e.g., `my-crate@v1.0.0`) instead of `my-crate-v1.0.0`.