### PR TITLE
Fix clippy pedantic warnings across workspace

### DIFF
--- a/.changeset/changesets/mightily-harmonic-canvasback.md
+++ b/.changeset/changesets/mightily-harmonic-canvasback.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: major
+---
+AddOperation::execute() now takes &AddInput instead of owned AddInput.

--- a/.changeset/changesets/nobly-handsome-onager.md
+++ b/.changeset/changesets/nobly-handsome-onager.md
@@ -1,0 +1,5 @@
+---
+changeset-project: none
+cargo-changeset: none
+---
+Internal refactoring to resolve clippy pedantic warnings with no user-visible changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ authors = ["Lukas Wagner <appdev.lukaswagner@gmail.com>"]
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
-needless_pass_by_value = "allow"             # needed for Bevy systems
-type_complexity = "allow"                    # Some bevy types are just complex. We do not care about that. Clippy's type complexity metric is too strict
-struct_excessive_bools = "allow"             # CLI input structs map directly to command-line flags
 unwrap_used = "deny"
 
 [workspace.metadata]

--- a/crates/cargo-changeset/src/commands/add.rs
+++ b/crates/cargo-changeset/src/commands/add.rs
@@ -34,11 +34,11 @@ pub(super) fn run(args: AddArgs, start_path: &Path) -> Result<()> {
     let result = if is_interactive() {
         let interaction_provider = TerminalInteractionProvider::new(args.editor);
         let operation = AddOperation::new(project_provider, changeset_writer, interaction_provider);
-        operation.execute(start_path, input)?
+        operation.execute(start_path, &input)?
     } else {
         let interaction_provider = NonInteractiveProvider;
         let operation = AddOperation::new(project_provider, changeset_writer, interaction_provider);
-        operation.execute(start_path, input)?
+        operation.execute(start_path, &input)?
     };
 
     match result {

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -170,7 +170,7 @@ impl DependencyGraphProvider for MockProjectProvider {
             .map(|p| p.name().clone())
             .collect();
         Ok(WorkspaceDependencyGraph::from_edges(
-            member_names,
+            &member_names,
             &self.dependency_edges,
         ))
     }
@@ -414,6 +414,20 @@ impl ChangesetWriter for MockChangesetWriter {
     }
 }
 
+#[derive(Clone, Copy)]
+enum TagFailMode {
+    Never,
+    Always,
+    OnNth(usize),
+}
+
+struct MockFailureFlags {
+    commit: bool,
+    stage_files: bool,
+    is_clean: bool,
+    create_tag: TagFailMode,
+}
+
 struct MockGitState {
     staged_files: Vec<PathBuf>,
     commits: Vec<String>,
@@ -421,11 +435,7 @@ struct MockGitState {
     deleted_files: Vec<PathBuf>,
     deleted_tags: Vec<String>,
     reset_count: usize,
-    fail_on_commit: bool,
-    fail_on_create_tag: bool,
-    fail_on_create_tag_nth: Option<usize>,
-    fail_on_stage_files: bool,
-    fail_on_is_clean: bool,
+    failure_flags: MockFailureFlags,
 }
 
 pub struct MockGitProvider {
@@ -453,11 +463,12 @@ impl MockGitProvider {
                 deleted_files: Vec::new(),
                 deleted_tags: Vec::new(),
                 reset_count: 0,
-                fail_on_commit: false,
-                fail_on_create_tag: false,
-                fail_on_create_tag_nth: None,
-                fail_on_stage_files: false,
-                fail_on_is_clean: false,
+                failure_flags: MockFailureFlags {
+                    commit: false,
+                    stage_files: false,
+                    is_clean: false,
+                    create_tag: TagFailMode::Never,
+                },
             }),
         }
     }
@@ -539,29 +550,47 @@ impl MockGitProvider {
     }
 
     pub fn set_fail_on_commit(&self, fail: bool) {
-        self.state.lock().expect("lock poisoned").fail_on_commit = fail;
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .failure_flags
+            .commit = fail;
     }
 
     pub fn set_fail_on_create_tag(&self, fail: bool) {
-        self.state.lock().expect("lock poisoned").fail_on_create_tag = fail;
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .failure_flags
+            .create_tag = if fail {
+            TagFailMode::Always
+        } else {
+            TagFailMode::Never
+        };
     }
 
     pub fn set_fail_on_create_tag_nth(&self, n: usize) {
         self.state
             .lock()
             .expect("lock poisoned")
-            .fail_on_create_tag_nth = Some(n);
+            .failure_flags
+            .create_tag = TagFailMode::OnNth(n);
     }
 
     pub fn set_fail_on_stage_files(&self, fail: bool) {
         self.state
             .lock()
             .expect("lock poisoned")
-            .fail_on_stage_files = fail;
+            .failure_flags
+            .stage_files = fail;
     }
 
     pub fn set_fail_on_is_clean(&self, fail: bool) {
-        self.state.lock().expect("lock poisoned").fail_on_is_clean = fail;
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .failure_flags
+            .is_clean = fail;
     }
 }
 
