### PR TITLE
Add 'none' bump type for non-version-incrementing changesets

### DIFF
--- a/.changeset/changesets/amiably-intense-sturgeon.md
+++ b/.changeset/changesets/amiably-intense-sturgeon.md
@@ -1,0 +1,5 @@
+---
+category: added
+cargo-changeset: minor
+---
+Add 'none' bump type option for tracking changes without version increments

--- a/.changeset/changesets/bountifully-altruistic-bandicoot.md
+++ b/.changeset/changesets/bountifully-altruistic-bandicoot.md
@@ -1,0 +1,5 @@
+---
+category: added
+changeset-core: minor
+---
+Add BumpType::None variant for tracking changes without version increments

--- a/.changeset/changesets/furiously-primed-trembler.md
+++ b/.changeset/changesets/furiously-primed-trembler.md
@@ -1,0 +1,5 @@
+---
+category: added
+changeset-operations: minor
+---
+Support non-bump changesets in add, status, verify, and release planning operations

--- a/.changeset/changesets/opaquely-fancy-tahr.md
+++ b/.changeset/changesets/opaquely-fancy-tahr.md
@@ -1,0 +1,5 @@
+---
+category: added
+changeset-version: minor
+---
+Support BumpType::None to preserve version unchanged during bump calculations

--- a/.changeset/changesets/seemly-adorable-meadowlark.md
+++ b/.changeset/changesets/seemly-adorable-meadowlark.md
@@ -1,0 +1,5 @@
+---
+category: added
+changeset-parse: minor
+---
+Support parsing and serializing 'none' as a bump type in changeset files

--- a/crates/cargo-changeset/src/commands/add.rs
+++ b/crates/cargo-changeset/src/commands/add.rs
@@ -55,7 +55,7 @@ pub(super) fn run(args: AddArgs, start_path: &Path) -> Result<()> {
             println!();
             println!("Releases:");
             for release in &changeset.releases {
-                println!("  - {}: {:?}", release.name, release.bump_type);
+                println!("  - {}: {}", release.name, release.bump_type);
             }
             Ok(())
         }
