### PR TITLE
Dogfood published GitHub Actions for verify and release

### DIFF
--- a/.changeset/changesets/palpably-haloed-amphibian.md
+++ b/.changeset/changesets/palpably-haloed-amphibian.md
@@ -1,0 +1,5 @@
+---
+category: fixed
+cargo-changeset: patch
+---
+Fixed typo in `README.md`

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,49 +1,53 @@
-name: "Release with Changesets"
-description: "Run cargo-changeset release to bump versions, update changelogs, and commit"
+---
+name: Release with Changesets
+description: Run cargo-changeset release to bump versions, update changelogs, and
+  commit
+
 branding:
-  icon: "package"
-  color: "blue"
+  icon: package
+  color: blue
 
 inputs:
   dry-run:
-    description: "Preview without modifying files"
+    description: Preview without modifying files
     required: false
-    default: "false"
+    default: 'false'
   convert:
-    description: "Convert pre-release versions to stable"
+    description: Convert pre-release versions to stable
     required: false
-    default: "false"
+    default: 'false'
   no-commit:
-    description: "Skip creating a release commit"
+    description: Skip creating a release commit
     required: false
-    default: "false"
+    default: 'false'
   no-tags:
-    description: "Skip creating git tags"
+    description: Skip creating git tags
     required: false
-    default: "false"
+    default: 'false'
   keep-changesets:
-    description: "Keep changeset files after release"
+    description: Keep changeset files after release
     required: false
-    default: "false"
+    default: 'false'
   force:
-    description: "Force release even without changesets"
+    description: Force release even without changesets
     required: false
-    default: "false"
+    default: 'false'
   prerelease:
-    description: "Pre-release identifiers (space-separated, e.g. 'foo:alpha bar:beta')"
+    description: Pre-release identifiers (space-separated, e.g. 'foo:alpha bar:beta')
     required: false
-    default: ""
+    default: ''
   graduate:
-    description: "Graduate pre-releases to stable (space-separated crate names, e.g. 'foo bar')"
+    description: Graduate pre-releases to stable (space-separated crate names, e.g.
+      'foo bar')
     required: false
-    default: ""
+    default: ''
   cargo-changeset-version:
-    description: "Docker image tag for cargo-changeset"
+    description: Docker image tag for cargo-changeset
     required: false
-    default: "latest"
+    default: latest
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Verify git identity is configured
       shell: bash
@@ -71,7 +75,7 @@ runs:
         INPUT_PRERELEASE: ${{ inputs.prerelease }}
         INPUT_GRADUATE: ${{ inputs.graduate }}
         INPUT_VERSION: ${{ inputs.cargo-changeset-version }}
-      run: |
+      run: |-
         FLAGS=""
 
         if [ "$INPUT_DRY_RUN" = "true" ]; then

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,21 +1,23 @@
-name: "Verify Changeset Coverage"
-description: "Verify that all changed crates have changeset coverage using cargo-changeset"
+---
+name: Verify Changeset Coverage
+description: Verify that all changed crates have changeset coverage using cargo-changeset
+
 branding:
-  icon: "check-circle"
-  color: "green"
+  icon: check-circle
+  color: green
 
 inputs:
   base:
-    description: "Base branch to compare against"
+    description: Base branch to compare against
     required: false
-    default: "main"
+    default: main
   cargo-changeset-version:
-    description: "Docker image tag for cargo-changeset"
+    description: Docker image tag for cargo-changeset
     required: false
-    default: "latest"
+    default: latest
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Fetch base ref
       shell: bash
@@ -28,8 +30,8 @@ runs:
       env:
         INPUT_BASE: ${{ inputs.base }}
         INPUT_VERSION: ${{ inputs.cargo-changeset-version }}
-      run: |
+      run: |-
         docker run --rm \
           -v "$(pwd):/workspace" -w /workspace \
           "ghcr.io/lukidoescode/cargo-changeset:${INPUT_VERSION}" \