@@ -590,7 +619,13 @@ impl GitWorkdirDiffProvider for MockGitProvider {
 
 impl GitStatusProvider for MockGitProvider {
     fn is_working_tree_clean(&self, _project_root: &Path) -> Result<bool> {
-        if self.state.lock().expect("lock poisoned").fail_on_is_clean {
+        if self
+            .state
+            .lock()
+            .expect("lock poisoned")
+            .failure_flags
+            .is_clean
+        {
             return Err(crate::OperationError::Io(std::io::Error::other(
                 "mock is_working_tree_clean failure",
             )));
@@ -610,7 +645,7 @@ impl GitStatusProvider for MockGitProvider {
 impl GitStagingProvider for MockGitProvider {
     fn stage_files(&self, _project_root: &Path, paths: &[&Path]) -> Result<()> {
         let mut state = self.state.lock().expect("lock poisoned");
-        if state.fail_on_stage_files {
+        if state.failure_flags.stage_files {
             return Err(crate::OperationError::Io(std::io::Error::other(
                 "mock stage files failure",
             )));
@@ -634,7 +669,7 @@ impl GitStagingProvider for MockGitProvider {
 impl GitCommitProvider for MockGitProvider {
     fn commit(&self, _project_root: &Path, message: &str) -> Result<CommitInfo> {
         let mut state = self.state.lock().expect("lock poisoned");
-        if state.fail_on_commit {
+        if state.failure_flags.commit {
             return Err(crate::OperationError::Io(std::io::Error::other(
                 "mock commit failure",
             )));
@@ -655,21 +690,16 @@ impl GitCommitProvider for MockGitProvider {
 impl GitTagProvider for MockGitProvider {
     fn create_tag(&self, _project_root: &Path, tag_name: &str, message: &str) -> Result<TagInfo> {
         let mut state = self.state.lock().expect("lock poisoned");
-        if state.fail_on_create_tag {
+        let should_fail = match state.failure_flags.create_tag {
+            TagFailMode::Never => false,
+            TagFailMode::Always => true,
+            TagFailMode::OnNth(n) => state.tags_created.len() == n,
+        };
+        if should_fail {
             return Err(crate::OperationError::Io(std::io::Error::other(
                 "mock create tag failure",
             )));
         }
-
-        let current_count = state.tags_created.len();
-        if let Some(n) = state.fail_on_create_tag_nth {
-            if current_count == n {
-                return Err(crate::OperationError::Io(std::io::Error::other(
-                    "mock create tag failure (nth)",
-                )));
-            }
-        }
-
         state
             .tags_created
             .push((tag_name.to_string(), message.to_string()));

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -68,7 +68,7 @@ where
     ///
     /// Returns an error if the project cannot be discovered, has no packages, or
     /// if the changeset cannot be written.
-    pub fn execute(&self, start_path: &Path, input: AddInput) -> Result<AddResult> {
+    pub fn execute(&self, start_path: &Path, input: &AddInput) -> Result<AddResult> {
         let project = self.project_provider.discover_project(start_path)?;
 
         if project.packages().is_empty() {
@@ -104,7 +104,7 @@ where
         });
 
         let packages =
-            match self.select_packages(project.packages(), &input, display_labels.as_deref())? {
+            match self.select_packages(project.packages(), input, display_labels.as_deref())? {
                 Some(packages) if packages.is_empty() => return Ok(AddResult::NoPackages),
                 Some(packages) => packages,
                 None => return Ok(AddResult::Cancelled),
@@ -120,15 +120,15 @@ where
             Vec::new()
         };
 
-        let Some(releases) = self.collect_releases(&packages, &input)? else {
+        let Some(releases) = self.collect_releases(&packages, input)? else {
             return Ok(AddResult::Cancelled);
         };
 
-        let Some(category) = self.select_category(&input)? else {
+        let Some(category) = self.select_category(input)? else {
             return Ok(AddResult::Cancelled);
         };
 
-        let Some(desc) = self.get_description(&input)? else {
+        let Some(desc) = self.get_description(input)? else {
             return Ok(AddResult::Cancelled);
         };
 
@@ -354,7 +354,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation failed with valid single-package input");
 
         match result {
@@ -393,7 +393,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation failed with valid multi-package input");
 
         match result {
@@ -420,7 +420,7 @@ mod tests {
         let operation = AddOperation::new(project_provider, writer, interaction);
 
         let result = operation
-            .execute(Path::new("/any"), AddInput::default())
+            .execute(Path::new("/any"), &AddInput::default())
             .expect("AddOperation should not fail when interaction is cancelled");
 
         assert!(matches!(result, AddResult::Cancelled));
@@ -441,7 +441,7 @@ mod tests {
         let operation = AddOperation::new(project_provider, writer, interaction);
 
         let result = operation
-            .execute(Path::new("/any"), AddInput::default())
+            .execute(Path::new("/any"), &AddInput::default())
             .expect("AddOperation should not fail when bump selection is cancelled");
 
         assert!(matches!(result, AddResult::Cancelled));
@@ -462,7 +462,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = operation.execute(Path::new("/any"), input);
+        let result = operation.execute(Path::new("/any"), &input);
 
         assert!(result.is_err());
         let err = result.expect_err("AddOperation should fail for unknown package");
@@ -484,7 +484,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = operation.execute(Path::new("/any"), input);
+        let result = operation.execute(Path::new("/any"), &input);
 
         assert!(result.is_err());
         let err = result.expect_err("AddOperation should fail for empty description");
@@ -507,7 +507,7 @@ mod tests {
         let operation = AddOperation::new(project_provider, writer, interaction);
 
         let result = operation
-            .execute(Path::new("/any"), AddInput::default())
+            .execute(Path::new("/any"), &AddInput::default())
             .expect("AddOperation failed with interactive workspace selection");
 
         match result {
@@ -538,7 +538,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation failed for single-package auto-selection");
 
         match result {
@@ -568,7 +568,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation failed with explicit category");
 
         match result {
@@ -595,7 +595,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation failed to create changeset file");
 
         match result {
@@ -621,7 +621,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = operation.execute(Path::new("/any"), input);
+        let result = operation.execute(Path::new("/any"), &input);
 
         assert!(result.is_err());
         let err = result.expect_err("AddOperation should fail for none bump without description");
@@ -644,7 +644,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed for none bump with description");
 
         match result {
@@ -677,7 +677,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed with interactive description for none bump");
 
         match result {
@@ -710,7 +710,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed for mixed none/patch bumps with description");
 
         match result {
@@ -756,7 +756,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed with exclude_dependents");
 
         match result {
@@ -791,7 +791,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed and report uncovered dependents");
 
         match result {
@@ -823,7 +823,7 @@ mod tests {
         };
 
         let result = operation
-            .execute(Path::new("/any"), input)
+            .execute(Path::new("/any"), &input)
             .expect("AddOperation should succeed for single-package project");
 
         match result {

--- a/crates/changeset-operations/src/operations/release/changelog_strategy.rs
+++ b/crates/changeset-operations/src/operations/release/changelog_strategy.rs
@@ -86,7 +86,7 @@ impl ChangelogHandler for RootChangelogStrategy {
                     previous_tag.as_deref(),
                 )?;
 
-                changelog_updates.push(build_changelog_update(result, version, None));
+                changelog_updates.push(build_changelog_update(&result, version, None));
             }
         }
 
@@ -141,7 +141,7 @@ impl ChangelogHandler for PerPackageChangelogStrategy {
                     )?;
 
                     changelog_updates.push(build_changelog_update(
-                        result,
+                        &result,
                         release.new_version().clone(),
                         Some(release.name().clone()),
                     ));
@@ -168,7 +168,7 @@ fn read_changelog_content(path: &Path) -> Result<String> {
 }
 
 fn build_changelog_update(
-    result: ChangelogWriteResult,
+    result: &ChangelogWriteResult,
     version: Version,
     package: Option<String>,
 ) -> ChangelogUpdate {

--- a/crates/changeset-operations/src/operations/release/dependency_expansion.rs
+++ b/crates/changeset-operations/src/operations/release/dependency_expansion.rs
@@ -80,7 +80,7 @@ mod tests {
             .iter()
             .map(|&(a, b)| (a.to_string(), b.to_string()))
             .collect();
-        WorkspaceDependencyGraph::from_edges(member_set, &edge_vec)
+        WorkspaceDependencyGraph::from_edges(&member_set, &edge_vec)
     }
 
     #[test]

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -370,12 +370,8 @@ where
             context.changeset_files.clone(),
         )
         .with_options(SagaReleaseOptions {
-            is_prerelease_release: context.classification.is_prerelease_release,
-            is_graduating: context.classification.is_graduating,
-            is_prerelease_graduation: context.classification.is_prerelease_graduation,
-            should_commit: context.git_options.should_commit,
-            should_create_tags: context.git_options.should_create_tags,
-            should_delete_changesets: context.git_options.should_delete_changesets,
+            classification: context.classification,
+            git_options: context.git_options,
         })
         .with_inherited_packages(context.inherited_packages.clone())
         .with_prerelease_state(context.prerelease_state.as_ref())

--- a/crates/changeset-operations/src/operations/release/saga_data.rs
+++ b/crates/changeset-operations/src/operations/release/saga_data.rs
@@ -5,18 +5,22 @@ use indexmap::IndexMap;
 use semver::Version;
 
 use super::steps::{GraduationStateUpdate, PrereleaseStateUpdate};
-use super::types::{ChangelogFileState, ChangesetFileState};
+use super::types::{ChangelogFileState, ChangesetFileState, GitOptions, ReleaseClassification};
 use super::{ChangelogUpdate, CommitResult, GitOperationResult, TagResult};
 use crate::types::PackageVersion;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SagaReleaseOptions {
-    pub is_prerelease_release: bool,
-    pub is_graduating: bool,
-    pub is_prerelease_graduation: bool,
-    pub should_commit: bool,
-    pub should_create_tags: bool,
-    pub should_delete_changesets: bool,
+    pub classification: ReleaseClassification,
+    pub git_options: GitOptions,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) enum ChangesetConsumedState {
+    #[default]
+    NotConsumed,
+    Consumed,
+    Cleared,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -29,12 +33,8 @@ pub struct ReleaseSagaData {
     pub package_paths: IndexMap<String, PathBuf>,
     pub changelog_updates: Vec<ChangelogUpdate>,
 
-    pub is_prerelease_release: bool,
-    pub is_graduating: bool,
-    pub is_prerelease_graduation: bool,
-    pub should_commit: bool,
-    pub should_create_tags: bool,
-    pub should_delete_changesets: bool,
+    pub classification: ReleaseClassification,
+    pub git_options: GitOptions,
 
     pub prerelease_state_update: Option<PrereleaseStateUpdate>,
     pub graduation_state_update: Option<GraduationStateUpdate>,
@@ -57,8 +57,7 @@ pub struct ReleaseSagaData {
     pub tags_created: Vec<TagResult>,
 
     pub changesets_deleted: Vec<PathBuf>,
-    pub changesets_consumed: bool,
-    pub consumed_cleared: bool,
+    pub consumed_state: ChangesetConsumedState,
     pub consumed_files_cleared: Vec<ChangesetFileState>,
 
     pub changelog_backups: Vec<ChangelogFileState>,
@@ -111,12 +110,8 @@ impl ReleaseSagaData {
     }
 
     pub fn with_options(mut self, options: SagaReleaseOptions) -> Self {
-        self.is_prerelease_release = options.is_prerelease_release;
-        self.is_graduating = options.is_graduating;
-        self.is_prerelease_graduation = options.is_prerelease_graduation;
-        self.should_commit = options.should_commit;
-        self.should_create_tags = options.should_create_tags;
-        self.should_delete_changesets = options.should_delete_changesets;
+        self.classification = options.classification;
+        self.git_options = options.git_options;
         self
     }
 

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -286,7 +286,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if !input.should_commit {
+        if !input.git_options.should_commit {
             return Ok(input);
         }
 
@@ -336,7 +336,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if input.is_prerelease_release && !input.changeset_files.is_empty() {
+        if input.classification.is_prerelease_release && !input.changeset_files.is_empty() {
             if let Some(first_release) = input.planned_releases.first() {
                 let paths_refs: Vec<&Path> = input
                     .changeset_files
@@ -348,7 +348,7 @@ where
                     &paths_refs,
                     first_release.new_version(),
                 )?;
-                input.changesets_consumed = true;
+                input.consumed_state = super::saga_data::ChangesetConsumedState::Consumed;
             }
         }
         Ok(input)
@@ -356,9 +356,9 @@ where
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
         // Check the same conditions as execute() to determine if we would have marked
-        // changesets as consumed. We cannot rely on input.changesets_consumed because
+        // changesets as consumed. We cannot rely on input.consumed_state because
         // compensate receives the original input, not the modified output.
-        if input.is_prerelease_release && !input.changeset_files.is_empty() {
+        if input.classification.is_prerelease_release && !input.changeset_files.is_empty() {
             let files_to_clear: Vec<&Path> = input
                 .changeset_files
                 .iter()
@@ -403,7 +403,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if input.is_graduating {
+        if input.classification.is_graduating {
             let consumed_paths = ctx
                 .changeset_rw()
                 .list_consumed_changesets(&input.changeset_dir)?;
@@ -422,7 +422,7 @@ where
                 let paths_refs: Vec<&Path> = consumed_paths.iter().map(AsRef::as_ref).collect();
                 ctx.changeset_rw()
                     .clear_consumed_for_prerelease(&input.changeset_dir, &paths_refs)?;
-                input.consumed_cleared = true;
+                input.consumed_state = super::saga_data::ChangesetConsumedState::Cleared;
                 input.consumed_files_cleared = consumed_files;
             }
         }
@@ -479,9 +479,9 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        let should_delete = input.should_delete_changesets
-            && !input.is_prerelease_release
-            && !input.is_prerelease_graduation;
+        let should_delete = input.git_options.should_delete_changesets
+            && !input.classification.is_prerelease_release
+            && !input.classification.is_prerelease_graduation;
 
         if should_delete && !input.changeset_files.is_empty() {
             for file_state in &mut input.changeset_files {
@@ -543,7 +543,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if !input.should_commit {
+        if !input.git_options.should_commit {
             return Ok(input);
         }
 
@@ -665,7 +665,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if !input.should_commit || !input.files_were_staged {
+        if !input.git_options.should_commit || !input.files_were_staged {
             return Ok(input);
         }
 
@@ -681,7 +681,7 @@ where
     }
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
-        if input.should_commit {
+        if input.git_options.should_commit {
             ctx.git_provider().reset_to_parent(ctx.project_root())?;
         }
         Ok(())
@@ -740,7 +740,7 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if !input.should_create_tags || input.commit_result.is_none() {
+        if !input.git_options.should_create_tags || input.commit_result.is_none() {
             return Ok(input);
         }
 
@@ -779,7 +779,7 @@ where
     }
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
-        if !input.should_create_tags {
+        if !input.git_options.should_create_tags {
             return Ok(());
         }
 
@@ -928,6 +928,7 @@ mod tests {
         MockReleaseStateIO,
     };
     use crate::operations::release::saga_data::SagaReleaseOptions;
+    use crate::operations::release::types::{GitOptions, ReleaseClassification};
     use crate::types::PackageVersion;
 
     type TestContext = ReleaseSagaContext<
@@ -980,12 +981,16 @@ mod tests {
             Vec::new(),
         )
         .with_options(SagaReleaseOptions {
-            is_prerelease_release: false,
-            is_graduating: false,
-            is_prerelease_graduation: false,
-            should_commit: true,
-            should_create_tags: true,
-            should_delete_changesets: true,
+            classification: ReleaseClassification {
+                is_prerelease_release: false,
+                is_graduating: false,
+                is_prerelease_graduation: false,
+            },
+            git_options: GitOptions {
+                should_commit: true,
+                should_create_tags: true,
+                should_delete_changesets: true,
+            },
         })
     }
 
@@ -1288,7 +1293,7 @@ mod tests {
             MockChangelogWriter,
         > = UpdateLockfileStep::new();
         let mut input = make_test_data();
-        input.should_commit = false;
+        input.git_options.should_commit = false;
 
         let result = SagaStep::execute(&step, &ctx, input)?;
 
@@ -1578,12 +1583,16 @@ mod tests {
             Vec::new(),
         )
         .with_options(SagaReleaseOptions {
-            is_prerelease_release: false,
-            is_graduating: false,
-            is_prerelease_graduation: false,
-            should_commit: true,
-            should_create_tags: true,
-            should_delete_changesets: true,
+            classification: ReleaseClassification {
+                is_prerelease_release: false,
+                is_graduating: false,
+                is_prerelease_graduation: false,
+            },
+            git_options: GitOptions {
+                should_commit: true,
+                should_create_tags: true,
+                should_delete_changesets: true,
+            },
         });
         input.commit_result = Some(CommitResult::new(
             "abc123".to_string(),
@@ -1657,12 +1666,16 @@ mod tests {
             Vec::new(),
         )
         .with_options(SagaReleaseOptions {
-            is_prerelease_release: false,
-            is_graduating: false,
-            is_prerelease_graduation: false,
-            should_commit: true,
-            should_create_tags: true,
-            should_delete_changesets: true,
+            classification: ReleaseClassification {
+                is_prerelease_release: false,
+                is_graduating: false,
+                is_prerelease_graduation: false,
+            },
+            git_options: GitOptions {
+                should_commit: true,
+                should_create_tags: true,
+                should_delete_changesets: true,
+            },
         });
         input.commit_result = Some(CommitResult::new(
             "abc123".to_string(),
@@ -2027,7 +2040,7 @@ mod tests {
                 .build();
 
             let mut input = make_test_data();
-            input.is_graduating = true;
+            input.classification.is_graduating = true;
             input.consumed_files_cleared = vec![ChangesetFileState {
                 path: changeset_path.clone(),
                 original_consumed_status: Some("1.0.1-alpha.1".to_string()),
@@ -2102,7 +2115,7 @@ mod tests {
                 .build();
 
             let mut input = make_test_data();
-            input.is_prerelease_release = true;
+            input.classification.is_prerelease_release = true;
             input.changeset_files = vec![ChangesetFileState {
                 path: changeset_path.clone(),
                 original_consumed_status: None,

--- a/crates/changeset-operations/src/operations/release/types.rs
+++ b/crates/changeset-operations/src/operations/release/types.rs
@@ -3,34 +3,162 @@ use std::path::PathBuf;
 
 use changeset_core::{Changeset, PackageInfo, PrereleaseSpec};
 use changeset_project::GraduationState;
-use derive_builder::Builder;
 use gset::Getset;
 use indexmap::IndexMap;
 use semver::Version;
 
 use crate::types::{PackageReleaseConfig, PackageVersion};
 
-#[derive(Builder, Getset, Default)]
-#[builder(default)]
-pub struct ReleaseInput {
-    #[getset(get_copy, vis = "pub")]
-    dry_run: bool,
-    #[getset(get_copy, vis = "pub")]
-    convert_inherited: bool,
-    #[getset(get_copy, vis = "pub")]
+#[derive(Default)]
+struct GitOverrideOptions {
     no_commit: bool,
-    #[getset(get_copy, vis = "pub")]
     no_tags: bool,
-    #[getset(get_copy, vis = "pub")]
+}
+
+#[derive(Default)]
+struct ChangesetHandlingOptions {
     keep_changesets: bool,
-    #[getset(get_copy, vis = "pub")]
+    convert_inherited: bool,
+}
+
+#[derive(Default)]
+pub struct ReleaseInput {
+    dry_run: bool,
     force: bool,
-    #[getset(get, vis = "pub")]
-    per_package_config: HashMap<String, PackageReleaseConfig>,
-    #[getset(get_as_ref, vis = "pub", ty = "Option<&PrereleaseSpec>")]
-    global_prerelease: Option<PrereleaseSpec>,
-    #[getset(get_copy, vis = "pub")]
     graduate_all: bool,
+    git_overrides: GitOverrideOptions,
+    changeset_handling: ChangesetHandlingOptions,
+    per_package_config: HashMap<String, PackageReleaseConfig>,
+    global_prerelease: Option<PrereleaseSpec>,
+}
+
+impl ReleaseInput {
+    #[must_use]
+    pub fn dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    #[must_use]
+    pub fn force(&self) -> bool {
+        self.force
+    }
+
+    #[must_use]
+    pub fn graduate_all(&self) -> bool {
+        self.graduate_all
+    }
+
+    #[must_use]
+    pub fn no_commit(&self) -> bool {
+        self.git_overrides.no_commit
+    }
+
+    #[must_use]
+    pub fn no_tags(&self) -> bool {
+        self.git_overrides.no_tags
+    }
+
+    #[must_use]
+    pub fn keep_changesets(&self) -> bool {
+        self.changeset_handling.keep_changesets
+    }
+
+    #[must_use]
+    pub fn convert_inherited(&self) -> bool {
+        self.changeset_handling.convert_inherited
+    }
+
+    #[must_use]
+    pub fn per_package_config(&self) -> &HashMap<String, PackageReleaseConfig> {
+        &self.per_package_config
+    }
+
+    #[must_use]
+    pub fn global_prerelease(&self) -> Option<&PrereleaseSpec> {
+        self.global_prerelease.as_ref()
+    }
+}
+
+#[derive(Default)]
+pub struct ReleaseInputBuilder {
+    dry_run: bool,
+    force: bool,
+    graduate_all: bool,
+    git_overrides: GitOverrideOptions,
+    changeset_handling: ChangesetHandlingOptions,
+    per_package_config: HashMap<String, PackageReleaseConfig>,
+    global_prerelease: Option<PrereleaseSpec>,
+}
+
+impl ReleaseInputBuilder {
+    #[must_use]
+    pub fn dry_run(mut self, value: bool) -> Self {
+        self.dry_run = value;
+        self
+    }
+
+    #[must_use]
+    pub fn force(mut self, value: bool) -> Self {
+        self.force = value;
+        self
+    }
+
+    #[must_use]
+    pub fn graduate_all(mut self, value: bool) -> Self {
+        self.graduate_all = value;
+        self
+    }
+
+    #[must_use]
+    pub fn no_commit(mut self, value: bool) -> Self {
+        self.git_overrides.no_commit = value;
+        self
+    }
+
+    #[must_use]
+    pub fn no_tags(mut self, value: bool) -> Self {
+        self.git_overrides.no_tags = value;
+        self
+    }
+
+    #[must_use]
+    pub fn keep_changesets(mut self, value: bool) -> Self {
+        self.changeset_handling.keep_changesets = value;
+        self
+    }
+
+    #[must_use]
+    pub fn convert_inherited(mut self, value: bool) -> Self {
+        self.changeset_handling.convert_inherited = value;
+        self
+    }
+
+    #[must_use]
+    pub fn per_package_config(mut self, value: HashMap<String, PackageReleaseConfig>) -> Self {
+        self.per_package_config = value;
+        self
+    }
+
+    #[must_use]
+    pub fn global_prerelease(mut self, value: Option<PrereleaseSpec>) -> Self {
+        self.global_prerelease = value;
+        self
+    }
+
+    /// # Errors
+    ///
+    /// Currently infallible; returns `Err` only for API compatibility.
+    pub fn build(self) -> Result<ReleaseInput, String> {
+        Ok(ReleaseInput {
+            dry_run: self.dry_run,
+            force: self.force,
+            graduate_all: self.graduate_all,
+            git_overrides: self.git_overrides,
+            changeset_handling: self.changeset_handling,
+            per_package_config: self.per_package_config,
+            global_prerelease: self.global_prerelease,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Getset)]
@@ -161,10 +289,11 @@ pub enum ReleaseOutcome {
     NoChangesets,
 }
 
-pub(super) struct GitOptions {
-    pub(super) should_commit: bool,
-    pub(super) should_create_tags: bool,
-    pub(super) should_delete_changesets: bool,
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct GitOptions {
+    pub(crate) should_commit: bool,
+    pub(crate) should_create_tags: bool,
+    pub(crate) should_delete_changesets: bool,
 }
 
 pub(super) enum PrepareResult {
@@ -172,11 +301,11 @@ pub(super) enum PrepareResult {
     EarlyReturn(ReleaseOutcome),
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(super) struct ReleaseClassification {
-    pub(super) is_prerelease_graduation: bool,
-    pub(super) is_graduating: bool,
-    pub(super) is_prerelease_release: bool,
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ReleaseClassification {
+    pub(crate) is_prerelease_graduation: bool,
+    pub(crate) is_graduating: bool,
+    pub(crate) is_prerelease_release: bool,
 }
 
 pub(super) struct ReleaseContext {

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -58,6 +58,13 @@ impl VerifyResult {
     }
 }
 
+struct CollectedChanges {
+    is_dirty: bool,
+    changeset_files: Vec<PathBuf>,
+    deleted_changesets: Vec<PathBuf>,
+    code_changes: Vec<PathBuf>,
+}
+
 pub struct VerifyOperation<P, G, R> {
     project_provider: P,
     git_provider: G,
@@ -85,8 +92,11 @@ where
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, package_configs) = self.project_provider.load_configs(&project)?;
 
-        let (is_dirty, changeset_files, deleted_changesets, changed_paths) =
-            self.collect_changes(&project, root_config.changeset_dir(), input)?;
+        let collected = self.collect_changes(&project, root_config.changeset_dir(), input)?;
+        let is_dirty = collected.is_dirty;
+        let changeset_files = collected.changeset_files;
+        let deleted_changesets = collected.deleted_changesets;
+        let changed_paths = collected.code_changes;
 
         let has_code_changes = !changed_paths.is_empty();
         let has_deleted_changesets = !deleted_changesets.is_empty();
@@ -140,7 +150,7 @@ where
         project: &changeset_project::CargoProject,
         changeset_dir: &Path,
         input: &VerifyInput,
-    ) -> Result<(bool, Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>)> {
+    ) -> Result<CollectedChanges> {
         let working_tree_dirty = if input.ignore_dirty() {
             false
         } else {
@@ -163,12 +173,17 @@ where
 
         let deleted_changesets = extract_deleted_changesets(&changeset_changes, changeset_dir);
         let changeset_files = extract_active_changesets(&changeset_changes);
-        let changed_paths = code_changes
+        let code_changes = code_changes
             .into_iter()
             .map(|change| change.path().clone())
             .collect();
 
-        Ok((is_dirty, changeset_files, deleted_changesets, changed_paths))
+        Ok(CollectedChanges {
+            is_dirty,
+            changeset_files,
+            deleted_changesets,
+            code_changes,
+        })
     }
 
     fn resolve_affected_packages(

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -21,11 +21,24 @@ pub enum TagFormat {
     CratePrefixed,
 }
 
-#[derive(Debug, Clone)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct GitConfig {
+#[derive(Debug, Clone, Copy)]
+struct GitOperationFlags {
     commit: bool,
     tags: bool,
+}
+
+impl Default for GitOperationFlags {
+    fn default() -> Self {
+        Self {
+            commit: true,
+            tags: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GitConfig {
+    operations: GitOperationFlags,
     keep_changesets: bool,
     tag_format: TagFormat,
     commit_title_template: String,
@@ -35,12 +48,12 @@ pub struct GitConfig {
 impl GitConfig {
     #[must_use]
     pub fn commit(&self) -> bool {
-        self.commit
+        self.operations.commit
     }
 
     #[must_use]
     pub fn tags(&self) -> bool {
-        self.tags
+        self.operations.tags
     }
 
     #[must_use]
@@ -74,8 +87,7 @@ impl GitConfig {
 impl Default for GitConfig {
     fn default() -> Self {
         Self {
-            commit: true,
-            tags: true,
+            operations: GitOperationFlags::default(),
             keep_changesets: false,
             tag_format: TagFormat::default(),
             commit_title_template: String::from("{new-version}"),
@@ -200,6 +212,7 @@ impl PackageChangesetConfig {
     }
 }
 
+#[derive(Copy, Clone)]
 enum CargoRootConfigType {
     Workspace,
     Package,
@@ -292,8 +305,10 @@ fn build_git_config(metadata: Option<&ChangesetMetadata>) -> GitConfig {
     match metadata {
         None => defaults,
         Some(cs) => GitConfig {
-            commit: cs.commit.unwrap_or(defaults.commit),
-            tags: cs.tags.unwrap_or(defaults.tags),
+            operations: GitOperationFlags {
+                commit: cs.commit.unwrap_or(defaults.operations.commit),
+                tags: cs.tags.unwrap_or(defaults.operations.tags),
+            },
             keep_changesets: cs.keep_changesets.unwrap_or(defaults.keep_changesets),
             tag_format: cs.tag_format.map_or(defaults.tag_format, |tf| match tf {
                 TagFormatValue::VersionOnly => TagFormat::VersionOnly,

--- a/crates/changeset-project/src/dependency_graph.rs
+++ b/crates/changeset-project/src/dependency_graph.rs
@@ -63,7 +63,7 @@ impl WorkspaceDependencyGraph {
 
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
-    pub fn from_edges(member_names: HashSet<String>, edges: &[(String, String)]) -> Self {
+    pub fn from_edges(member_names: &HashSet<String>, edges: &[(String, String)]) -> Self {
         let mut depended_on_by: HashMap<String, HashSet<String>> = member_names
             .iter()
             .map(|name| (name.clone(), HashSet::new()))
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn empty_graph_has_no_dependents() {
-        let graph = WorkspaceDependencyGraph::from_edges(member_set(&["a", "b"]), &[]);
+        let graph = WorkspaceDependencyGraph::from_edges(&member_set(&["a", "b"]), &[]);
 
         assert!(graph.transitive_dependents("a").is_empty());
         assert!(graph.transitive_dependents("b").is_empty());
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn single_package_no_edges() {
-        let graph = WorkspaceDependencyGraph::from_edges(member_set(&["solo"]), &[]);
+        let graph = WorkspaceDependencyGraph::from_edges(&member_set(&["solo"]), &[]);
 
         assert!(graph.transitive_dependents("solo").is_empty());
         assert!(graph.direct_dependencies("solo").is_empty());
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn direct_dependency_detection() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["app", "lib"]),
+            &member_set(&["app", "lib"]),
             &edges(&[("app", "lib")]),
         );
 
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn transitive_dependents_chain() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b", "c"]),
+            &member_set(&["a", "b", "c"]),
             &edges(&[("b", "a"), ("c", "b")]),
         );
 
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn transitive_dependents_diamond() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["core", "left", "right", "top"]),
+            &member_set(&["core", "left", "right", "top"]),
             &edges(&[
                 ("left", "core"),
                 ("right", "core"),
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn transitive_dependents_of_set_excludes_input() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b", "c", "d"]),
+            &member_set(&["a", "b", "c", "d"]),
             &edges(&[("b", "a"), ("c", "b"), ("d", "c")]),
         );
 
@@ -244,7 +244,7 @@ mod tests {
     #[test]
     fn transitive_dependents_of_set_deduplicates_shared_dependent() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b", "shared"]),
+            &member_set(&["a", "b", "shared"]),
             &edges(&[("shared", "a"), ("shared", "b")]),
         );
 
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn cycle_handling_terminates() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b"]),
+            &member_set(&["a", "b"]),
             &edges(&[("a", "b"), ("b", "a")]),
         );
 
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn cycle_three_nodes() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b", "c"]),
+            &member_set(&["a", "b", "c"]),
             &edges(&[("a", "b"), ("b", "c"), ("c", "a")]),
         );
 
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn unknown_package_returns_empty() {
-        let graph = WorkspaceDependencyGraph::from_edges(member_set(&["a"]), &[]);
+        let graph = WorkspaceDependencyGraph::from_edges(&member_set(&["a"]), &[]);
 
         assert!(graph.transitive_dependents("nonexistent").is_empty());
         assert!(graph.direct_dependencies("nonexistent").is_empty());
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn from_edges_ignores_non_member_edges() {
         let graph = WorkspaceDependencyGraph::from_edges(
-            member_set(&["a", "b"]),
+            &member_set(&["a", "b"]),
             &edges(&[("a", "external"), ("external", "b")]),
         );
 


### PR DESCRIPTION
Removes stale Bevy-specific lint exceptions and resolves all pedantic warnings by refactoring flat bool fields into focused structs/enums, taking references instead of owned values where appropriate, and replacing the derive_builder dependency with a hand-written builder.