@@ -110,6 +110,7 @@ fn parse_package_bump(input: &str) -> Result<(String, BumpType)> {
         "major" => BumpType::Major,
         "minor" => BumpType::Minor,
         "patch" => BumpType::Patch,
+        "none" => BumpType::None,
         _ => {
             return Err(CliError::InvalidBumpType {
                 input: bump_str.to_string(),
@@ -155,6 +156,14 @@ mod tests {
 
         assert_eq!(name, "my-package");
         assert_eq!(bump, BumpType::Patch);
+    }
+
+    #[test]
+    fn parse_package_bump_valid_none() {
+        let (name, bump) = parse_package_bump("my-package:none").expect("should parse");
+
+        assert_eq!(name, "my-package");
+        assert_eq!(bump, BumpType::None);
     }
 
     #[test]

--- a/crates/cargo-changeset/src/interaction.rs
+++ b/crates/cargo-changeset/src/interaction.rs
@@ -60,6 +60,7 @@ impl InteractionProvider for TerminalInteractionProvider {
             "patch - Bug fixes (backwards compatible)",
             "minor - New features (backwards compatible)",
             "major - Breaking changes",
+            "none  - No version bump (internal changes only)",
         ];
 
         let selection = Select::new()
@@ -75,6 +76,7 @@ impl InteractionProvider for TerminalInteractionProvider {
             Some(0) => Ok(BumpSelection::Selected(BumpType::Patch)),
             Some(1) => Ok(BumpSelection::Selected(BumpType::Minor)),
             Some(2) => Ok(BumpSelection::Selected(BumpType::Major)),
+            Some(3) => Ok(BumpSelection::Selected(BumpType::None)),
             _ => Ok(BumpSelection::Cancelled),
         }
     }

--- a/crates/cargo-changeset/src/output/error_format.rs
+++ b/crates/cargo-changeset/src/output/error_format.rs
@@ -46,7 +46,7 @@ fn format_operation_error(out: &mut String, error: &changeset_operations::Operat
                 .expect("string write");
                 writeln!(
                     out,
-                    "  --bump <TYPE>          Bump type: major, minor, or patch"
+                    "  --bump <TYPE>          Bump type: major, minor, patch, or none"
                 )
                 .expect("string write");
                 writeln!(out, "  -m <MESSAGE>           Change description").expect("string write");

--- a/crates/cargo-changeset/src/output/status.rs
+++ b/crates/cargo-changeset/src/output/status.rs
@@ -31,7 +31,7 @@ impl PlainTextStatusFormatter {
             let bump_detail = Self::format_bump_detail(status, &release.name);
 
             output.push_str(&format!(
-                "  {}: {} -> {} ({:?}){}\n",
+                "  {}: {} -> {} ({}){}\n",
                 release.name,
                 release.current_version,
                 release.new_version,
@@ -52,8 +52,20 @@ impl PlainTextStatusFormatter {
 
         let mut sorted_bumps: Vec<_> = bumps.iter().collect();
         sorted_bumps.sort();
-        let bump_strs: Vec<_> = sorted_bumps.iter().map(|b| format!("{b:?}")).collect();
+        let bump_strs: Vec<_> = sorted_bumps.iter().map(|b| format!("{b}")).collect();
         format!(" (from: {})", bump_strs.join(", "))
+    }
+
+    fn format_none_bump_packages(output: &mut String, status: &StatusOutput) {
+        if status.none_bump_packages.is_empty() {
+            return;
+        }
+
+        output.push('\n');
+        output.push_str("Packages with no version bump:\n");
+        for name in &status.none_bump_packages {
+            output.push_str(&format!("  {name} (none)\n"));
+        }
     }
 
     fn format_unchanged_packages(output: &mut String, status: &StatusOutput) {
@@ -83,7 +95,7 @@ impl PlainTextStatusFormatter {
     fn format_summary(output: &mut String, status: &StatusOutput) {
         output.push('\n');
         output.push_str(&format!(
-            "Summary: {} changeset(s), {} package(s) affected\n",
+            "Summary: {} changeset(s), {} package(s) to release\n",
             status.changesets.len(),
             status.projected_releases.len()
         ));
@@ -148,6 +160,7 @@ impl StatusFormatter for PlainTextStatusFormatter {
             Self::format_changesets(&mut output, status);
             Self::format_consumed_prerelease_changesets(&mut output, status);
             Self::format_projected_releases(&mut output, status);
+            Self::format_none_bump_packages(&mut output, status);
             Self::format_unchanged_packages(&mut output, status);
             Self::format_unknown_packages(&mut output, status);
             Self::format_summary(&mut output, status);
@@ -173,6 +186,7 @@ mod tests {
             changeset_files: Vec::new(),
             projected_releases: Vec::new(),
             bumps_by_package: IndexMap::new(),
+            none_bump_packages: Vec::new(),
             unchanged_packages: Vec::new(),
             packages_with_inherited_versions: Vec::new(),
             unknown_packages: Vec::new(),
@@ -273,8 +287,8 @@ mod tests {
         assert!(result.contains("Pending changesets: 1"));
         assert!(result.contains("fix-bug.md"));
         assert!(result.contains("Projected releases:"));
-        assert!(result.contains("my-crate: 1.0.0 -> 1.0.1 (Patch)"));
-        assert!(result.contains("Summary: 1 changeset(s), 1 package(s) affected"));
+        assert!(result.contains("my-crate: 1.0.0 -> 1.0.1 (patch)"));
+        assert!(result.contains("Summary: 1 changeset(s), 1 package(s) to release"));
     }
 
     #[test]
@@ -314,7 +328,7 @@ mod tests {
 
         let result = formatter.format_status(&status);
 
-        assert!(result.contains("my-crate: 1.0.0 -> 1.1.0 (Minor) (from: Patch, Minor)"));
+        assert!(result.contains("my-crate: 1.0.0 -> 1.1.0 (minor) (from: patch, minor)"));
     }
 
     #[test]
@@ -434,9 +448,9 @@ mod tests {
         let result = formatter.format_status(&status);
 
         assert!(result.contains("Pending changesets: 2"));
-        assert!(result.contains("crate-a: 1.0.0 -> 1.0.1 (Patch)"));
-        assert!(result.contains("crate-b: 2.0.0 -> 2.1.0 (Minor)"));
-        assert!(result.contains("Summary: 2 changeset(s), 2 package(s) affected"));
+        assert!(result.contains("crate-a: 1.0.0 -> 1.0.1 (patch)"));
+        assert!(result.contains("crate-b: 2.0.0 -> 2.1.0 (minor)"));
+        assert!(result.contains("Summary: 2 changeset(s), 2 package(s) to release"));
     }
 
     #[test]
@@ -492,7 +506,7 @@ mod tests {
 
         assert!(result.contains("Pending changesets: 1"));
         assert!(result.contains("Warning: Unknown packages in changesets:"));
-        assert!(result.contains("Summary: 1 changeset(s), 0 package(s) affected"));
+        assert!(result.contains("Summary: 1 changeset(s), 0 package(s) to release"));
     }
 
     #[test]
@@ -686,5 +700,71 @@ mod tests {
             !result.contains("... and"),
             "should not show truncation for small lists"
         );
+    }
+
+    #[test]
+    fn format_none_only_packages_section() {
+        let formatter = PlainTextStatusFormatter;
+        let mut status = empty_status();
+        status.changesets = vec![make_changeset(
+            &[("internal-crate", BumpType::None)],
+            ChangeCategory::Changed,
+            "Refactor",
+        )];
+        status.changeset_files = vec![PathBuf::from(".changeset/changesets/refactor.md")];
+        status.bumps_by_package = {
+            let mut map = IndexMap::new();
+            map.insert("internal-crate".to_string(), vec![BumpType::None]);
+            map
+        };
+        status.none_bump_packages = vec!["internal-crate".to_string()];
+
+        let result = formatter.format_status(&status);
+
+        assert!(result.contains("Packages with no version bump:"));
+        assert!(result.contains("internal-crate (none)"));
+        assert!(!result.contains("Projected releases:"));
+    }
+
+    #[test]
+    fn format_mixed_none_and_patch_packages() {
+        let formatter = PlainTextStatusFormatter;
+        let mut status = empty_status();
+        status.changesets = vec![
+            make_changeset(
+                &[("internal-crate", BumpType::None)],
+                ChangeCategory::Changed,
+                "Refactor",
+            ),
+            make_changeset(
+                &[("public-crate", BumpType::Patch)],
+                ChangeCategory::Fixed,
+                "Fix",
+            ),
+        ];
+        status.changeset_files = vec![
+            PathBuf::from(".changeset/changesets/refactor.md"),
+            PathBuf::from(".changeset/changesets/fix.md"),
+        ];
+        status.projected_releases = vec![make_package_version(
+            "public-crate",
+            "1.0.0",
+            "1.0.1",
+            BumpType::Patch,
+        )];
+        status.bumps_by_package = {
+            let mut map = IndexMap::new();
+            map.insert("internal-crate".to_string(), vec![BumpType::None]);
+            map.insert("public-crate".to_string(), vec![BumpType::Patch]);
+            map
+        };
+        status.none_bump_packages = vec!["internal-crate".to_string()];
+
+        let result = formatter.format_status(&status);
+
+        assert!(result.contains("Projected releases:"));
+        assert!(result.contains("public-crate: 1.0.0 -> 1.0.1 (patch)"));
+        assert!(result.contains("Packages with no version bump:"));
+        assert!(result.contains("internal-crate (none)"));
     }
 }

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -256,7 +256,7 @@ mod non_interactive {
             .success()
             .stdout(contains("Created changeset"))
             .stdout(contains("crate-a"))
-            .stdout(contains("Major"));
+            .stdout(contains("major"));
     }
 
     #[test]
@@ -275,9 +275,9 @@ mod non_interactive {
             .assert()
             .success()
             .stdout(contains("crate-a"))
-            .stdout(contains("Major"))
+            .stdout(contains("major"))
             .stdout(contains("crate-b"))
-            .stdout(contains("Patch"));
+            .stdout(contains("patch"));
     }
 
     #[test]
@@ -298,9 +298,9 @@ mod non_interactive {
             .assert()
             .success()
             .stdout(contains("crate-a"))
-            .stdout(contains("Major"))
+            .stdout(contains("major"))
             .stdout(contains("crate-b"))
-            .stdout(contains("Minor"));
+            .stdout(contains("minor"));
     }
 
     #[test]
@@ -460,6 +460,39 @@ mod non_interactive {
             .collect();
 
         assert_eq!(files.len(), 3, "should have three unique changeset files");
+    }
+
+    #[test]
+    fn add_single_crate_with_bump_none_succeeds() {
+        let workspace = create_single_crate_workspace();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("add")
+            .arg("--bump")
+            .arg("none")
+            .arg("-m")
+            .arg("Internal refactoring")
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Created changeset"))
+            .stdout(contains("Internal refactoring"));
+
+        let changeset_dir = workspace.path().join(".changeset/changesets");
+        let files: Vec<_> = fs::read_dir(&changeset_dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .collect();
+
+        assert_eq!(files.len(), 1, "should have one changeset file");
+
+        let content = fs::read_to_string(files[0].path()).expect("read changeset file");
+        assert!(content.contains("none"), "should contain none bump type");
+        assert!(
+            content.contains("Internal refactoring"),
+            "should contain message"
+        );
     }
 
     #[test]

--- a/crates/cargo-changeset/tests/status_command.rs
+++ b/crates/cargo-changeset/tests/status_command.rs
@@ -148,8 +148,8 @@ fn status_shows_single_changeset() {
         .stdout(contains("Pending changesets: 1"))
         .stdout(contains("fix-bug.md"))
         .stdout(contains("Projected releases:"))
-        .stdout(contains("my-crate: 1.0.0 -> 1.0.1 (Patch)"))
-        .stdout(contains("Summary: 1 changeset(s), 1 package(s) affected"));
+        .stdout(contains("my-crate: 1.0.0 -> 1.0.1 (patch)"))
+        .stdout(contains("Summary: 1 changeset(s), 1 package(s) to release"));
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn status_shows_multiple_changesets() {
         .assert()
         .success()
         .stdout(contains("Pending changesets: 2"))
-        .stdout(contains("my-crate: 1.0.0 -> 1.1.0 (Minor)"))
-        .stdout(contains("(from: Patch, Minor)"));
+        .stdout(contains("my-crate: 1.0.0 -> 1.1.0 (minor)"))
+        .stdout(contains("(from: patch, minor)"));
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn status_shows_workspace_packages() {
         .current_dir(workspace.path())
         .assert()
         .success()
-        .stdout(contains("crate-a: 1.0.0 -> 1.0.1 (Patch)"))
+        .stdout(contains("crate-a: 1.0.0 -> 1.0.1 (patch)"))
         .stdout(contains("Packages without changesets:"))
         .stdout(contains("crate-b (2.0.0)"));
 }
@@ -253,8 +253,8 @@ fn status_multiple_packages_multiple_bumps() {
         .success()
         .stdout(contains("Pending changesets: 3"))
         .stdout(contains(
-            "crate-a: 1.0.0 -> 1.1.0 (Minor) (from: Patch, Minor)",
+            "crate-a: 1.0.0 -> 1.1.0 (minor) (from: patch, minor)",
         ))
-        .stdout(contains("crate-b: 2.0.0 -> 3.0.0 (Major)"))
-        .stdout(contains("Summary: 3 changeset(s), 2 package(s) affected"));
+        .stdout(contains("crate-b: 2.0.0 -> 3.0.0 (major)"))
+        .stdout(contains("Summary: 3 changeset(s), 2 package(s) to release"));
 }

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -8,9 +8,29 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BumpType {
+    None,
     Patch,
     Minor,
     Major,
+}
+
+impl BumpType {
+    #[must_use]
+    pub fn is_noop(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+impl fmt::Display for BumpType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::None => "none",
+            Self::Patch => "patch",
+            Self::Minor => "minor",
+            Self::Major => "major",
+        };
+        write!(f, "{s}")
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -26,19 +46,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bump_type_ordering_patch_is_smallest() {
+    fn bump_type_ordering_none_is_smallest() {
+        assert!(BumpType::None < BumpType::Patch);
+        assert!(BumpType::None < BumpType::Minor);
+        assert!(BumpType::None < BumpType::Major);
+    }
+
+    #[test]
+    fn bump_type_ordering_patch_is_second() {
+        assert!(BumpType::Patch > BumpType::None);
         assert!(BumpType::Patch < BumpType::Minor);
         assert!(BumpType::Patch < BumpType::Major);
     }
 
     #[test]
     fn bump_type_ordering_minor_is_middle() {
+        assert!(BumpType::Minor > BumpType::None);
         assert!(BumpType::Minor > BumpType::Patch);
         assert!(BumpType::Minor < BumpType::Major);
     }
 
     #[test]
     fn bump_type_ordering_major_is_largest() {
+        assert!(BumpType::Major > BumpType::None);
         assert!(BumpType::Major > BumpType::Patch);
         assert!(BumpType::Major > BumpType::Minor);
     }
@@ -47,6 +77,34 @@ mod tests {
     fn bump_type_max_returns_largest() {
         let bumps = [BumpType::Patch, BumpType::Minor, BumpType::Major];
         assert_eq!(bumps.iter().max(), Some(&BumpType::Major));
+    }
+
+    #[test]
+    fn bump_type_max_none_and_patch_returns_patch() {
+        let bumps = [BumpType::None, BumpType::Patch];
+        assert_eq!(bumps.iter().max(), Some(&BumpType::Patch));
+    }
+
+    #[test]
+    fn bump_type_max_all_none_returns_none() {
+        let bumps = [BumpType::None, BumpType::None];
+        assert_eq!(bumps.iter().max(), Some(&BumpType::None));
+    }
+
+    #[test]
+    fn bump_type_is_noop() {
+        assert!(BumpType::None.is_noop());
+        assert!(!BumpType::Patch.is_noop());
+        assert!(!BumpType::Minor.is_noop());
+        assert!(!BumpType::Major.is_noop());
+    }
+
+    #[test]
+    fn bump_type_display() {
+        assert_eq!(format!("{}", BumpType::None), "none");
+        assert_eq!(format!("{}", BumpType::Patch), "patch");
+        assert_eq!(format!("{}", BumpType::Minor), "minor");
+        assert_eq!(format!("{}", BumpType::Major), "major");
     }
 }
 

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -82,21 +82,35 @@ where
             return Ok(AddResult::Cancelled);
         };
 
-        let Some(category) = self.select_category(&input)? else {
-            return Ok(AddResult::Cancelled);
-        };
+        let all_none = releases.iter().all(|r| r.bump_type.is_noop());
 
-        let Some(description) = self.get_description(&input)? else {
-            return Ok(AddResult::Cancelled);
-        };
+        let (category, description) = if all_none {
+            let category = input.category;
+            let description = input
+                .description
+                .clone()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            (category, description)
+        } else {
+            let Some(category) = self.select_category(&input)? else {
+                return Ok(AddResult::Cancelled);
+            };
 
-        let description = description.trim();
-        if description.is_empty() {
-            return Err(OperationError::EmptyDescription);
-        }
+            let Some(desc) = self.get_description(&input)? else {
+                return Ok(AddResult::Cancelled);
+            };
+
+            let desc = desc.trim().to_string();
+            if desc.is_empty() {
+                return Err(OperationError::EmptyDescription);
+            }
+            (category, desc)
+        };
 
         let changeset = Changeset {
-            summary: description.to_string(),
+            summary: description,
             releases,
             category,
             consumed_for_prerelease: None,
@@ -562,6 +576,61 @@ mod operation_tests {
         match result {
             AddResult::Created { file_path, .. } => {
                 assert!(file_path.to_string_lossy().contains("my-changeset.md"));
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn all_none_bumps_skip_description_and_category_prompts() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["my-crate".to_string()],
+            bump: Some(BumpType::None),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), input)
+            .expect("AddOperation should succeed for all-none bumps without description");
+
+        match result {
+            AddResult::Created { changeset, .. } => {
+                assert!(changeset.summary.is_empty());
+                assert_eq!(changeset.releases[0].bump_type, BumpType::None);
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn all_none_bumps_with_explicit_description() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["my-crate".to_string()],
+            bump: Some(BumpType::None),
+            description: Some("Internal refactoring".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), input)
+            .expect("AddOperation should succeed for all-none bumps with description");
+
+        match result {
+            AddResult::Created { changeset, .. } => {
+                assert_eq!(changeset.summary, "Internal refactoring");
+                assert_eq!(changeset.releases[0].bump_type, BumpType::None);
             }
             _ => panic!("Expected AddResult::Created"),
         }

--- a/crates/changeset-operations/src/operations/status.rs
+++ b/crates/changeset-operations/src/operations/status.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use changeset_core::{BumpType, Changeset, PackageInfo};
+use changeset_version::max_bump_type;
 use indexmap::IndexMap;
 
 use crate::Result;
@@ -17,6 +18,8 @@ pub struct StatusOutput {
     pub projected_releases: Vec<PackageVersion>,
     /// Raw bump types per package (for verbose display).
     pub bumps_by_package: IndexMap<String, Vec<BumpType>>,
+    /// Packages whose max bump type is `None` (tracked but not version-bumped).
+    pub none_bump_packages: Vec<String>,
     /// Packages with no pending changesets.
     pub unchanged_packages: Vec<PackageInfo>,
     /// Packages using inherited versions (informational warning).
@@ -86,11 +89,19 @@ where
             .inherited_checker
             .find_packages_with_inherited_versions(project.packages())?;
 
+        let mut none_bump_packages: Vec<String> = bumps_by_package
+            .iter()
+            .filter(|(_, bumps)| max_bump_type(bumps).is_some_and(|b| b.is_noop()))
+            .map(|(name, _)| name.clone())
+            .collect();
+        none_bump_packages.sort();
+
         Ok(StatusOutput {
             changesets,
             changeset_files,
             projected_releases: plan.releases,
             bumps_by_package,
+            none_bump_packages,
             unchanged_packages,
             packages_with_inherited_versions,
             unknown_packages: plan.unknown_packages,

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -331,6 +331,51 @@ mod tests {
     }
 
     #[test]
+    fn returns_success_when_changeset_has_none_bump_type() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![
+            FileChange {
+                path: PathBuf::from(".changeset/changesets/internal.md"),
+                status: FileStatus::Added,
+                old_path: None,
+            },
+            FileChange {
+                path: PathBuf::from("src/lib.rs"),
+                status: FileStatus::Modified,
+                old_path: None,
+            },
+        ]);
+
+        let changeset =
+            crate::mocks::make_changeset("my-crate", BumpType::None, "Internal refactoring");
+        let changeset_reader = MockChangesetReader::new().with_changeset(
+            PathBuf::from(".changeset/changesets/internal.md"),
+            changeset,
+        );
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInput {
+            base: "main".to_string(),
+            head: None,
+            allow_deleted_changesets: false,
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("VerifyOperation failed when changeset has None bump type");
+
+        match result {
+            VerifyOutcome::Success(verification_result) => {
+                assert!(verification_result.uncovered_packages.is_empty());
+                assert!(verification_result.covered_packages.contains("my-crate"));
+            }
+            other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn is_markdown_file_recognizes_md_extension() {
         assert!(is_markdown_file(Path::new("test.md")));
         assert!(is_markdown_file(Path::new("path/to/file.md")));

--- a/crates/changeset-operations/src/planner.rs
+++ b/crates/changeset-operations/src/planner.rs
@@ -46,20 +46,26 @@ impl VersionPlanner {
     ) -> Result<ReleasePlan, VersionError> {
         let package_lookup: IndexMap<_, _> = packages.iter().map(|p| (p.name.clone(), p)).collect();
         let bumps_by_package = Self::aggregate_bumps(changesets);
+        let graduates = Self::collect_graduates(changesets);
 
         let mut releases = Vec::new();
         let mut unknown_packages = Vec::new();
 
         for (name, bumps) in &bumps_by_package {
             let bump_type = max_bump_type(bumps);
+            let should_graduate = graduates.contains(name);
 
-            if bump_type.is_none() && prerelease.is_none() {
+            if Self::should_skip_package(bump_type, prerelease, should_graduate) {
                 continue;
             }
 
             if let Some(pkg) = package_lookup.get(name) {
                 let new_version = calculate_new_version(&pkg.version, bump_type, prerelease)?;
-                let effective_bump = bump_type.unwrap_or(BumpType::Patch);
+                let effective_bump = if should_graduate {
+                    BumpType::Major
+                } else {
+                    bump_type.unwrap_or(BumpType::Patch)
+                };
                 releases.push(PackageVersion {
                     name: name.clone(),
                     current_version: pkg.version.clone(),
@@ -125,11 +131,16 @@ impl VersionPlanner {
             let bump_type = max_bump_type(bumps);
             let should_graduate = graduates.contains(name);
 
-            if bump_type.is_none() && prerelease.is_none() && !should_graduate {
+            if Self::should_skip_package(bump_type, prerelease, should_graduate) {
                 continue;
             }
 
             if let Some(pkg) = package_lookup.get(name) {
+                let effective_bump = if should_graduate {
+                    BumpType::Major
+                } else {
+                    bump_type.unwrap_or(BumpType::Patch)
+                };
                 let new_version = calculate_new_version_with_zero_behavior(
                     &pkg.version,
                     bump_type,
@@ -137,7 +148,6 @@ impl VersionPlanner {
                     zero_behavior,
                     should_graduate,
                 )?;
-                let effective_bump = bump_type.unwrap_or(BumpType::Patch);
                 releases.push(PackageVersion {
                     name: name.clone(),
                     current_version: pkg.version.clone(),
@@ -219,11 +229,16 @@ impl VersionPlanner {
             let should_graduate =
                 config.is_some_and(|c| c.graduate_zero) || changeset_graduates.contains(name);
 
-            if bump_type.is_none() && prerelease.is_none() && !should_graduate {
+            if Self::should_skip_package(bump_type, prerelease, should_graduate) {
                 continue;
             }
 
             if let Some(pkg) = package_lookup.get(name) {
+                let effective_bump = if should_graduate {
+                    BumpType::Major
+                } else {
+                    bump_type.unwrap_or(BumpType::Patch)
+                };
                 let new_version = calculate_new_version_with_zero_behavior(
                     &pkg.version,
                     bump_type,
@@ -231,7 +246,6 @@ impl VersionPlanner {
                     zero_behavior,
                     should_graduate,
                 )?;
-                let effective_bump = bump_type.unwrap_or(BumpType::Patch);
                 releases.push(PackageVersion {
                     name: name.clone(),
                     current_version: pkg.version.clone(),
@@ -273,6 +287,15 @@ impl VersionPlanner {
             releases,
             unknown_packages,
         })
+    }
+
+    fn should_skip_package(
+        bump_type: Option<BumpType>,
+        prerelease: Option<&PrereleaseSpec>,
+        should_graduate: bool,
+    ) -> bool {
+        let is_noop_or_absent = bump_type.is_none() || bump_type.is_some_and(|b| b.is_noop());
+        is_noop_or_absent && prerelease.is_none() && !should_graduate
     }
 
     fn collect_graduates(changesets: &[Changeset]) -> HashSet<String> {
@@ -722,6 +745,25 @@ mod tests {
                 "0.2.0-alpha.1".parse::<Version>().expect("valid")
             );
         }
+
+        #[test]
+        fn auto_promote_none_bump_excludes_package() {
+            let packages = vec![make_package("my-crate", "0.1.2")];
+            let changesets = vec![make_changeset("my-crate", BumpType::None, "internal")];
+
+            let plan = VersionPlanner::plan_releases_with_behavior(
+                &changesets,
+                &packages,
+                None,
+                ZeroVersionBehavior::AutoPromoteOnMajor,
+            )
+            .expect("plan_releases_with_behavior");
+
+            assert!(
+                plan.releases.is_empty(),
+                "package with only None bumps should not appear in releases"
+            );
+        }
     }
 
     mod zero_graduation_tests {
@@ -873,6 +915,68 @@ mod tests {
                 .find(|r| r.name == "regular")
                 .expect("regular should be in releases");
             assert_eq!(regular.new_version, Version::new(0, 4, 0));
+        }
+    }
+
+    mod graduation_with_none_bump {
+        use super::*;
+
+        fn make_graduating_changeset(package_name: &str, bump: BumpType) -> Changeset {
+            Changeset {
+                summary: "Graduate to 1.0".to_string(),
+                releases: vec![PackageRelease {
+                    name: package_name.to_string(),
+                    bump_type: bump,
+                }],
+                category: ChangeCategory::Changed,
+                consumed_for_prerelease: None,
+                graduate: true,
+            }
+        }
+
+        #[test]
+        fn graduate_field_with_none_bump_still_graduates() {
+            let packages = vec![make_package("my-crate", "0.5.3")];
+            let changesets = vec![make_graduating_changeset("my-crate", BumpType::None)];
+
+            let plan = VersionPlanner::plan_releases_with_behavior(
+                &changesets,
+                &packages,
+                None,
+                ZeroVersionBehavior::EffectiveMinor,
+            )
+            .expect("plan_releases_with_behavior");
+
+            assert_eq!(plan.releases.len(), 1);
+            let release = &plan.releases[0];
+            assert_eq!(release.new_version, Version::new(1, 0, 0));
+        }
+
+        #[test]
+        fn per_package_graduate_with_none_bump_still_graduates() {
+            let packages = vec![make_package("my-crate", "0.5.3")];
+            let changesets = vec![make_graduating_changeset("my-crate", BumpType::None)];
+
+            let mut config = HashMap::new();
+            config.insert(
+                "my-crate".to_string(),
+                PackageReleaseConfig {
+                    prerelease: None,
+                    graduate_zero: true,
+                },
+            );
+
+            let plan = VersionPlanner::plan_releases_per_package(
+                &changesets,
+                &packages,
+                &config,
+                ZeroVersionBehavior::EffectiveMinor,
+            )
+            .expect("plan_releases_per_package");
+
+            assert_eq!(plan.releases.len(), 1);
+            let release = &plan.releases[0];
+            assert_eq!(release.new_version, Version::new(1, 0, 0));
         }
     }
 
@@ -1529,6 +1633,85 @@ mod tests {
                 plan.unknown_packages.is_empty(),
                 "config for nonexistent packages does not add to unknown_packages"
             );
+        }
+    }
+
+    mod none_bump_type {
+        use super::*;
+
+        #[test]
+        fn all_none_bumps_exclude_package_from_releases() {
+            let packages = vec![make_package("my-crate", "1.0.0")];
+            let changesets = vec![make_changeset("my-crate", BumpType::None, "internal")];
+
+            let plan =
+                VersionPlanner::plan_releases(&changesets, &packages).expect("should succeed");
+
+            assert!(
+                plan.releases.is_empty(),
+                "package with only None bumps should not appear in releases"
+            );
+        }
+
+        #[test]
+        fn none_bumps_still_tracked_in_aggregate() {
+            let changesets = vec![make_changeset("my-crate", BumpType::None, "internal")];
+
+            let bumps = VersionPlanner::aggregate_bumps(&changesets);
+
+            assert!(bumps.contains_key("my-crate"));
+            assert_eq!(bumps["my-crate"], vec![BumpType::None]);
+        }
+
+        #[test]
+        fn mixed_none_and_patch_uses_patch() {
+            let packages = vec![make_package("my-crate", "1.0.0")];
+            let changesets = vec![
+                make_changeset("my-crate", BumpType::None, "internal"),
+                make_changeset("my-crate", BumpType::Patch, "fix bug"),
+            ];
+
+            let plan =
+                VersionPlanner::plan_releases(&changesets, &packages).expect("should succeed");
+
+            assert_eq!(plan.releases.len(), 1);
+            assert_eq!(plan.releases[0].bump_type, BumpType::Patch);
+            assert_eq!(
+                plan.releases[0].new_version,
+                Version::parse("1.0.1").expect("valid version")
+            );
+        }
+
+        #[test]
+        fn all_none_excluded_from_behavior_plan() {
+            let packages = vec![make_package("my-crate", "0.1.0")];
+            let changesets = vec![make_changeset("my-crate", BumpType::None, "internal")];
+
+            let plan = VersionPlanner::plan_releases_with_behavior(
+                &changesets,
+                &packages,
+                None,
+                ZeroVersionBehavior::EffectiveMinor,
+            )
+            .expect("should succeed");
+
+            assert!(plan.releases.is_empty());
+        }
+
+        #[test]
+        fn all_none_excluded_from_per_package_plan() {
+            let packages = vec![make_package("my-crate", "1.0.0")];
+            let changesets = vec![make_changeset("my-crate", BumpType::None, "internal")];
+
+            let plan = VersionPlanner::plan_releases_per_package(
+                &changesets,
+                &packages,
+                &HashMap::new(),
+                ZeroVersionBehavior::EffectiveMinor,
+            )
+            .expect("should succeed");
+
+            assert!(plan.releases.is_empty());
         }
     }
 }

--- a/crates/changeset-parse/src/parse.rs
+++ b/crates/changeset-parse/src/parse.rs
@@ -533,6 +533,74 @@ Major bump.
     }
 
     #[test]
+    fn parses_none_bump_type_with_body() {
+        let content = r#"---
+"my-crate": none
+---
+Internal refactoring only.
+"#;
+
+        let changeset = parse_changeset(content).expect("should parse");
+        assert_eq!(changeset.releases.len(), 1);
+        assert_eq!(changeset.releases[0].name, "my-crate");
+        assert_eq!(changeset.releases[0].bump_type, BumpType::None);
+        assert_eq!(changeset.summary, "Internal refactoring only.");
+    }
+
+    #[test]
+    fn parses_none_bump_type_with_empty_body() {
+        let content = r#"---
+"my-crate": none
+---
+"#;
+
+        let changeset = parse_changeset(content).expect("should parse");
+        assert_eq!(changeset.releases[0].bump_type, BumpType::None);
+        assert!(changeset.summary.is_empty());
+    }
+
+    #[test]
+    fn parses_mixed_none_and_patch_bump_types() {
+        let content = r#"---
+"crate-a": none
+"crate-b": patch
+---
+Mixed bump types.
+"#;
+
+        let changeset = parse_changeset(content).expect("should parse");
+        assert_eq!(changeset.releases.len(), 2);
+        assert_eq!(changeset.releases[0].bump_type, BumpType::None);
+        assert_eq!(changeset.releases[1].bump_type, BumpType::Patch);
+    }
+
+    #[test]
+    fn yaml_null_does_not_parse_as_bump_type_none() {
+        let content = r#"---
+"my-crate": None
+---
+Summary.
+"#;
+
+        let err = parse_changeset(content)
+            .expect_err("YAML None (null) should not parse as BumpType::None");
+        assert!(err.to_string().contains("YAML"));
+    }
+
+    #[test]
+    fn yaml_uppercase_none_does_not_parse_as_bump_type_none() {
+        let content = r#"---
+"my-crate": NONE
+---
+Summary.
+"#;
+
+        let err =
+            parse_changeset(content).expect_err("YAML NONE should not parse as BumpType::None");
+        assert!(err.to_string().contains("YAML"));
+    }
+
+    #[test]
     fn parses_graduate_with_category() {
         let content = r#"---
 category: added

--- a/crates/changeset-parse/src/serialize.rs
+++ b/crates/changeset-parse/src/serialize.rs
@@ -320,6 +320,26 @@ mod tests {
     }
 
     #[test]
+    fn roundtrip_with_none_bump_type() {
+        let original = Changeset {
+            summary: "Internal refactoring".to_string(),
+            releases: vec![PackageRelease {
+                name: "my-crate".to_string(),
+                bump_type: BumpType::None,
+            }],
+            category: ChangeCategory::default(),
+            consumed_for_prerelease: None,
+            graduate: false,
+        };
+
+        let serialized = serialize_changeset(&original).expect("should serialize");
+        let parsed = parse_changeset(&serialized).expect("should parse");
+
+        assert_eq!(parsed.releases[0].bump_type, BumpType::None);
+        assert_eq!(parsed.summary, original.summary);
+    }
+
+    #[test]
     fn roundtrip_with_graduate() {
         let original = Changeset {
             summary: "Graduating to 1.0".to_string(),

--- a/crates/changeset-version/src/lib.rs
+++ b/crates/changeset-version/src/lib.rs
@@ -21,6 +21,7 @@ pub fn bump_version(version: &Version, bump_type: BumpType) -> Version {
     let mut new_version = version.clone();
 
     match bump_type {
+        BumpType::None => return new_version,
         BumpType::Major => {
             new_version.major += 1;
             new_version.minor = 0;
@@ -160,6 +161,7 @@ pub fn calculate_new_version_with_zero_behavior(
 
     let effective_bump = match zero_behavior {
         ZeroVersionBehavior::EffectiveMinor => bump_type.map(|bt| match bt {
+            BumpType::None => BumpType::None,
             BumpType::Major => BumpType::Minor,
             BumpType::Minor | BumpType::Patch => BumpType::Patch,
         }),
@@ -239,6 +241,20 @@ mod tests {
         assert_eq!(bumped, Version::parse("1.2.4").unwrap());
     }
 
+    #[test]
+    fn bump_none_returns_version_unchanged() {
+        let version = Version::parse("1.2.3").unwrap();
+        let bumped = bump_version(&version, BumpType::None);
+        assert_eq!(bumped, Version::parse("1.2.3").unwrap());
+    }
+
+    #[test]
+    fn bump_none_preserves_prerelease() {
+        let version = Version::parse("1.2.3-alpha.1").unwrap();
+        let bumped = bump_version(&version, BumpType::None);
+        assert_eq!(bumped, Version::parse("1.2.3-alpha.1").unwrap());
+    }
+
     mod max_bump_type_tests {
         use super::*;
 
@@ -292,6 +308,27 @@ mod tests {
                 max_bump_type(&[BumpType::Major, BumpType::Patch, BumpType::Minor]),
                 Some(BumpType::Major)
             );
+        }
+
+        #[test]
+        fn none_with_patch_returns_patch() {
+            assert_eq!(
+                max_bump_type(&[BumpType::None, BumpType::Patch]),
+                Some(BumpType::Patch)
+            );
+        }
+
+        #[test]
+        fn all_none_returns_none() {
+            assert_eq!(
+                max_bump_type(&[BumpType::None, BumpType::None]),
+                Some(BumpType::None)
+            );
+        }
+
+        #[test]
+        fn single_none() {
+            assert_eq!(max_bump_type(&[BumpType::None]), Some(BumpType::None));
         }
     }
 
@@ -607,6 +644,20 @@ mod tests {
                 .unwrap();
                 assert_eq!(result, Version::parse("0.1.0").unwrap());
             }
+
+            #[test]
+            fn none_stays_none() {
+                let version = Version::parse("0.1.2").unwrap();
+                let result = calculate_new_version_with_zero_behavior(
+                    &version,
+                    Some(BumpType::None),
+                    None,
+                    ZeroVersionBehavior::EffectiveMinor,
+                    false,
+                )
+                .unwrap();
+                assert_eq!(result, Version::parse("0.1.2").unwrap());
+            }
         }
 
         mod auto_promote_behavior {
@@ -666,6 +717,24 @@ mod tests {
                 )
                 .unwrap();
                 assert_eq!(result, Version::parse("1.0.0-alpha.1").unwrap());
+            }
+        }
+
+        mod none_bump_behavior {
+            use super::*;
+
+            #[test]
+            fn none_leaves_version_unchanged() {
+                let version = Version::parse("0.1.2").unwrap();
+                let result = calculate_new_version_with_zero_behavior(
+                    &version,
+                    Some(BumpType::None),
+                    None,
+                    ZeroVersionBehavior::AutoPromoteOnMajor,
+                    false,
+                )
+                .unwrap();
+                assert_eq!(result, Version::parse("0.1.2").unwrap());
             }
         }
 


### PR DESCRIPTION
- Resolves #62 

Support tracking changes that should appear in changelogs without triggering version bumps. The 'none' bump type flows through parsing, serialization, version computation, status display, and the add command.