-          verify --base "origin/$INPUT_BASE" --quiet
+          verify --base "origin/$INPUT_BASE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,12 @@ on:
         type: string
         required: false
       graduate:
-        description: Graduate pre-releases to stable
-        type: boolean
-        default: false
+        description: >-
+          Space-separated crate names to graduate to 1.0.0
+          (e.g. "crate-a crate-b")
+        type: string
+        required: false
+        default: ""
       keep_changesets:
         description: Keep changeset files after release
         type: boolean
@@ -41,38 +44,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Cache cargo-changeset binary
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-changeset
-          key: cargo-changeset-${{ runner.os }}-0.1.4
-
-      - name: Install cargo-changeset
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-changeset --version 0.1.4
-
-      - name: Build release flags
-        id: flags
-        run: |
-          FLAGS=""
-          if [ -n "${{ inputs.pre_release }}" ]; then
-            FLAGS="$FLAGS --prerelease ${{ inputs.pre_release }}"
-          fi
-          if [ "${{ inputs.graduate }}" = "true" ]; then
-            FLAGS="$FLAGS --graduate"
-          fi
-          if [ "${{ inputs.keep_changesets }}" = "true" ]; then
-            FLAGS="$FLAGS --keep-changesets"
-          fi
-          echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
-
       - name: Dry run release
-        run: cargo changeset release --dry-run ${{ steps.flags.outputs.flags }}
+        uses: ./.github/actions/release
+        with:
+          dry-run: "true"
+          prerelease: ${{ inputs.pre_release }}
+          graduate: ${{ inputs.graduate }}
+          keep-changesets: ${{ inputs.keep_changesets && 'true' || 'false' }}
 
       - name: Execute release
         if: ${{ inputs.dry_run == false }}
-        run: cargo changeset release ${{ steps.flags.outputs.flags }}
+        uses: ./.github/actions/release
+        with:
+          prerelease: ${{ inputs.pre_release }}
+          graduate: ${{ inputs.graduate }}
+          keep-changesets: ${{ inputs.keep_changesets && 'true' || 'false' }}
 
       - name: Push release commit and tags
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,16 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
-      - name: Cache cargo-changeset binary
-        id: cache
-        uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/cargo-changeset
-          key: cargo-changeset-${{ runner.os }}-0.1.4
-      - name: Install cargo-changeset
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-changeset --version 0.1.4
-      - name: Verify changeset coverage
-        run: cargo changeset verify --base origin/${{ github.base_ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/verify
+        with:
+          base: ${{ github.base_ref }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each file lists one or more crates with a bump type (`major`, `minor`, `patch`, 
 | **Dependency-aware releases** | Automatically bumps workspace crates that depend on a released crate and generates changelog entries for the update. |
 | **Keep a Changelog** | Generates [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) entries grouped by category. Supports root or per-package changelogs with optional comparison links for GitHub, GitLab, Bitbucket, Gitea, Codeberg, and SourceHut. |
 | **Git integration** | Creates commits and annotated tags automatically. Supports `version-only` (`v1.0.0`) and `crate-prefixed` (`crate@v1.0.0`) tag formats. |
-| **CI-ready** | Auto-detects GitHub Actions, GitLab CI, CircleCI, Travis, Jenkins, Buildkite, and Azure DevOps. Ships as Docker images and pre-built binaries. Provides GitHub Actions for verify and release. |
+| **CI-ready** | Supports GitHub Actions, GitLab CI, CircleCI, Travis, Jenkins, Buildkite, and Azure DevOps. Ships as Docker images and pre-built binaries. Provides GitHub Actions for verify and release. |
 
 <details>
 <summary><strong>Instructions for AI Coding Agents 🤖</strong></summary>


### PR DESCRIPTION
- Resolves #48

Replace manual `cargo-changeset` installation with the repo's own composite actions in `verify.yml` and `release.yml` workflows.

- `verify.yml`: use `.github/actions/verify` instead of `cargo changeset verify`
- `release.yml`: use `.github/actions/release` instead of `cargo changeset release`
- Change graduate input from boolean to string (space-separated crate names)