### PR TITLE
Support changeset-driven versioning for non-Rust packages in a Cargo workspace

### DIFF
--- a/.changeset/changesets/astoundingly-intimate-weevil.md
+++ b/.changeset/changesets/astoundingly-intimate-weevil.md
@@ -1,0 +1,4 @@
+---
+changeset-project: minor
+---
+Support declaring non-Rust packages via additional-packages in `Cargo.toml` workspace metadata; they are now available through `RootChangesetConfig`

--- a/.changeset/changesets/becomingly-tenacious-phoebe.md
+++ b/.changeset/changesets/becomingly-tenacious-phoebe.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: minor
+---
+Additional non-Rust packages are now discoverable and selectable via cargo changeset add, and tracked by cargo changeset verify

--- a/.changeset/changesets/blatantly-cheerful-shoebill.md
+++ b/.changeset/changesets/blatantly-cheerful-shoebill.md
@@ -1,0 +1,6 @@
+---
+changeset-changelog: none
+changeset-parse: none
+changeset-version: none
+---
+Acknowledge dependency on changeset-core which now supports non-Rust package manifests

--- a/.changeset/changesets/brazenly-champion-monster.md
+++ b/.changeset/changesets/brazenly-champion-monster.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Include additional non-Rust packages in status output

--- a/.changeset/changesets/centrally-omnipotent-snapper.md
+++ b/.changeset/changesets/centrally-omnipotent-snapper.md
@@ -1,0 +1,4 @@
+---
+changeset-manifest: minor
+---
+Add functions to read and write version-tracking dependencies in TOML, YAML, and JSON external manifests.

--- a/.changeset/changesets/charily-sociable-swordfish.md
+++ b/.changeset/changesets/charily-sociable-swordfish.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: none
+---
+Use `CARGO_MANIFEST_FILENAME` constant instead of hardcoded `Cargo.toml` strings

--- a/.changeset/changesets/fussily-undamaged-murrelet.md
+++ b/.changeset/changesets/fussily-undamaged-murrelet.md
@@ -1,0 +1,4 @@
+---
+changeset-project: minor
+---
+Add `add_members()` and `extend_with_edges()` to `WorkspaceDependencyGraph`, and `collect_version_tracking_info()` / `tracking_edges()` for integrating non-Rust packages into the dependency graph.

--- a/.changeset/changesets/holly-equitable-setter.md
+++ b/.changeset/changesets/holly-equitable-setter.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Add non-Rust package support to the release saga, enabling version bumps of additional packages (YAML, JSON, TOML manifests) alongside Cargo crates

--- a/.changeset/changesets/indiscreetly-galore-emperor.md
+++ b/.changeset/changesets/indiscreetly-galore-emperor.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Add operations, traits, and providers for managing additional (non-Rust) package declarations

--- a/.changeset/changesets/indiscreetly-galore-emperor.md
+++ b/.changeset/changesets/indiscreetly-galore-emperor.md
@@ -1,4 +1,4 @@
 ---
 changeset-operations: minor
 ---
-Add operations, traits, and providers for managing additional (non-Rust) package declarations
+Add operations, traits, and providers for managing additional (non-Rust) package declarations; additional-packages operations require a Cargo workspace and return a clear error for single-package projects

--- a/.changeset/changesets/jokingly-necessary-gull.md
+++ b/.changeset/changesets/jokingly-necessary-gull.md
@@ -1,0 +1,4 @@
+---
+changeset-manifest: minor
+---
+Add support for writing and verifying versions in external non-Rust manifests in TOML, YAML, and JSON formats

--- a/.changeset/changesets/mistily-giving-waterbuck.md
+++ b/.changeset/changesets/mistily-giving-waterbuck.md
@@ -1,0 +1,4 @@
+---
+changeset-core: minor
+---
+Add `ManifestFormat`, `AdditionalPackageManifest`, and `AdditionalPackageDeclaration` types for declaring non-Rust packages in workspace configuration

--- a/.changeset/changesets/perkily-full-rockhopper.md
+++ b/.changeset/changesets/perkily-full-rockhopper.md
@@ -1,0 +1,4 @@
+---
+changeset-project: minor
+---
+Add `discover_additional_packages`, `compile_influence_patterns`, and `map_files_to_all_packages` for non-Rust package support

--- a/.changeset/changesets/radiantly-honest-markhor.md
+++ b/.changeset/changesets/radiantly-honest-markhor.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: minor
+---
+Add additional-packages dependencies add/remove/list subcommands, and automatically patch-bump non-Rust packages whose version-tracking dependencies are released.

--- a/.changeset/changesets/rapaciously-exultant-sylph.md
+++ b/.changeset/changesets/rapaciously-exultant-sylph.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: minor
+---
+Add 'additional-packages' subcommand for managing non-Rust package declarations in Cargo.toml metadata

--- a/.changeset/changesets/rapaciously-exultant-sylph.md
+++ b/.changeset/changesets/rapaciously-exultant-sylph.md
@@ -1,4 +1,4 @@
 ---
 cargo-changeset: minor
 ---
-Add 'additional-packages' subcommand for managing non-Rust package declarations in Cargo.toml metadata
+Add 'additional-packages' subcommand for managing non-Rust package declarations in Cargo.toml metadata; the subcommand requires a Cargo workspace and exits with a clear error in single-package projects

--- a/.changeset/changesets/remotely-devout-guan.md
+++ b/.changeset/changesets/remotely-devout-guan.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Add ExternalManifestVersionWriter trait and discover_additional_packages to ProjectProvider for non-Rust package support

--- a/.changeset/changesets/rosily-subtle-butterfish.md
+++ b/.changeset/changesets/rosily-subtle-butterfish.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Add `WriteVersionTrackingStep` saga step that updates tracked external manifest fields during release, and config validation for circular, unknown, and duplicate version-tracking dependency declarations.

--- a/.changeset/changesets/simply-original-flea.md
+++ b/.changeset/changesets/simply-original-flea.md
@@ -1,0 +1,4 @@
+---
+changeset-core: minor
+---
+Add `VersionTrackingManifest` and `VersionTrackingDependency` types for declaring external manifest fields to update when a dependency's version changes.

--- a/.changeset/changesets/squarely-sufficient-butcherbird.md
+++ b/.changeset/changesets/squarely-sufficient-butcherbird.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: none
+---
+Internal dependency update: changeset-project and changeset-manifest gain external manifest support

--- a/.changeset/changesets/squarely-sufficient-butcherbird.md
+++ b/.changeset/changesets/squarely-sufficient-butcherbird.md
@@ -1,4 +1,0 @@
----
-changeset-operations: none
----
-Internal dependency update: changeset-project and changeset-manifest gain external manifest support

--- a/.changeset/changesets/stingily-fun-dipper.md
+++ b/.changeset/changesets/stingily-fun-dipper.md
@@ -1,0 +1,4 @@
+---
+changeset-project: minor
+---
+Add support for reading versions from external non-Rust manifests in TOML, YAML, and JSON formats

--- a/.changeset/changesets/strictly-awake-tahr.md
+++ b/.changeset/changesets/strictly-awake-tahr.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: minor
+---
+Additional packages (Helm charts, Docker configs, etc.) now participate in verify and add operations via influence globs

--- a/.changeset/changesets/teasingly-peaceful-swiftlet.md
+++ b/.changeset/changesets/teasingly-peaceful-swiftlet.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: minor
+---
+Release command now versions additional non-Rust packages (Helm charts, etc.) alongside Cargo crates

--- a/.changeset/changesets/weirdly-unruffled-lobster.md
+++ b/.changeset/changesets/weirdly-unruffled-lobster.md
@@ -1,0 +1,4 @@
+---
+changeset-manifest: minor
+---
+Add functions for reading and writing non-Rust package declarations in Cargo.toml metadata

--- a/.changeset/changesets/witlessly-clear-sidewinder.md
+++ b/.changeset/changesets/witlessly-clear-sidewinder.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: none
+---
+Internal dependency update: changeset-project and changeset-manifest gain external manifest support

--- a/.changeset/changesets/witlessly-clear-sidewinder.md
+++ b/.changeset/changesets/witlessly-clear-sidewinder.md
@@ -1,4 +1,0 @@
----
-cargo-changeset: none
----
-Internal dependency update: changeset-project and changeset-manifest gain external manifest support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,11 +154,13 @@ dependencies = [
  "dialoguer",
  "expectrl",
  "indexmap 2.13.0",
+ "indoc",
  "predicates",
  "semver",
  "serde_json",
  "tempfile",
  "thiserror",
+ "vt100",
 ]
 
 [[package]]
@@ -931,6 +939,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1835,6 +1852,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "petname",
  "semver",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "git2",
+ "globset",
  "gset",
  "indexmap 2.13.0",
  "petname",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,10 +215,13 @@ dependencies = [
 name = "changeset-manifest"
 version = "0.0.3"
 dependencies = [
+ "changeset-core",
+ "jsonc-parser",
  "semver",
  "tempfile",
  "thiserror",
  "toml_edit",
+ "yaml-edit",
 ]
 
 [[package]]
@@ -274,6 +277,8 @@ dependencies = [
  "gset",
  "semver",
  "serde",
+ "serde_json",
+ "serde_yml",
  "tempfile",
  "thiserror",
  "toml",
@@ -387,6 +392,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "darling"
@@ -726,6 +737,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -952,6 +969,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
 
 [[package]]
 name = "lazy_format"
@@ -1335,6 +1358,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash",
+ "text-size",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1618,12 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -2145,6 +2192,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yaml-edit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c249044401e064d1f4d7ec0937c343b283e9da13de92298435ff6bf0ad53552"
+dependencies = [
+ "base64",
+ "rowan",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "indexmap 2.13.0",
  "predicates",
  "semver",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 license = "MIT"
 repository = "https://github.com/lukidoescode/cargo-changeset"
 homepage = "https://github.com/lukidoescode/cargo-changeset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ git2 = { version = "0.20", default-features = false }
 dialoguer = "0.12.0"
 petname = "2.0.2"
 toml_edit = "0.25.0"
+yaml-edit = "0.2.1"
+jsonc-parser = { version = "0.32.3", features = ["cst"] }
 tracing = "0.1.44"
 gset = "1.1.0"
 derive_builder = "0.20.2"

--- a/crates/cargo-changeset/Cargo.toml
+++ b/crates/cargo-changeset/Cargo.toml
@@ -37,3 +37,4 @@ predicates = "3.1"
 expectrl = "0.8"
 indexmap = { workspace = true }
 semver = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/cargo-changeset/Cargo.toml
+++ b/crates/cargo-changeset/Cargo.toml
@@ -38,3 +38,5 @@ expectrl = "0.8"
 indexmap = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
+vt100 = "0.16.2"
+indoc = "2.0.7"

--- a/crates/cargo-changeset/src/commands/add.rs
+++ b/crates/cargo-changeset/src/commands/add.rs
@@ -21,10 +21,8 @@ pub(super) fn run(args: AddArgs, start_path: &Path) -> Result<()> {
 
     let is_single_package =
         *project.kind() == ProjectKind::SinglePackage && args.packages.is_empty();
-    if is_single_package {
-        if let Some(pkg) = project.packages().first() {
-            println!("Using package: {} ({})", pkg.name(), pkg.version());
-        }
+    if is_single_package && let Some(pkg) = project.packages().first() {
+        println!("Using package: {} ({})", pkg.name(), pkg.version());
     }
 
     let changeset_writer = FileSystemChangesetIO::new(project.root());

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -19,7 +19,7 @@ use changeset_operations::operations::{
 };
 use changeset_operations::providers::{FileSystemManifestWriter, FileSystemProjectProvider};
 use changeset_operations::traits::{
-    AdditionalPackageField, AdditionalPackageInteractionProvider, MenuSelection,
+    AdditionalPackageField, AdditionalPackageInteractionProvider, MenuSelection, ProjectProvider,
 };
 
 use crate::environment::is_interactive;
@@ -48,7 +48,7 @@ pub(crate) enum AdditionalPackageCommand {
 #[derive(Args)]
 pub(crate) struct DependenciesArgs {
     #[command(subcommand)]
-    pub command: DependencySubcommand,
+    pub(crate) command: DependencySubcommand,
 }
 
 #[derive(Subcommand)]
@@ -163,16 +163,35 @@ pub(crate) struct EditAdditionalPackageArgs {
     pub version_field_path: Option<String>,
 }
 
+struct PackageDependenciesSelectionMenuItem {
+    name: String,
+    label: String,
+}
+
+#[derive(Default)]
 struct TerminalAdditionalPackageInteractionProvider {
+    default_manifest_path: Mutex<Option<PathBuf>>,
     last_manifest_path: Mutex<Option<PathBuf>>,
 }
 
 impl TerminalAdditionalPackageInteractionProvider {
-    fn prompt_dependency_name(&self) -> changeset_operations::Result<String> {
-        Input::new()
-            .with_prompt("Dependency name")
-            .interact_text()
-            .map_err(dialoguer_to_operation_error)
+    fn select_package(
+        &self,
+        prompt: &str,
+        items: &[PackageDependenciesSelectionMenuItem],
+    ) -> changeset_operations::Result<MenuSelection<String>> {
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+        let selection = Select::new()
+            .with_prompt(prompt)
+            .items(&labels)
+            .interact_opt()
+            .map_err(super::dialoguer_to_operation_error)?;
+
+        Ok(match selection {
+            Some(index) => MenuSelection::Selected(items[index].name.clone()),
+            None => MenuSelection::Cancelled,
+        })
     }
 }
 
@@ -181,14 +200,14 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
         Input::new()
             .with_prompt("Package name")
             .interact_text()
-            .map_err(dialoguer_to_operation_error)
+            .map_err(super::dialoguer_to_operation_error)
     }
 
     fn prompt_package_path(&self) -> changeset_operations::Result<PathBuf> {
         let s: String = Input::new()
             .with_prompt("Package directory path (relative to workspace root)")
             .interact_text()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
         Ok(PathBuf::from(s))
     }
 
@@ -206,7 +225,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .default(default)
             .allow_empty(true)
             .interact_text()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
         if first.is_empty() {
             return Ok(patterns);
         }
@@ -216,7 +235,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
                 .with_prompt("Additional pattern")
                 .allow_empty(true)
                 .interact_text()
-                .map_err(dialoguer_to_operation_error)?;
+                .map_err(super::dialoguer_to_operation_error)?;
             if s.is_empty() {
                 break;
             }
@@ -226,10 +245,21 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
     }
 
     fn prompt_manifest_file_path(&self) -> changeset_operations::Result<PathBuf> {
-        let s: String = Input::new()
-            .with_prompt("Path to version manifest file")
-            .interact_text()
-            .map_err(dialoguer_to_operation_error)?;
+        let default_path = if let Ok(guard) = self.default_manifest_path.lock() {
+            guard.as_ref().map(|p| p.display().to_string())
+        } else {
+            None
+        };
+
+        let input = Input::<String>::new().with_prompt("Path to version manifest file");
+        let s: String = if let Some(default) = default_path {
+            input.default(default)
+        } else {
+            input
+        }
+        .interact_text()
+        .map_err(super::dialoguer_to_operation_error)?;
+
         let path = PathBuf::from(s);
         if let Ok(mut guard) = self.last_manifest_path.lock() {
             *guard = Some(path.clone());
@@ -241,21 +271,22 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
         let variants = ManifestFormat::value_variants();
         let items: Vec<String> = variants.iter().map(ToString::to_string).collect();
 
-        let default_index = self
-            .last_manifest_path
-            .lock()
-            .ok()
-            .as_ref()
-            .and_then(|guard| guard.as_deref().and_then(ManifestFormat::from_path))
-            .and_then(|detected| variants.iter().position(|v| *v == detected))
-            .unwrap_or(0);
+        let default_index = if let Ok(guard) = self.last_manifest_path.lock() {
+            guard
+                .as_deref()
+                .and_then(ManifestFormat::from_path)
+                .and_then(|detected| variants.iter().position(|v| *v == detected))
+                .unwrap_or(0)
+        } else {
+            0
+        };
 
         let selection = Select::new()
             .with_prompt("Manifest format")
             .items(&items)
             .default(default_index)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         match selection {
             Some(index) => Ok(variants[index]),
@@ -267,7 +298,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
         Input::new()
             .with_prompt("Path to version field in manifest (e.g. 'version' or 'info.version')")
             .interact_text()
-            .map_err(dialoguer_to_operation_error)
+            .map_err(super::dialoguer_to_operation_error)
     }
 
     fn select_package_to_remove(
@@ -283,7 +314,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .with_prompt("Select package to remove")
             .items(&items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -304,7 +335,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .with_prompt("Select package to edit")
             .items(&items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -328,7 +359,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .with_prompt("Which field would you like to edit?")
             .items(options)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(0) => MenuSelection::Selected(AdditionalPackageField::Path),
@@ -345,7 +376,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .with_prompt(format!("Remove additional package '{name}'?"))
             .default(false)
             .interact()
-            .map_err(dialoguer_to_operation_error)
+            .map_err(super::dialoguer_to_operation_error)
     }
 }
 
@@ -392,18 +423,13 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             manifest_format: format,
             manifest_version_field_path: version_field_path,
         };
-        let op = AdditionalPackageDirectAddOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-        );
+        let op = AdditionalPackageDirectAddOperation::new(project_provider(), manifest_writer());
         op.execute(start_path, input)?
     } else if is_interactive() {
         let op = AdditionalPackageInteractiveAddOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider {
-                last_manifest_path: Mutex::new(None),
-            },
+            project_provider(),
+            manifest_writer(),
+            TerminalAdditionalPackageInteractionProvider::default(),
         );
         op.execute(start_path)?
     } else if has_all_required {
@@ -418,18 +444,13 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
 
 fn run_remove(args: RemoveAdditionalPackageArgs, start_path: &Path) -> Result<()> {
     let events = if let Some(name) = args.name {
-        let op = AdditionalPackageDirectRemoveOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-        );
+        let op = AdditionalPackageDirectRemoveOperation::new(project_provider(), manifest_writer());
         op.execute(start_path, &name)?
     } else if is_interactive() {
         let op = AdditionalPackageInteractiveRemoveOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider {
-                last_manifest_path: Mutex::new(None),
-            },
+            project_provider(),
+            manifest_writer(),
+            TerminalAdditionalPackageInteractionProvider::default(),
         );
         op.execute(start_path)?
     } else {
@@ -460,18 +481,13 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             manifest_version_field_path: args.version_field_path,
         };
         let input = AdditionalPackageEditInput { name, updates };
-        let op = AdditionalPackageDirectEditOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-        );
+        let op = AdditionalPackageDirectEditOperation::new(project_provider(), manifest_writer());
         op.execute(start_path, input)?
     } else if is_interactive() {
         let op = AdditionalPackageInteractiveEditOperation::new(
-            FileSystemProjectProvider::new(),
-            FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider {
-                last_manifest_path: Mutex::new(None),
-            },
+            project_provider(),
+            manifest_writer(),
+            TerminalAdditionalPackageInteractionProvider::default(),
         );
         op.execute(start_path)?
     } else {
@@ -483,7 +499,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
 }
 
 fn run_list(start_path: &Path) -> Result<()> {
-    let op = AdditionalPackageListOperation::new(FileSystemProjectProvider::new());
+    let op = AdditionalPackageListOperation::new(project_provider());
     let events = op.execute(start_path)?;
     print_additional_package_events(&events);
     Ok(())
@@ -531,11 +547,43 @@ fn run_dependency_add(args: AddDependencyArgs, start_path: &Path) -> Result<()> 
             start_path,
         )?
     } else if is_interactive() {
-        let interaction = TerminalAdditionalPackageInteractionProvider {
-            last_manifest_path: Mutex::new(None),
+        let provider = project_provider();
+        let project = provider.discover_project(start_path)?;
+        let (root_config, _) = provider.load_configs(&project)?;
+        let items = build_package_menu_items(project.packages(), root_config.additional_packages());
+
+        let interaction = TerminalAdditionalPackageInteractionProvider::default();
+
+        let package = match interaction.select_package("Select the owner package", &items)? {
+            MenuSelection::Selected(name) => name,
+            MenuSelection::Cancelled => return Ok(()),
         };
-        let package = interaction.prompt_package_name()?;
-        let dependency = interaction.prompt_dependency_name()?;
+
+        if let Some(additional_pkg) = root_config
+            .additional_packages()
+            .iter()
+            .find(|p| p.name() == &package)
+            && let Ok(mut guard) = interaction.default_manifest_path.lock()
+        {
+            *guard = Some(additional_pkg.manifest().file_path().to_path_buf());
+        }
+
+        let dep_items: Vec<PackageDependenciesSelectionMenuItem> = items
+            .into_iter()
+            .filter(|item| item.name != package)
+            .collect();
+
+        if dep_items.is_empty() {
+            println!("No other packages available to select as a dependency.");
+            return Ok(());
+        }
+
+        let dependency =
+            match interaction.select_package("Select the dependency to track", &dep_items)? {
+                MenuSelection::Selected(name) => name,
+                MenuSelection::Cancelled => return Ok(()),
+            };
+
         let manifest_file = interaction.prompt_manifest_file_path()?;
         let format = interaction.prompt_manifest_format()?;
         let version_field_path = interaction.prompt_manifest_version_field_path()?;
@@ -562,11 +610,38 @@ fn run_dependency_remove(args: RemoveDependencyArgs, start_path: &Path) -> Resul
     let events = if let (Some(package), Some(dependency)) = (args.package, args.dependency) {
         execute_dependency_remove(package, dependency, start_path)?
     } else if is_interactive() {
-        let interaction = TerminalAdditionalPackageInteractionProvider {
-            last_manifest_path: Mutex::new(None),
+        let provider = project_provider();
+        let project = provider.discover_project(start_path)?;
+        let (root_config, pkg_configs) = provider.load_configs(&project)?;
+        let items = build_package_menu_items(project.packages(), root_config.additional_packages());
+
+        let interaction = TerminalAdditionalPackageInteractionProvider::default();
+
+        let package = match interaction.select_package("Select package", &items)? {
+            MenuSelection::Selected(name) => name,
+            MenuSelection::Cancelled => return Ok(()),
         };
-        let package = interaction.prompt_package_name()?;
-        let dependency = interaction.prompt_dependency_name()?;
+
+        let crate_deps = pkg_configs
+            .get(&package)
+            .map(|c| c.additional_package_dependencies())
+            .unwrap_or_default();
+        let dep_items = build_registered_dependency_items(
+            &package,
+            root_config.additional_packages(),
+            crate_deps,
+        );
+
+        if dep_items.is_empty() {
+            println!("No version-tracking dependencies configured for '{package}'.");
+            return Ok(());
+        }
+
+        let dependency =
+            match interaction.select_package("Select dependency to remove", &dep_items)? {
+                MenuSelection::Selected(name) => name,
+                MenuSelection::Cancelled => return Ok(()),
+            };
 
         execute_dependency_remove(package, dependency, start_path)?
     } else {
@@ -579,15 +654,22 @@ fn run_dependency_remove(args: RemoveDependencyArgs, start_path: &Path) -> Resul
 
 fn run_dependency_list(args: ListDependencyArgs, start_path: &Path) -> Result<()> {
     let events = if let Some(package) = args.package {
-        let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
+        let op = VersionTrackingDependencyListOperation::new(project_provider());
         op.execute(start_path, &package)?
     } else if is_interactive() {
-        let interaction = TerminalAdditionalPackageInteractionProvider {
-            last_manifest_path: Mutex::new(None),
-        };
-        let package = interaction.prompt_package_name()?;
+        let provider = project_provider();
+        let project = provider.discover_project(start_path)?;
+        let (root_config, _) = provider.load_configs(&project)?;
+        let items = build_package_menu_items(project.packages(), root_config.additional_packages());
 
-        let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
+        let interaction = TerminalAdditionalPackageInteractionProvider::default();
+
+        let package = match interaction.select_package("Select package", &items)? {
+            MenuSelection::Selected(name) => name,
+            MenuSelection::Cancelled => return Ok(()),
+        };
+
+        let op = VersionTrackingDependencyListOperation::new(provider);
         op.execute(start_path, &package)?
     } else {
         return Err(CliError::IncompleteArgs);
@@ -612,10 +694,7 @@ fn execute_dependency_add(
         manifest_format,
         version_field_path,
     );
-    let op = VersionTrackingDependencyAddOperation::new(
-        FileSystemProjectProvider::new(),
-        FileSystemManifestWriter::new(),
-    );
+    let op = VersionTrackingDependencyAddOperation::new(project_provider(), manifest_writer());
     Ok(op.execute(start_path, input)?)
 }
 
@@ -625,10 +704,7 @@ fn execute_dependency_remove(
     start_path: &Path,
 ) -> Result<Vec<VersionTrackingDependencyEvent>> {
     let input = VersionTrackingDependencyRemoveInput::new(package, dependency);
-    let op = VersionTrackingDependencyRemoveOperation::new(
-        FileSystemProjectProvider::new(),
-        FileSystemManifestWriter::new(),
-    );
+    let op = VersionTrackingDependencyRemoveOperation::new(project_provider(), manifest_writer());
     Ok(op.execute(start_path, input)?)
 }
 
@@ -710,17 +786,217 @@ fn print_additional_package_events(events: &[AdditionalPackageEvent]) {
     }
 }
 
-fn dialoguer_to_operation_error(e: dialoguer::Error) -> OperationError {
-    match e {
-        dialoguer::Error::IO(io_err) => OperationError::Io(io_err),
+fn build_package_menu_items(
+    crate_packages: &[changeset_core::PackageInfo],
+    additional_packages: &[AdditionalPackageDeclaration],
+) -> Vec<PackageDependenciesSelectionMenuItem> {
+    let mut items: Vec<PackageDependenciesSelectionMenuItem> = crate_packages
+        .iter()
+        .map(|p| PackageDependenciesSelectionMenuItem {
+            name: p.name().clone(),
+            label: format!("{} (crate)", p.name()),
+        })
+        .collect();
+
+    for pkg in additional_packages {
+        items.push(PackageDependenciesSelectionMenuItem {
+            name: pkg.name().clone(),
+            label: format!("{} (additional: {})", pkg.name(), pkg.path().display()),
+        });
     }
+
+    items
+}
+
+fn build_registered_dependency_items(
+    package_name: &str,
+    additional_packages: &[AdditionalPackageDeclaration],
+    crate_deps: &[changeset_core::VersionTrackingDependency],
+) -> Vec<PackageDependenciesSelectionMenuItem> {
+    if let Some(additional) = additional_packages
+        .iter()
+        .find(|p| p.name() == package_name)
+    {
+        return additional
+            .dependencies()
+            .iter()
+            .map(|dep| PackageDependenciesSelectionMenuItem {
+                name: dep.dependency_name().clone(),
+                label: dep.dependency_name().clone(),
+            })
+            .collect();
+    }
+
+    crate_deps
+        .iter()
+        .map(|dep| PackageDependenciesSelectionMenuItem {
+            name: dep.dependency_name().clone(),
+            label: dep.dependency_name().clone(),
+        })
+        .collect()
+}
+
+fn project_provider() -> FileSystemProjectProvider {
+    FileSystemProjectProvider::new()
+}
+
+fn manifest_writer() -> FileSystemManifestWriter {
+    FileSystemManifestWriter::new()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    use changeset_core::ManifestFormat;
+    use changeset_core::{
+        AdditionalPackageDeclaration, AdditionalPackageManifest, ManifestFormat, PackageInfo,
+        VersionTrackingDependency, VersionTrackingManifest,
+    };
+    use semver::Version;
+
+    use super::{build_package_menu_items, build_registered_dependency_items};
+
+    fn sample_crate_packages() -> Vec<PackageInfo> {
+        vec![
+            PackageInfo::new(
+                "crate-a".to_string(),
+                Version::new(1, 0, 0),
+                PathBuf::from("crates/crate-a"),
+            ),
+            PackageInfo::new(
+                "crate-b".to_string(),
+                Version::new(0, 2, 0),
+                PathBuf::from("crates/crate-b"),
+            ),
+        ]
+    }
+
+    fn sample_additional_package(
+        name: &str,
+        path: &str,
+        deps: Vec<VersionTrackingDependency>,
+    ) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(path),
+            vec![format!("{path}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("{path}/Chart.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            deps,
+        )
+    }
+
+    fn sample_version_tracking_dependency(name: &str) -> VersionTrackingDependency {
+        VersionTrackingDependency::new(
+            name.to_string(),
+            VersionTrackingManifest::new(
+                PathBuf::from("manifest.yaml"),
+                ManifestFormat::Yaml,
+                "dependencies.version".to_string(),
+            ),
+        )
+    }
+
+    #[test]
+    fn build_menu_items_includes_crates() {
+        let crates = sample_crate_packages();
+
+        let items = build_package_menu_items(&crates, &[]);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].name, "crate-a");
+        assert!(items[0].label.contains("(crate)"));
+        assert_eq!(items[1].name, "crate-b");
+        assert!(items[1].label.contains("(crate)"));
+    }
+
+    #[test]
+    fn build_menu_items_includes_additional_packages() {
+        let crates = sample_crate_packages();
+        let additional = vec![sample_additional_package(
+            "my-chart",
+            "charts/my-chart",
+            vec![],
+        )];
+
+        let items = build_package_menu_items(&crates, &additional);
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[2].name, "my-chart");
+        assert!(items[2].label.contains("(additional:"));
+        assert!(items[2].label.contains("charts/my-chart"));
+    }
+
+    #[test]
+    fn build_menu_items_empty_when_no_packages() {
+        let items = build_package_menu_items(&[], &[]);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn registered_deps_from_additional_package() {
+        let dep = sample_version_tracking_dependency("crate-a");
+        let additional = vec![sample_additional_package(
+            "my-chart",
+            "charts/my-chart",
+            vec![dep],
+        )];
+
+        let items = build_registered_dependency_items("my-chart", &additional, &[]);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "crate-a");
+    }
+
+    #[test]
+    fn registered_deps_from_crate_deps() {
+        let dep = sample_version_tracking_dependency("my-chart");
+
+        let items = build_registered_dependency_items("crate-a", &[], &[dep]);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "my-chart");
+    }
+
+    #[test]
+    fn registered_deps_returns_empty_when_no_sources() {
+        let items = build_registered_dependency_items("nonexistent", &[], &[]);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn registered_deps_returns_empty_when_additional_package_has_no_deps() {
+        let additional = vec![sample_additional_package(
+            "my-chart",
+            "charts/my-chart",
+            vec![],
+        )];
+
+        let items = build_registered_dependency_items("my-chart", &additional, &[]);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn registered_deps_prefers_additional_package_over_crate_deps() {
+        let dep_from_additional = sample_version_tracking_dependency("from-additional");
+        let dep_from_crate = sample_version_tracking_dependency("from-crate");
+        let additional = vec![sample_additional_package(
+            "dual-pkg",
+            "charts/dual-pkg",
+            vec![dep_from_additional],
+        )];
+
+        let items = build_registered_dependency_items("dual-pkg", &additional, &[dep_from_crate]);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "from-additional");
+    }
 
     #[test]
     fn manifest_format_from_path_detects_toml() {

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -1,0 +1,409 @@
+use std::path::{Path, PathBuf};
+
+use clap::{Args, Subcommand, ValueEnum};
+use dialoguer::{Confirm, Input, Select};
+
+use changeset_core::{AdditionalPackageDeclaration, ManifestFormat};
+use changeset_manifest::AdditionalPackageUpdate;
+use changeset_operations::OperationError;
+use changeset_operations::operations::{
+    AdditionalPackageAddInput, AdditionalPackageDirectAddOperation,
+    AdditionalPackageDirectEditOperation, AdditionalPackageDirectRemoveOperation,
+    AdditionalPackageEditInput, AdditionalPackageEvent, AdditionalPackageInteractiveAddOperation,
+    AdditionalPackageInteractiveEditOperation, AdditionalPackageInteractiveRemoveOperation,
+    AdditionalPackageListOperation,
+};
+use changeset_operations::providers::{FileSystemManifestWriter, FileSystemProjectProvider};
+use changeset_operations::traits::{
+    AdditionalPackageField, AdditionalPackageInteractionProvider, MenuSelection,
+};
+
+use crate::environment::is_interactive;
+use crate::error::{CliError, Result};
+
+#[derive(Args)]
+pub(crate) struct AdditionalPackagesArgs {
+    #[command(subcommand)]
+    pub(crate) command: AdditionalPackageCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum AdditionalPackageCommand {
+    /// Add a non-Rust package declaration
+    Add(AddAdditionalPackageArgs),
+    /// Remove a non-Rust package declaration
+    Remove(RemoveAdditionalPackageArgs),
+    /// Edit a non-Rust package declaration
+    Edit(EditAdditionalPackageArgs),
+    /// List all non-Rust package declarations
+    List,
+}
+
+#[derive(Args)]
+pub(crate) struct AddAdditionalPackageArgs {
+    /// Package name
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Package directory path (relative to workspace root)
+    #[arg(long)]
+    pub path: Option<PathBuf>,
+
+    /// Glob patterns that influence this package (can be repeated)
+    #[arg(long = "influence", value_name = "GLOB")]
+    pub influence: Vec<String>,
+
+    /// Path to the version manifest file
+    #[arg(long = "manifest-file")]
+    pub manifest_file: Option<PathBuf>,
+
+    /// Format of the version manifest
+    #[arg(long = "manifest-format", value_enum)]
+    pub manifest_format: Option<ManifestFormat>,
+
+    /// JSONPath-style path to the version field in the manifest
+    #[arg(long = "version-path")]
+    pub version_path: Option<String>,
+}
+
+#[derive(Args)]
+pub(crate) struct RemoveAdditionalPackageArgs {
+    /// Package name to remove
+    #[arg(long)]
+    pub name: Option<String>,
+}
+
+#[derive(Args)]
+pub(crate) struct EditAdditionalPackageArgs {
+    /// Package name to edit
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// New package directory path
+    #[arg(long)]
+    pub path: Option<PathBuf>,
+
+    /// New influence glob patterns (replaces all existing patterns)
+    #[arg(long = "influence", value_name = "GLOB")]
+    pub influence: Vec<String>,
+
+    /// New manifest file path
+    #[arg(long = "manifest-file")]
+    pub manifest_file: Option<PathBuf>,
+
+    /// New manifest format
+    #[arg(long = "manifest-format", value_enum)]
+    pub manifest_format: Option<ManifestFormat>,
+
+    /// New version path
+    #[arg(long = "version-path")]
+    pub version_path: Option<String>,
+}
+
+struct TerminalAdditionalPackageInteractionProvider;
+
+impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteractionProvider {
+    fn prompt_package_name(&self) -> changeset_operations::Result<String> {
+        Input::new()
+            .with_prompt("Package name")
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)
+    }
+
+    fn prompt_package_path(&self) -> changeset_operations::Result<PathBuf> {
+        let s: String = Input::new()
+            .with_prompt("Package directory path (relative to workspace root)")
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)?;
+        Ok(PathBuf::from(s))
+    }
+
+    fn prompt_influence_patterns(&self) -> changeset_operations::Result<Vec<String>> {
+        let mut patterns = Vec::new();
+        println!(
+            "Enter glob patterns for files that influence this package (empty line to finish):"
+        );
+        loop {
+            let s: String = Input::new()
+                .with_prompt("Glob pattern")
+                .allow_empty(true)
+                .interact_text()
+                .map_err(dialoguer_to_operation_error)?;
+            if s.is_empty() {
+                break;
+            }
+            patterns.push(s);
+        }
+        Ok(patterns)
+    }
+
+    fn prompt_manifest_file_path(&self) -> changeset_operations::Result<PathBuf> {
+        let s: String = Input::new()
+            .with_prompt("Path to version manifest file")
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)?;
+        Ok(PathBuf::from(s))
+    }
+
+    fn prompt_manifest_format(&self) -> changeset_operations::Result<ManifestFormat> {
+        let variants = ManifestFormat::value_variants();
+        let items: Vec<String> = variants.iter().map(ToString::to_string).collect();
+        let selection = Select::new()
+            .with_prompt("Manifest format")
+            .items(&items)
+            .default(0)
+            .interact_opt()
+            .map_err(dialoguer_to_operation_error)?;
+
+        match selection {
+            Some(index) => Ok(variants[index]),
+            None => Err(OperationError::Cancelled),
+        }
+    }
+
+    fn prompt_manifest_version_path(&self) -> changeset_operations::Result<String> {
+        Input::new()
+            .with_prompt("Path to version field in manifest (e.g. 'version' or 'info.version')")
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)
+    }
+
+    fn select_package_to_remove(
+        &self,
+        packages: &[&AdditionalPackageDeclaration],
+    ) -> changeset_operations::Result<MenuSelection<usize>> {
+        let items: Vec<String> = packages
+            .iter()
+            .map(|p| format!("{} ({})", p.name(), p.path().display()))
+            .collect();
+
+        let selection = Select::new()
+            .with_prompt("Select package to remove")
+            .items(&items)
+            .interact_opt()
+            .map_err(dialoguer_to_operation_error)?;
+
+        Ok(match selection {
+            Some(index) => MenuSelection::Selected(index),
+            None => MenuSelection::Cancelled,
+        })
+    }
+
+    fn select_package_to_edit(
+        &self,
+        packages: &[&AdditionalPackageDeclaration],
+    ) -> changeset_operations::Result<MenuSelection<usize>> {
+        let items: Vec<String> = packages
+            .iter()
+            .map(|p| format!("{} ({})", p.name(), p.path().display()))
+            .collect();
+
+        let selection = Select::new()
+            .with_prompt("Select package to edit")
+            .items(&items)
+            .interact_opt()
+            .map_err(dialoguer_to_operation_error)?;
+
+        Ok(match selection {
+            Some(index) => MenuSelection::Selected(index),
+            None => MenuSelection::Cancelled,
+        })
+    }
+
+    fn select_field_to_edit(
+        &self,
+    ) -> changeset_operations::Result<MenuSelection<AdditionalPackageField>> {
+        let options = [
+            "path",
+            "influence patterns",
+            "manifest file path",
+            "manifest format",
+            "manifest version path",
+            "Done",
+        ];
+
+        let selection = Select::new()
+            .with_prompt("Which field would you like to edit?")
+            .items(options)
+            .interact_opt()
+            .map_err(dialoguer_to_operation_error)?;
+
+        Ok(match selection {
+            Some(0) => MenuSelection::Selected(AdditionalPackageField::Path),
+            Some(1) => MenuSelection::Selected(AdditionalPackageField::Influence),
+            Some(2) => MenuSelection::Selected(AdditionalPackageField::ManifestFilePath),
+            Some(3) => MenuSelection::Selected(AdditionalPackageField::ManifestFormat),
+            Some(4) => MenuSelection::Selected(AdditionalPackageField::ManifestVersionPath),
+            _ => MenuSelection::Cancelled,
+        })
+    }
+
+    fn confirm_removal(&self, name: &str) -> changeset_operations::Result<bool> {
+        Confirm::new()
+            .with_prompt(format!("Remove additional package '{name}'?"))
+            .default(false)
+            .interact()
+            .map_err(dialoguer_to_operation_error)
+    }
+}
+
+pub(crate) fn run(args: AdditionalPackagesArgs, start_path: &Path) -> Result<()> {
+    match args.command {
+        AdditionalPackageCommand::Add(args) => run_add(args, start_path),
+        AdditionalPackageCommand::Remove(args) => run_remove(args, start_path),
+        AdditionalPackageCommand::Edit(args) => run_edit(args, start_path),
+        AdditionalPackageCommand::List => run_list(start_path),
+    }
+}
+
+fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
+    let all_provided = args.name.is_some()
+        && args.path.is_some()
+        && args.manifest_file.is_some()
+        && args.manifest_format.is_some()
+        && args.version_path.is_some();
+
+    let events = if all_provided {
+        let input = AdditionalPackageAddInput {
+            name: args.name.expect("checked above"),
+            path: args.path.expect("checked above"),
+            influence: args.influence,
+            manifest_file_path: args.manifest_file.expect("checked above"),
+            manifest_format: args.manifest_format.expect("checked above"),
+            manifest_version_path: args.version_path.expect("checked above"),
+        };
+        let op = AdditionalPackageDirectAddOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+        );
+        op.execute(start_path, input)?
+    } else if is_interactive() {
+        let op = AdditionalPackageInteractiveAddOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+            TerminalAdditionalPackageInteractionProvider,
+        );
+        op.execute(start_path)?
+    } else {
+        return Err(CliError::NotATty);
+    };
+
+    print_additional_package_events(&events);
+    Ok(())
+}
+
+fn run_remove(args: RemoveAdditionalPackageArgs, start_path: &Path) -> Result<()> {
+    let events = if let Some(name) = args.name {
+        let op = AdditionalPackageDirectRemoveOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+        );
+        op.execute(start_path, &name)?
+    } else if is_interactive() {
+        let op = AdditionalPackageInteractiveRemoveOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+            TerminalAdditionalPackageInteractionProvider,
+        );
+        op.execute(start_path)?
+    } else {
+        return Err(CliError::NotATty);
+    };
+
+    print_additional_package_events(&events);
+    Ok(())
+}
+
+fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
+    let has_updates = args.path.is_some()
+        || !args.influence.is_empty()
+        || args.manifest_file.is_some()
+        || args.manifest_format.is_some()
+        || args.version_path.is_some();
+
+    let events = if args.name.is_some() && has_updates {
+        let updates = AdditionalPackageUpdate {
+            path: args.path,
+            influence: if args.influence.is_empty() {
+                None
+            } else {
+                Some(args.influence)
+            },
+            manifest_file_path: args.manifest_file,
+            manifest_format: args.manifest_format,
+            manifest_version_path: args.version_path,
+        };
+        let input = AdditionalPackageEditInput {
+            name: args.name.expect("checked above"),
+            updates,
+        };
+        let op = AdditionalPackageDirectEditOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+        );
+        op.execute(start_path, input)?
+    } else if is_interactive() {
+        let op = AdditionalPackageInteractiveEditOperation::new(
+            FileSystemProjectProvider::new(),
+            FileSystemManifestWriter::new(),
+            TerminalAdditionalPackageInteractionProvider,
+        );
+        op.execute(start_path)?
+    } else {
+        return Err(CliError::NotATty);
+    };
+
+    print_additional_package_events(&events);
+    Ok(())
+}
+
+fn run_list(start_path: &Path) -> Result<()> {
+    let op = AdditionalPackageListOperation::new(FileSystemProjectProvider::new());
+    let events = op.execute(start_path)?;
+    print_additional_package_events(&events);
+    Ok(())
+}
+
+fn print_additional_package_events(events: &[AdditionalPackageEvent]) {
+    for event in events {
+        match event {
+            AdditionalPackageEvent::Added { name } => {
+                println!("Added additional package '{name}'");
+            }
+            AdditionalPackageEvent::Removed { name } => {
+                println!("Removed additional package '{name}'");
+            }
+            AdditionalPackageEvent::Updated { name, field } => {
+                println!("Updated additional package '{name}' (fields: {field})");
+            }
+            AdditionalPackageEvent::Listed(summaries) => {
+                println!();
+                println!("Additional packages:");
+                for s in summaries {
+                    println!("  {} ({})", s.name, s.path.display());
+                    println!(
+                        "    manifest: {} [{}]",
+                        s.manifest_file_path.display(),
+                        s.manifest_format
+                    );
+                }
+                println!();
+            }
+            AdditionalPackageEvent::NotFound { name } => {
+                println!("Additional package '{name}' not found");
+            }
+            AdditionalPackageEvent::AlreadyExists { name } => {
+                println!("A package named '{name}' already exists");
+            }
+            AdditionalPackageEvent::NoAdditionalPackages => {
+                println!("No additional packages configured.");
+            }
+        }
+    }
+}
+
+fn dialoguer_to_operation_error(e: dialoguer::Error) -> OperationError {
+    match e {
+        dialoguer::Error::IO(io_err) => OperationError::Io(io_err),
+    }
+}

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -65,41 +65,41 @@ pub(crate) enum DependencySubcommand {
 pub(crate) struct AddDependencyArgs {
     /// Name of the package that owns the dependency
     #[arg(long)]
-    pub package: String,
+    pub package: Option<String>,
 
     /// Name of the dependency to track
     #[arg(long)]
-    pub dependency: String,
+    pub dependency: Option<String>,
 
     /// Path to the manifest file where the dependency version is tracked
     #[arg(long = "manifest-file")]
-    pub manifest_file: PathBuf,
+    pub manifest_file: Option<PathBuf>,
 
-    /// Format of the manifest file
+    /// Format of the manifest file (auto-detected from file extension if omitted)
     #[arg(long = "manifest-format", value_enum)]
-    pub manifest_format: ManifestFormat,
+    pub manifest_format: Option<ManifestFormat>,
 
     /// Path to the version field inside the manifest
     #[arg(long = "version-field-path")]
-    pub version_field_path: String,
+    pub version_field_path: Option<String>,
 }
 
 #[derive(Args)]
 pub(crate) struct RemoveDependencyArgs {
     /// Name of the package that owns the dependency
     #[arg(long)]
-    pub package: String,
+    pub package: Option<String>,
 
     /// Name of the dependency to remove
     #[arg(long)]
-    pub dependency: String,
+    pub dependency: Option<String>,
 }
 
 #[derive(Args)]
 pub(crate) struct ListDependencyArgs {
     /// Name of the package to list dependencies for
     #[arg(long)]
-    pub package: String,
+    pub package: Option<String>,
 }
 
 #[derive(Args)]
@@ -165,6 +165,15 @@ pub(crate) struct EditAdditionalPackageArgs {
 
 struct TerminalAdditionalPackageInteractionProvider {
     last_manifest_path: Mutex<Option<PathBuf>>,
+}
+
+impl TerminalAdditionalPackageInteractionProvider {
+    fn prompt_dependency_name(&self) -> changeset_operations::Result<String> {
+        Input::new()
+            .with_prompt("Dependency name")
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)
+    }
 }
 
 impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteractionProvider {
@@ -351,17 +360,28 @@ pub(crate) fn run(args: AdditionalPackagesArgs, start_path: &Path) -> Result<()>
 }
 
 fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
+    let manifest_format = args.manifest_format.or_else(|| {
+        args.manifest_file
+            .as_deref()
+            .and_then(ManifestFormat::from_path)
+    });
+
+    let has_all_required = args.name.is_some()
+        && args.path.is_some()
+        && args.manifest_file.is_some()
+        && args.version_field_path.is_some();
+
     let events = if let (
         Some(name),
         Some(path),
         Some(manifest_file),
-        Some(manifest_format),
+        Some(format),
         Some(version_field_path),
     ) = (
         args.name,
         args.path,
         args.manifest_file,
-        args.manifest_format,
+        manifest_format,
         args.version_field_path,
     ) {
         let input = AdditionalPackageAddInput {
@@ -369,7 +389,7 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             path,
             influence: args.influence,
             manifest_file_path: manifest_file,
-            manifest_format,
+            manifest_format: format,
             manifest_version_field_path: version_field_path,
         };
         let op = AdditionalPackageDirectAddOperation::new(
@@ -386,8 +406,10 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             },
         );
         op.execute(start_path)?
+    } else if has_all_required {
+        return Err(CliError::ManifestFormatRequired);
     } else {
-        return Err(CliError::NotATty);
+        return Err(CliError::IncompleteArgs);
     };
 
     print_additional_package_events(&events);
@@ -411,7 +433,7 @@ fn run_remove(args: RemoveAdditionalPackageArgs, start_path: &Path) -> Result<()
         );
         op.execute(start_path)?
     } else {
-        return Err(CliError::NotATty);
+        return Err(CliError::IncompleteArgs);
     };
 
     print_additional_package_events(&events);
@@ -453,7 +475,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         );
         op.execute(start_path)?
     } else {
-        return Err(CliError::NotATty);
+        return Err(CliError::IncompleteArgs);
     };
 
     print_additional_package_events(&events);
@@ -476,38 +498,138 @@ fn run_dependencies(args: DependenciesArgs, start_path: &Path) -> Result<()> {
 }
 
 fn run_dependency_add(args: AddDependencyArgs, start_path: &Path) -> Result<()> {
-    let input = VersionTrackingDependencyAddInput::new(
+    let manifest_format = args.manifest_format.or_else(|| {
+        args.manifest_file
+            .as_deref()
+            .and_then(ManifestFormat::from_path)
+    });
+
+    let has_all_required = args.package.is_some()
+        && args.dependency.is_some()
+        && args.manifest_file.is_some()
+        && args.version_field_path.is_some();
+
+    let events = if let (
+        Some(package),
+        Some(dependency),
+        Some(manifest_file),
+        Some(format),
+        Some(version_field_path),
+    ) = (
         args.package,
         args.dependency,
         args.manifest_file,
-        args.manifest_format,
+        manifest_format,
         args.version_field_path,
-    );
-    let op = VersionTrackingDependencyAddOperation::new(
-        FileSystemProjectProvider::new(),
-        FileSystemManifestWriter::new(),
-    );
-    let events = op.execute(start_path, input)?;
+    ) {
+        execute_dependency_add(
+            package,
+            dependency,
+            manifest_file,
+            format,
+            version_field_path,
+            start_path,
+        )?
+    } else if is_interactive() {
+        let interaction = TerminalAdditionalPackageInteractionProvider {
+            last_manifest_path: Mutex::new(None),
+        };
+        let package = interaction.prompt_package_name()?;
+        let dependency = interaction.prompt_dependency_name()?;
+        let manifest_file = interaction.prompt_manifest_file_path()?;
+        let format = interaction.prompt_manifest_format()?;
+        let version_field_path = interaction.prompt_manifest_version_field_path()?;
+
+        execute_dependency_add(
+            package,
+            dependency,
+            manifest_file,
+            format,
+            version_field_path,
+            start_path,
+        )?
+    } else if has_all_required {
+        return Err(CliError::ManifestFormatRequired);
+    } else {
+        return Err(CliError::IncompleteArgs);
+    };
+
     print_dependency_events(&events);
     Ok(())
 }
 
 fn run_dependency_remove(args: RemoveDependencyArgs, start_path: &Path) -> Result<()> {
-    let input = VersionTrackingDependencyRemoveInput::new(args.package, args.dependency);
-    let op = VersionTrackingDependencyRemoveOperation::new(
-        FileSystemProjectProvider::new(),
-        FileSystemManifestWriter::new(),
-    );
-    let events = op.execute(start_path, input)?;
+    let events = if let (Some(package), Some(dependency)) = (args.package, args.dependency) {
+        execute_dependency_remove(package, dependency, start_path)?
+    } else if is_interactive() {
+        let interaction = TerminalAdditionalPackageInteractionProvider {
+            last_manifest_path: Mutex::new(None),
+        };
+        let package = interaction.prompt_package_name()?;
+        let dependency = interaction.prompt_dependency_name()?;
+
+        execute_dependency_remove(package, dependency, start_path)?
+    } else {
+        return Err(CliError::IncompleteArgs);
+    };
+
     print_dependency_events(&events);
     Ok(())
 }
 
 fn run_dependency_list(args: ListDependencyArgs, start_path: &Path) -> Result<()> {
-    let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
-    let events = op.execute(start_path, &args.package)?;
+    let events = if let Some(package) = args.package {
+        let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
+        op.execute(start_path, &package)?
+    } else if is_interactive() {
+        let interaction = TerminalAdditionalPackageInteractionProvider {
+            last_manifest_path: Mutex::new(None),
+        };
+        let package = interaction.prompt_package_name()?;
+
+        let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
+        op.execute(start_path, &package)?
+    } else {
+        return Err(CliError::IncompleteArgs);
+    };
+
     print_dependency_events(&events);
     Ok(())
+}
+
+fn execute_dependency_add(
+    package: String,
+    dependency: String,
+    manifest_file: PathBuf,
+    manifest_format: ManifestFormat,
+    version_field_path: String,
+    start_path: &Path,
+) -> Result<Vec<VersionTrackingDependencyEvent>> {
+    let input = VersionTrackingDependencyAddInput::new(
+        package,
+        dependency,
+        manifest_file,
+        manifest_format,
+        version_field_path,
+    );
+    let op = VersionTrackingDependencyAddOperation::new(
+        FileSystemProjectProvider::new(),
+        FileSystemManifestWriter::new(),
+    );
+    Ok(op.execute(start_path, input)?)
+}
+
+fn execute_dependency_remove(
+    package: String,
+    dependency: String,
+    start_path: &Path,
+) -> Result<Vec<VersionTrackingDependencyEvent>> {
+    let input = VersionTrackingDependencyRemoveInput::new(package, dependency);
+    let op = VersionTrackingDependencyRemoveOperation::new(
+        FileSystemProjectProvider::new(),
+        FileSystemManifestWriter::new(),
+    );
+    Ok(op.execute(start_path, input)?)
 }
 
 fn print_dependency_events(events: &[VersionTrackingDependencyEvent]) {

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use clap::{Args, Subcommand, ValueEnum};
 use dialoguer::{Confirm, Input, Select};
@@ -162,7 +163,9 @@ pub(crate) struct EditAdditionalPackageArgs {
     pub version_field_path: Option<String>,
 }
 
-struct TerminalAdditionalPackageInteractionProvider;
+struct TerminalAdditionalPackageInteractionProvider {
+    last_manifest_path: Mutex<Option<PathBuf>>,
+}
 
 impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteractionProvider {
     fn prompt_package_name(&self) -> changeset_operations::Result<String> {
@@ -218,16 +221,30 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             .with_prompt("Path to version manifest file")
             .interact_text()
             .map_err(dialoguer_to_operation_error)?;
-        Ok(PathBuf::from(s))
+        let path = PathBuf::from(s);
+        if let Ok(mut guard) = self.last_manifest_path.lock() {
+            *guard = Some(path.clone());
+        }
+        Ok(path)
     }
 
     fn prompt_manifest_format(&self) -> changeset_operations::Result<ManifestFormat> {
         let variants = ManifestFormat::value_variants();
         let items: Vec<String> = variants.iter().map(ToString::to_string).collect();
+
+        let default_index = self
+            .last_manifest_path
+            .lock()
+            .ok()
+            .as_ref()
+            .and_then(|guard| guard.as_deref().and_then(ManifestFormat::from_path))
+            .and_then(|detected| variants.iter().position(|v| *v == detected))
+            .unwrap_or(0);
+
         let selection = Select::new()
             .with_prompt("Manifest format")
             .items(&items)
-            .default(0)
+            .default(default_index)
             .interact_opt()
             .map_err(dialoguer_to_operation_error)?;
 
@@ -364,7 +381,9 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         let op = AdditionalPackageInteractiveAddOperation::new(
             FileSystemProjectProvider::new(),
             FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider,
+            TerminalAdditionalPackageInteractionProvider {
+                last_manifest_path: Mutex::new(None),
+            },
         );
         op.execute(start_path)?
     } else {
@@ -386,7 +405,9 @@ fn run_remove(args: RemoveAdditionalPackageArgs, start_path: &Path) -> Result<()
         let op = AdditionalPackageInteractiveRemoveOperation::new(
             FileSystemProjectProvider::new(),
             FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider,
+            TerminalAdditionalPackageInteractionProvider {
+                last_manifest_path: Mutex::new(None),
+            },
         );
         op.execute(start_path)?
     } else {
@@ -426,7 +447,9 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         let op = AdditionalPackageInteractiveEditOperation::new(
             FileSystemProjectProvider::new(),
             FileSystemManifestWriter::new(),
-            TerminalAdditionalPackageInteractionProvider,
+            TerminalAdditionalPackageInteractionProvider {
+                last_manifest_path: Mutex::new(None),
+            },
         );
         op.execute(start_path)?
     } else {
@@ -568,5 +591,54 @@ fn print_additional_package_events(events: &[AdditionalPackageEvent]) {
 fn dialoguer_to_operation_error(e: dialoguer::Error) -> OperationError {
     match e {
         dialoguer::Error::IO(io_err) => OperationError::Io(io_err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use changeset_core::ManifestFormat;
+
+    #[test]
+    fn manifest_format_from_path_detects_toml() {
+        assert_eq!(
+            ManifestFormat::from_path(Path::new("Cargo.toml")),
+            Some(ManifestFormat::Toml)
+        );
+    }
+
+    #[test]
+    fn manifest_format_from_path_detects_yaml() {
+        assert_eq!(
+            ManifestFormat::from_path(Path::new("Chart.yaml")),
+            Some(ManifestFormat::Yaml)
+        );
+    }
+
+    #[test]
+    fn manifest_format_from_path_detects_yml() {
+        assert_eq!(
+            ManifestFormat::from_path(Path::new("config.yml")),
+            Some(ManifestFormat::Yaml)
+        );
+    }
+
+    #[test]
+    fn manifest_format_from_path_detects_json() {
+        assert_eq!(
+            ManifestFormat::from_path(Path::new("package.json")),
+            Some(ManifestFormat::Json)
+        );
+    }
+
+    #[test]
+    fn manifest_format_from_path_returns_none_for_unknown_extension() {
+        assert_eq!(ManifestFormat::from_path(Path::new("readme.txt")), None);
+    }
+
+    #[test]
+    fn manifest_format_from_path_returns_none_for_no_extension() {
+        assert_eq!(ManifestFormat::from_path(Path::new("Makefile")), None);
     }
 }

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -62,8 +62,8 @@ pub(crate) struct AddAdditionalPackageArgs {
     pub manifest_format: Option<ManifestFormat>,
 
     /// JSONPath-style path to the version field in the manifest
-    #[arg(long = "version-path")]
-    pub version_path: Option<String>,
+    #[arg(long = "version-field-path")]
+    pub version_field_path: Option<String>,
 }
 
 #[derive(Args)]
@@ -95,9 +95,9 @@ pub(crate) struct EditAdditionalPackageArgs {
     #[arg(long = "manifest-format", value_enum)]
     pub manifest_format: Option<ManifestFormat>,
 
-    /// New version path
-    #[arg(long = "version-path")]
-    pub version_path: Option<String>,
+    /// New version field path
+    #[arg(long = "version-field-path")]
+    pub version_field_path: Option<String>,
 }
 
 struct TerminalAdditionalPackageInteractionProvider;
@@ -175,7 +175,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
         }
     }
 
-    fn prompt_manifest_version_path(&self) -> changeset_operations::Result<String> {
+    fn prompt_manifest_version_field_path(&self) -> changeset_operations::Result<String> {
         Input::new()
             .with_prompt("Path to version field in manifest (e.g. 'version' or 'info.version')")
             .interact_text()
@@ -247,7 +247,7 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
             Some(1) => MenuSelection::Selected(AdditionalPackageField::Influence),
             Some(2) => MenuSelection::Selected(AdditionalPackageField::ManifestFilePath),
             Some(3) => MenuSelection::Selected(AdditionalPackageField::ManifestFormat),
-            Some(4) => MenuSelection::Selected(AdditionalPackageField::ManifestVersionPath),
+            Some(4) => MenuSelection::Selected(AdditionalPackageField::ManifestVersionFieldPath),
             _ => MenuSelection::Cancelled,
         })
     }
@@ -276,13 +276,13 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         Some(path),
         Some(manifest_file),
         Some(manifest_format),
-        Some(version_path),
+        Some(version_field_path),
     ) = (
         args.name,
         args.path,
         args.manifest_file,
         args.manifest_format,
-        args.version_path,
+        args.version_field_path,
     ) {
         let input = AdditionalPackageAddInput {
             name,
@@ -290,7 +290,7 @@ fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             influence: args.influence,
             manifest_file_path: manifest_file,
             manifest_format,
-            manifest_version_path: version_path,
+            manifest_version_field_path: version_field_path,
         };
         let op = AdditionalPackageDirectAddOperation::new(
             FileSystemProjectProvider::new(),
@@ -339,7 +339,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         || !args.influence.is_empty()
         || args.manifest_file.is_some()
         || args.manifest_format.is_some()
-        || args.version_path.is_some();
+        || args.version_field_path.is_some();
 
     let events = if let Some(name) = args.name.filter(|_| has_updates) {
         let updates = AdditionalPackageUpdate {
@@ -351,7 +351,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             },
             manifest_file_path: args.manifest_file,
             manifest_format: args.manifest_format,
-            manifest_version_path: args.version_path,
+            manifest_version_field_path: args.version_field_path,
         };
         let input = AdditionalPackageEditInput { name, updates };
         let op = AdditionalPackageDirectEditOperation::new(

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -257,20 +257,26 @@ pub(crate) fn run(args: AdditionalPackagesArgs, start_path: &Path) -> Result<()>
 }
 
 fn run_add(args: AddAdditionalPackageArgs, start_path: &Path) -> Result<()> {
-    let all_provided = args.name.is_some()
-        && args.path.is_some()
-        && args.manifest_file.is_some()
-        && args.manifest_format.is_some()
-        && args.version_path.is_some();
-
-    let events = if all_provided {
+    let events = if let (
+        Some(name),
+        Some(path),
+        Some(manifest_file),
+        Some(manifest_format),
+        Some(version_path),
+    ) = (
+        args.name,
+        args.path,
+        args.manifest_file,
+        args.manifest_format,
+        args.version_path,
+    ) {
         let input = AdditionalPackageAddInput {
-            name: args.name.expect("checked above"),
-            path: args.path.expect("checked above"),
+            name,
+            path,
             influence: args.influence,
-            manifest_file_path: args.manifest_file.expect("checked above"),
-            manifest_format: args.manifest_format.expect("checked above"),
-            manifest_version_path: args.version_path.expect("checked above"),
+            manifest_file_path: manifest_file,
+            manifest_format,
+            manifest_version_path: version_path,
         };
         let op = AdditionalPackageDirectAddOperation::new(
             FileSystemProjectProvider::new(),
@@ -321,7 +327,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
         || args.manifest_format.is_some()
         || args.version_path.is_some();
 
-    let events = if args.name.is_some() && has_updates {
+    let events = if let Some(name) = args.name.filter(|_| has_updates) {
         let updates = AdditionalPackageUpdate {
             path: args.path,
             influence: if args.influence.is_empty() {
@@ -333,10 +339,7 @@ fn run_edit(args: EditAdditionalPackageArgs, start_path: &Path) -> Result<()> {
             manifest_format: args.manifest_format,
             manifest_version_path: args.version_path,
         };
-        let input = AdditionalPackageEditInput {
-            name: args.name.expect("checked above"),
-            updates,
-        };
+        let input = AdditionalPackageEditInput { name, updates };
         let op = AdditionalPackageDirectEditOperation::new(
             FileSystemProjectProvider::new(),
             FileSystemManifestWriter::new(),

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -118,14 +118,28 @@ impl AdditionalPackageInteractionProvider for TerminalAdditionalPackageInteracti
         Ok(PathBuf::from(s))
     }
 
-    fn prompt_influence_patterns(&self) -> changeset_operations::Result<Vec<String>> {
+    fn prompt_influence_patterns(
+        &self,
+        package_path: &Path,
+    ) -> changeset_operations::Result<Vec<String>> {
         let mut patterns = Vec::new();
         println!(
-            "Enter glob patterns for files that influence this package (empty line to finish):"
+            "Enter glob patterns for files that influence this package (one per line, empty line to finish):"
         );
+        let default = format!("{}/**", package_path.display());
+        let first: String = Input::new()
+            .with_prompt("Glob pattern")
+            .default(default)
+            .allow_empty(true)
+            .interact_text()
+            .map_err(dialoguer_to_operation_error)?;
+        if first.is_empty() {
+            return Ok(patterns);
+        }
+        patterns.push(first);
         loop {
             let s: String = Input::new()
-                .with_prompt("Glob pattern")
+                .with_prompt("Additional pattern")
                 .allow_empty(true)
                 .interact_text()
                 .map_err(dialoguer_to_operation_error)?;

--- a/crates/cargo-changeset/src/commands/additional_packages.rs
+++ b/crates/cargo-changeset/src/commands/additional_packages.rs
@@ -11,7 +11,10 @@ use changeset_operations::operations::{
     AdditionalPackageDirectEditOperation, AdditionalPackageDirectRemoveOperation,
     AdditionalPackageEditInput, AdditionalPackageEvent, AdditionalPackageInteractiveAddOperation,
     AdditionalPackageInteractiveEditOperation, AdditionalPackageInteractiveRemoveOperation,
-    AdditionalPackageListOperation,
+    AdditionalPackageListOperation, VersionTrackingDependencyAddInput,
+    VersionTrackingDependencyAddOperation, VersionTrackingDependencyEvent,
+    VersionTrackingDependencyListOperation, VersionTrackingDependencyRemoveInput,
+    VersionTrackingDependencyRemoveOperation,
 };
 use changeset_operations::providers::{FileSystemManifestWriter, FileSystemProjectProvider};
 use changeset_operations::traits::{
@@ -37,6 +40,65 @@ pub(crate) enum AdditionalPackageCommand {
     Edit(EditAdditionalPackageArgs),
     /// List all non-Rust package declarations
     List,
+    /// Manage version-tracking dependencies for a package
+    Dependencies(DependenciesArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct DependenciesArgs {
+    #[command(subcommand)]
+    pub command: DependencySubcommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DependencySubcommand {
+    /// Add a version-tracking dependency to a package
+    Add(AddDependencyArgs),
+    /// Remove a version-tracking dependency from a package
+    Remove(RemoveDependencyArgs),
+    /// List version-tracking dependencies for a package
+    List(ListDependencyArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct AddDependencyArgs {
+    /// Name of the package that owns the dependency
+    #[arg(long)]
+    pub package: String,
+
+    /// Name of the dependency to track
+    #[arg(long)]
+    pub dependency: String,
+
+    /// Path to the manifest file where the dependency version is tracked
+    #[arg(long = "manifest-file")]
+    pub manifest_file: PathBuf,
+
+    /// Format of the manifest file
+    #[arg(long = "manifest-format", value_enum)]
+    pub manifest_format: ManifestFormat,
+
+    /// Path to the version field inside the manifest
+    #[arg(long = "version-field-path")]
+    pub version_field_path: String,
+}
+
+#[derive(Args)]
+pub(crate) struct RemoveDependencyArgs {
+    /// Name of the package that owns the dependency
+    #[arg(long)]
+    pub package: String,
+
+    /// Name of the dependency to remove
+    #[arg(long)]
+    pub dependency: String,
+}
+
+#[derive(Args)]
+pub(crate) struct ListDependencyArgs {
+    /// Name of the package to list dependencies for
+    #[arg(long)]
+    pub package: String,
 }
 
 #[derive(Args)]
@@ -267,6 +329,7 @@ pub(crate) fn run(args: AdditionalPackagesArgs, start_path: &Path) -> Result<()>
         AdditionalPackageCommand::Remove(args) => run_remove(args, start_path),
         AdditionalPackageCommand::Edit(args) => run_edit(args, start_path),
         AdditionalPackageCommand::List => run_list(start_path),
+        AdditionalPackageCommand::Dependencies(args) => run_dependencies(args, start_path),
     }
 }
 
@@ -379,6 +442,89 @@ fn run_list(start_path: &Path) -> Result<()> {
     let events = op.execute(start_path)?;
     print_additional_package_events(&events);
     Ok(())
+}
+
+fn run_dependencies(args: DependenciesArgs, start_path: &Path) -> Result<()> {
+    match args.command {
+        DependencySubcommand::Add(args) => run_dependency_add(args, start_path),
+        DependencySubcommand::Remove(args) => run_dependency_remove(args, start_path),
+        DependencySubcommand::List(args) => run_dependency_list(args, start_path),
+    }
+}
+
+fn run_dependency_add(args: AddDependencyArgs, start_path: &Path) -> Result<()> {
+    let input = VersionTrackingDependencyAddInput::new(
+        args.package,
+        args.dependency,
+        args.manifest_file,
+        args.manifest_format,
+        args.version_field_path,
+    );
+    let op = VersionTrackingDependencyAddOperation::new(
+        FileSystemProjectProvider::new(),
+        FileSystemManifestWriter::new(),
+    );
+    let events = op.execute(start_path, input)?;
+    print_dependency_events(&events);
+    Ok(())
+}
+
+fn run_dependency_remove(args: RemoveDependencyArgs, start_path: &Path) -> Result<()> {
+    let input = VersionTrackingDependencyRemoveInput::new(args.package, args.dependency);
+    let op = VersionTrackingDependencyRemoveOperation::new(
+        FileSystemProjectProvider::new(),
+        FileSystemManifestWriter::new(),
+    );
+    let events = op.execute(start_path, input)?;
+    print_dependency_events(&events);
+    Ok(())
+}
+
+fn run_dependency_list(args: ListDependencyArgs, start_path: &Path) -> Result<()> {
+    let op = VersionTrackingDependencyListOperation::new(FileSystemProjectProvider::new());
+    let events = op.execute(start_path, &args.package)?;
+    print_dependency_events(&events);
+    Ok(())
+}
+
+fn print_dependency_events(events: &[VersionTrackingDependencyEvent]) {
+    for event in events {
+        match event {
+            VersionTrackingDependencyEvent::Added {
+                package_name,
+                dependency_name,
+            } => {
+                println!(
+                    "Added version-tracking dependency '{dependency_name}' to package '{package_name}'"
+                );
+            }
+            VersionTrackingDependencyEvent::Removed {
+                package_name,
+                dependency_name,
+            } => {
+                println!(
+                    "Removed version-tracking dependency '{dependency_name}' from package '{package_name}'"
+                );
+            }
+            VersionTrackingDependencyEvent::Listed(summaries) => {
+                println!();
+                println!("Version-tracking dependencies:");
+                for s in summaries {
+                    println!(
+                        "  {} -> {} [{}]",
+                        s.dependency_name(),
+                        s.manifest_file_path().display(),
+                        s.manifest_format()
+                    );
+                    println!("    version field: {}", s.version_field_path());
+                }
+                println!();
+            }
+            VersionTrackingDependencyEvent::NoDependencies { package_name } => {
+                println!("No version-tracking dependencies configured for '{package_name}'.");
+            }
+        }
+    }
 }
 
 fn print_additional_package_events(events: &[AdditionalPackageEvent]) {

--- a/crates/cargo-changeset/src/commands/init.rs
+++ b/crates/cargo-changeset/src/commands/init.rs
@@ -97,6 +97,9 @@ pub(crate) fn run(args: InitArgs, start_path: &Path) -> Result<()> {
         }
     }
 
+    println!();
+    println!("Tip: Use 'cargo changeset additional-packages add' to declare non-Rust packages.");
+
     Ok(())
 }
 

--- a/crates/cargo-changeset/src/commands/init.rs
+++ b/crates/cargo-changeset/src/commands/init.rs
@@ -91,10 +91,10 @@ pub(crate) fn run(args: InitArgs, start_path: &Path) -> Result<()> {
         println!("Created .gitkeep file");
     }
 
-    if output.wrote_config() {
-        if let Some(section) = output.config_location() {
-            println!("Wrote configuration to {section} in Cargo.toml");
-        }
+    if output.wrote_config()
+        && let Some(section) = output.config_location()
+    {
+        println!("Wrote configuration to {section} in Cargo.toml");
     }
 
     println!();
@@ -214,10 +214,10 @@ fn print_config_summary(config: &InitConfig) {
     {
         println!("  dependency_bump_changelog_template = \"{dependency_bump_changelog_template}\"");
     }
-    if let Some(ref ignored_files) = config.ignored_files {
-        if !ignored_files.is_empty() {
-            println!("  ignored_files = {:?}", ignored_files);
-        }
+    if let Some(ref ignored_files) = config.ignored_files
+        && !ignored_files.is_empty()
+    {
+        println!("  ignored_files = {:?}", ignored_files);
     }
 }
 

--- a/crates/cargo-changeset/src/commands/manage.rs
+++ b/crates/cargo-changeset/src/commands/manage.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use dialoguer::{Input, Select};
 
 use changeset_core::PackageInfo;
-use changeset_operations::OperationError;
 use changeset_operations::operations::{
     GraduationDirectInput, GraduationDirectOperation, GraduationEvent, GraduationManageOperation,
     PrereleaseDirectInput, PrereleaseDirectOperation, PrereleaseEvent, PrereleaseManageOperation,
@@ -36,7 +35,7 @@ impl PrereleaseInteractionProvider for TerminalManageInteractionProvider {
             .items(options)
             .default(0)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(0) => MenuSelection::Selected(PrereleaseAction::Add),
@@ -59,7 +58,7 @@ impl PrereleaseInteractionProvider for TerminalManageInteractionProvider {
             .with_prompt("Select a crate to add to pre-release")
             .items(&items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -71,7 +70,7 @@ impl PrereleaseInteractionProvider for TerminalManageInteractionProvider {
         let tag: String = Input::new()
             .with_prompt("Enter pre-release tag (e.g., alpha, beta, rc)")
             .interact_text()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(tag)
     }
@@ -89,7 +88,7 @@ impl PrereleaseInteractionProvider for TerminalManageInteractionProvider {
             .with_prompt("Select a crate to remove from pre-release")
             .items(&display_items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -113,7 +112,7 @@ impl GraduationInteractionProvider for TerminalManageInteractionProvider {
             .items(options)
             .default(0)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(0) => MenuSelection::Selected(GraduationAction::Add),
@@ -135,7 +134,7 @@ impl GraduationInteractionProvider for TerminalManageInteractionProvider {
             .with_prompt("Select a crate to graduate (move to graduation queue)")
             .items(&items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -151,7 +150,7 @@ impl GraduationInteractionProvider for TerminalManageInteractionProvider {
             .with_prompt("Select a crate to remove from graduation queue")
             .items(items)
             .interact_opt()
-            .map_err(dialoguer_to_operation_error)?;
+            .map_err(super::dialoguer_to_operation_error)?;
 
         Ok(match selection {
             Some(index) => MenuSelection::Selected(index),
@@ -295,81 +294,6 @@ fn print_graduation_events(events: &[GraduationEvent]) {
             }
             GraduationEvent::NoGraduationPackages => {
                 println!("No packages are currently queued for graduation.");
-            }
-        }
-    }
-}
-
-fn dialoguer_to_operation_error(e: dialoguer::Error) -> OperationError {
-    match e {
-        dialoguer::Error::IO(io_err) => OperationError::Io(io_err),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    mod dialoguer_conversion {
-        use super::*;
-        use std::io;
-
-        #[test]
-        fn converts_io_error_to_operation_io_variant() {
-            let io_err = io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed");
-            let dialoguer_err = dialoguer::Error::IO(io_err);
-
-            let result = dialoguer_to_operation_error(dialoguer_err);
-
-            assert!(matches!(result, OperationError::Io(_)));
-        }
-
-        #[test]
-        fn preserves_io_error_kind() {
-            let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "access denied");
-            let dialoguer_err = dialoguer::Error::IO(io_err);
-
-            let result = dialoguer_to_operation_error(dialoguer_err);
-
-            match result {
-                OperationError::Io(inner) => {
-                    assert_eq!(inner.kind(), io::ErrorKind::PermissionDenied);
-                }
-                other => panic!("expected OperationError::Io, got {other:?}"),
-            }
-        }
-
-        #[test]
-        fn preserves_error_chain() {
-            let io_err = io::Error::other("chain test");
-            let dialoguer_err = dialoguer::Error::IO(io_err);
-
-            let result = dialoguer_to_operation_error(dialoguer_err);
-
-            let source = std::error::Error::source(&result);
-            assert!(
-                source.is_some(),
-                "error chain should be preserved through conversion"
-            );
-        }
-
-        #[test]
-        fn preserves_io_error_message() {
-            let io_err = io::Error::other("terminal unavailable");
-            let dialoguer_err = dialoguer::Error::IO(io_err);
-
-            let result = dialoguer_to_operation_error(dialoguer_err);
-
-            assert!(
-                result.to_string().contains("IO error"),
-                "expected display to contain 'IO error', got: {}",
-                result
-            );
-            match result {
-                OperationError::Io(inner) => {
-                    assert_eq!(inner.to_string(), "terminal unavailable");
-                }
-                other => panic!("expected OperationError::Io, got {other:?}"),
             }
         }
     }

--- a/crates/cargo-changeset/src/commands/mod.rs
+++ b/crates/cargo-changeset/src/commands/mod.rs
@@ -14,6 +14,7 @@ use changeset_core::{BumpType, ChangeCategory};
 use changeset_manifest::{
     ChangelogLocation, ComparisonLinks, NoneBumpBehavior, TagFormat, ZeroVersionBehavior,
 };
+use changeset_operations::OperationError;
 
 use crate::error::Result;
 
@@ -380,6 +381,80 @@ impl Commands {
                 additional_packages::run(args, start_path),
                 ExecuteResult { quiet: false },
             ),
+        }
+    }
+}
+
+pub(super) fn dialoguer_to_operation_error(e: dialoguer::Error) -> OperationError {
+    match e {
+        dialoguer::Error::IO(io_err) => OperationError::Io(io_err),
+    }
+}
+
+#[cfg(test)]
+mod dialoguer_conversion_tests {
+    use std::io;
+
+    use changeset_operations::OperationError;
+
+    use super::dialoguer_to_operation_error;
+
+    #[test]
+    fn converts_io_error_to_operation_io_variant() {
+        let io_err = io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed");
+        let dialoguer_err = dialoguer::Error::IO(io_err);
+
+        let result = dialoguer_to_operation_error(dialoguer_err);
+
+        assert!(matches!(result, OperationError::Io(_)));
+    }
+
+    #[test]
+    fn preserves_io_error_kind() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "access denied");
+        let dialoguer_err = dialoguer::Error::IO(io_err);
+
+        let result = dialoguer_to_operation_error(dialoguer_err);
+
+        match result {
+            OperationError::Io(inner) => {
+                assert_eq!(inner.kind(), io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("expected OperationError::Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserves_error_chain() {
+        let io_err = io::Error::other("chain test");
+        let dialoguer_err = dialoguer::Error::IO(io_err);
+
+        let result = dialoguer_to_operation_error(dialoguer_err);
+
+        let source = std::error::Error::source(&result);
+        assert!(
+            source.is_some(),
+            "error chain should be preserved through conversion"
+        );
+    }
+
+    #[test]
+    fn preserves_io_error_message() {
+        let io_err = io::Error::other("terminal unavailable");
+        let dialoguer_err = dialoguer::Error::IO(io_err);
+
+        let result = dialoguer_to_operation_error(dialoguer_err);
+
+        assert!(
+            result.to_string().contains("IO error"),
+            "expected display to contain 'IO error', got: {}",
+            result
+        );
+        match result {
+            OperationError::Io(inner) => {
+                assert_eq!(inner.to_string(), "terminal unavailable");
+            }
+            other => panic!("expected OperationError::Io, got {other:?}"),
         }
     }
 }

--- a/crates/cargo-changeset/src/commands/mod.rs
+++ b/crates/cargo-changeset/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod additional_packages;
 mod init;
 mod manage;
 mod release;
@@ -352,6 +353,9 @@ Use 'cargo changeset manage' to configure these files."
     Init(InitArgs),
     /// Manage release configuration files
     Manage(ManageArgs),
+    /// Manage non-Rust package declarations in Cargo.toml metadata
+    #[command(name = "additional-packages")]
+    AdditionalPackages(additional_packages::AdditionalPackagesArgs),
 }
 
 impl Commands {
@@ -370,6 +374,10 @@ impl Commands {
             Self::Init(args) => (init::run(args, start_path), ExecuteResult { quiet: false }),
             Self::Manage(args) => (
                 manage::run(args, start_path),
+                ExecuteResult { quiet: false },
+            ),
+            Self::AdditionalPackages(args) => (
+                additional_packages::run(args, start_path),
                 ExecuteResult { quiet: false },
             ),
         }

--- a/crates/cargo-changeset/src/error.rs
+++ b/crates/cargo-changeset/src/error.rs
@@ -25,6 +25,14 @@ pub enum CliError {
     #[error("interactive mode requires a terminal")]
     NotATty,
 
+    #[error(
+        "not all required arguments were provided and no terminal is available for interactive prompts"
+    )]
+    IncompleteArgs,
+
+    #[error("could not determine manifest format from file extension; use --manifest-format")]
+    ManifestFormatRequired,
+
     #[error("invalid --package-bump format '{input}' (expected 'package-name:bump-type')")]
     InvalidPackageBumpFormat { input: String },
 
@@ -91,6 +99,16 @@ mod tests {
         let err = CliError::NotATty;
 
         assert!(err.to_string().contains("terminal"));
+    }
+
+    #[test]
+    fn incomplete_args_error_message() {
+        let err = CliError::IncompleteArgs;
+
+        let msg = err.to_string();
+
+        assert!(msg.contains("not all required arguments"));
+        assert!(msg.contains("interactive"));
     }
 
     #[test]

--- a/crates/cargo-changeset/src/interaction.rs
+++ b/crates/cargo-changeset/src/interaction.rs
@@ -345,6 +345,9 @@ fn cli_to_operation_error(e: CliError) -> changeset_operations::OperationError {
         CliError::Project(e) => OperationError::Project(e),
         CliError::Operation(e) => e,
         CliError::CurrentDir(io) => OperationError::Io(io),
+        CliError::ManifestFormatRequired | CliError::IncompleteArgs => {
+            OperationError::InteractionRequired
+        }
         CliError::InvalidPackageBumpFormat { .. }
         | CliError::InvalidBumpType { .. }
         | CliError::VerificationFailed { .. }

--- a/crates/cargo-changeset/src/main.rs
+++ b/crates/cargo-changeset/src/main.rs
@@ -35,7 +35,15 @@ fn main() -> ExitCode {
     let cli = match CargoCli::try_parse() {
         Ok(CargoCli::Changeset(cli)) => cli,
         Err(e) if !e.use_stderr() => e.exit(),
-        Err(_) => ChangesetCli::parse(),
+        Err(e) => {
+            let invoked_via_cargo = std::env::args_os()
+                .nth(1)
+                .is_some_and(|arg| arg == "changeset");
+            if invoked_via_cargo {
+                e.exit();
+            }
+            ChangesetCli::parse()
+        }
     };
 
     let start_path = match resolve_start_path(cli.path) {

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::process::Command;
 use std::time::Duration;
@@ -5,68 +7,10 @@ use std::time::Duration;
 use predicates::str::contains;
 use tempfile::TempDir;
 
-fn create_single_crate_workspace() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[package]
-name = "test-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write Cargo.toml");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
-
-    dir
-}
-
-fn create_virtual_workspace() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/a/src")).expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/b/src")).expect("failed to create crate b dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/a/Cargo.toml"),
-        r#"
-[package]
-name = "crate-a"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/a/src/lib.rs"), "").expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/b/Cargo.toml"),
-        r#"
-[package]
-name = "crate-b"
-version = "0.2.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-b Cargo.toml");
-
-    fs::write(dir.path().join("crates/b/src/lib.rs"), "").expect("failed to write crate-b lib.rs");
-
-    dir
-}
+use common::workspaces::{
+    create_single_crate_workspace, create_virtual_workspace,
+    create_workspace_with_additional_package,
+};
 
 fn create_workspace_with_underscored_crate() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
@@ -511,6 +455,56 @@ mod non_interactive {
             .success()
             .stdout(contains("Message from stdin"));
     }
+
+    #[test]
+    fn add_creates_changeset_for_additional_package() {
+        let workspace = create_workspace_with_additional_package();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("add")
+            .arg("--package-bump")
+            .arg("my-helm-chart:minor")
+            .arg("-m")
+            .arg("Add new endpoint")
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Created changeset"));
+
+        let changeset_dir = workspace.path().join(".changeset/changesets");
+        let files: Vec<_> = fs::read_dir(&changeset_dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .collect();
+
+        assert_eq!(files.len(), 1, "should have one changeset file");
+
+        let content = fs::read_to_string(files[0].path()).expect("read changeset file");
+        assert!(
+            content.contains("my-helm-chart: minor"),
+            "should contain package bump entry, got:\n{content}"
+        );
+        assert!(
+            content.contains("Add new endpoint"),
+            "should contain message"
+        );
+    }
+
+    #[test]
+    fn add_rejects_unknown_additional_package_name() {
+        let workspace = create_workspace_with_additional_package();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("add")
+            .arg("--package-bump")
+            .arg("nonexistent-pkg:patch")
+            .arg("-m")
+            .arg("test")
+            .current_dir(workspace.path())
+            .assert()
+            .failure();
+    }
 }
 
 #[cfg(not(windows))]
@@ -572,6 +566,9 @@ MOCK_EDITOR_EOF
 
         let result = session.expect("Select packages");
         assert!(result.is_ok(), "Expected to see 'Select packages' prompt");
+
+        session.send("\x1b").expect("failed to send escape");
+        session.expect(expectrl::Eof).ok();
     }
 
     #[test]
@@ -580,6 +577,9 @@ MOCK_EDITOR_EOF
         let mut session = spawn_add_in_workspace(&workspace);
 
         session.expect("crate-a").expect("Expected to see crate-a");
+
+        session.send("\x1b").expect("failed to send escape");
+        session.expect(expectrl::Eof).ok();
     }
 
     #[test]
@@ -630,6 +630,9 @@ MOCK_EDITOR_EOF
         session
             .expect("category")
             .expect("Expected category prompt");
+
+        session.send("\x1b").expect("failed to send escape");
+        session.expect(expectrl::Eof).ok();
     }
 
     #[test]

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -746,6 +746,240 @@ mod dependencies_advanced_tests {
     }
 }
 
+mod non_interactive_fallback_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_add_no_args_non_interactive_shows_incomplete_args_error() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "dependencies", "add"])
+            .env("CARGO_CHANGESET_NO_TTY", "1")
+            .env("NO_COLOR", "1")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not all required arguments"));
+    }
+
+    #[test]
+    fn dependencies_remove_no_args_non_interactive_shows_incomplete_args_error() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "dependencies", "remove"])
+            .env("CARGO_CHANGESET_NO_TTY", "1")
+            .env("NO_COLOR", "1")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not all required arguments"));
+    }
+
+    #[test]
+    fn dependencies_list_no_args_non_interactive_shows_incomplete_args_error() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "dependencies", "list"])
+            .env("CARGO_CHANGESET_NO_TTY", "1")
+            .env("NO_COLOR", "1")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not all required arguments"));
+    }
+
+    #[test]
+    fn dependencies_add_partial_args_non_interactive_shows_incomplete_args_error() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+            ])
+            .env("CARGO_CHANGESET_NO_TTY", "1")
+            .env("NO_COLOR", "1")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not all required arguments"));
+    }
+}
+
+mod auto_detect_format_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_add_auto_detects_yaml_format() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains(r#"format = "yaml""#),
+            "expected auto-detected yaml format stored in Cargo.toml, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn dependencies_add_auto_detects_json_format() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        fs::write(
+            workspace.path().join("charts/my-chart/versions.json"),
+            r#"{"appVersion": "1.0.0"}"#,
+        )
+        .expect("write json file");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/versions.json",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains(r#"format = "json""#),
+            "expected auto-detected json format stored in Cargo.toml, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn dependencies_add_auto_detects_toml_format() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        fs::write(
+            workspace.path().join("charts/my-chart/versions.toml"),
+            "[versions]\nappVersion = \"1.0.0\"\n",
+        )
+        .expect("write toml file");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/versions.toml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains(r#"format = "toml""#),
+            "expected auto-detected toml format stored in Cargo.toml, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn additional_packages_add_auto_detects_manifest_format() {
+        let workspace = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "charts/my-chart/**",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--version-field-path",
+                "version",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added additional package 'my-helm-chart'"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains(r#"format = "yaml""#),
+            "expected auto-detected yaml format stored in Cargo.toml, got:\n{cargo_toml}"
+        );
+    }
+}
+
+mod direct_binary_invocation_tests {
+    use super::*;
+
+    #[test]
+    fn direct_invocation_additional_packages_dependencies_add_no_args_shows_proper_error() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::Command::cargo_bin("cargo-changeset")
+            .expect("binary exists")
+            .args(["additional-packages", "dependencies", "add"])
+            .env("CARGO_CHANGESET_NO_TTY", "1")
+            .env("NO_COLOR", "1")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not all required arguments"));
+    }
+}
+
 mod help_and_ux_tests {
     use super::*;
 

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -1,11 +1,17 @@
 mod common;
 
 use std::fs;
+use std::process::Command;
 
 use predicates::str::contains;
 
+use common::changesets::write_changeset;
+use common::git::{git_add_and_commit, init_git_repo};
 use common::workspaces::{
     add_helm_chart_config, create_single_crate_workspace, create_workspace_with_helm_chart,
+    create_workspace_with_unknown_dependency,
+    create_workspace_with_version_tracking_additional_to_cargo,
+    create_workspace_with_version_tracking_cargo_to_additional,
 };
 
 mod add_tests {
@@ -318,5 +324,214 @@ mod workspace_rejection_tests {
             .assert()
             .failure()
             .stderr(contains("workspace"));
+    }
+}
+
+mod version_tracking_tests {
+    use super::*;
+
+    #[test]
+    fn release_with_version_tracking_dep_additional_to_cargo() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+        init_git_repo(&workspace);
+
+        let lockfile_output = Command::new("cargo")
+            .args(["generate-lockfile"])
+            .current_dir(workspace.path())
+            .output()
+            .expect("failed to run cargo generate-lockfile");
+        assert!(
+            lockfile_output.status.success(),
+            "cargo generate-lockfile failed: {}",
+            String::from_utf8_lossy(&lockfile_output.stderr)
+        );
+
+        git_add_and_commit(&workspace, "Initial commit");
+
+        write_changeset(
+            &workspace,
+            "bump-rust.md",
+            "my-rust-crate",
+            "patch",
+            "Fix a bug in Rust crate",
+        );
+        git_add_and_commit(&workspace, "Add changeset");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("release")
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        let rust_toml =
+            fs::read_to_string(workspace.path().join("crates/my-rust-crate/Cargo.toml"))
+                .expect("failed to read my-rust-crate Cargo.toml");
+        assert!(
+            rust_toml.contains("version = \"1.0.1\""),
+            "expected my-rust-crate version 1.0.1, got:\n{rust_toml}"
+        );
+
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/Chart.yaml"))
+            .expect("failed to read Chart.yaml");
+        assert!(
+            chart_yaml.contains("version: 0.1.1"),
+            "expected my-helm-chart auto-bumped to 0.1.1, got:\n{chart_yaml}"
+        );
+        assert!(
+            chart_yaml.contains("appVersion: 1.0.1"),
+            "expected appVersion updated to 1.0.1, got:\n{chart_yaml}"
+        );
+    }
+
+    #[test]
+    fn release_with_version_tracking_dep_cargo_to_additional() {
+        let workspace = create_workspace_with_version_tracking_cargo_to_additional();
+        init_git_repo(&workspace);
+
+        let lockfile_output = Command::new("cargo")
+            .args(["generate-lockfile"])
+            .current_dir(workspace.path())
+            .output()
+            .expect("failed to run cargo generate-lockfile");
+        assert!(
+            lockfile_output.status.success(),
+            "cargo generate-lockfile failed: {}",
+            String::from_utf8_lossy(&lockfile_output.stderr)
+        );
+
+        git_add_and_commit(&workspace, "Initial commit");
+
+        write_changeset(
+            &workspace,
+            "bump-lib.md",
+            "my-lib",
+            "patch",
+            "Fix a bug in my-lib",
+        );
+        git_add_and_commit(&workspace, "Add changeset");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("release")
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        let package_json =
+            fs::read_to_string(workspace.path().join("packages/my-lib/package.json"))
+                .expect("failed to read package.json");
+        assert!(
+            package_json.contains("\"version\": \"2.0.1\"")
+                || package_json.contains("\"version\":\"2.0.1\""),
+            "expected my-lib version 2.0.1, got:\n{package_json}"
+        );
+
+        let rust_toml =
+            fs::read_to_string(workspace.path().join("crates/my-rust-crate/Cargo.toml"))
+                .expect("failed to read my-rust-crate Cargo.toml");
+        assert!(
+            rust_toml.contains("version = \"1.0.1\""),
+            "expected my-rust-crate auto-bumped to 1.0.1, got:\n{rust_toml}"
+        );
+
+        let upstream_json = fs::read_to_string(
+            workspace
+                .path()
+                .join("crates/my-rust-crate/src/upstream_version.json"),
+        )
+        .expect("failed to read upstream_version.json");
+        assert!(
+            upstream_json.contains("\"version\": \"2.0.1\"")
+                || upstream_json.contains("\"version\":\"2.0.1\""),
+            "expected upstream_version.json version field updated to 2.0.1, got:\n{upstream_json}"
+        );
+    }
+
+    #[test]
+    fn validate_unknown_dependency_errors() {
+        let workspace = create_workspace_with_unknown_dependency();
+        init_git_repo(&workspace);
+        git_add_and_commit(&workspace, "Initial commit");
+
+        write_changeset(
+            &workspace,
+            "some-change.md",
+            "crate-a",
+            "patch",
+            "Some change",
+        );
+        git_add_and_commit(&workspace, "Add changeset");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("release")
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("unknown-pkg"));
+    }
+}
+
+mod dependencies_cli_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_cli_add_list_remove() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "list",
+                "--package",
+                "my-helm-chart",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("crate-a"));
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "remove",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Removed version-tracking dependency"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            !cargo_toml.contains("crate-a"),
+            "expected crate-a dependency to be removed from Cargo.toml, got:\n{cargo_toml}"
+        );
     }
 }

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -8,8 +8,8 @@ use predicates::str::contains;
 use common::changesets::write_changeset;
 use common::git::{git_add_and_commit, init_git_repo};
 use common::workspaces::{
-    add_helm_chart_config, create_single_crate_workspace, create_workspace_with_helm_chart,
-    create_workspace_with_unknown_dependency,
+    add_helm_chart_config, add_helm_chart_config_with_three_deps, create_single_crate_workspace,
+    create_workspace_with_helm_chart, create_workspace_with_unknown_dependency,
     create_workspace_with_version_tracking_additional_to_cargo,
     create_workspace_with_version_tracking_cargo_to_additional,
 };
@@ -533,5 +533,296 @@ mod dependencies_cli_tests {
             !cargo_toml.contains("crate-a"),
             "expected crate-a dependency to be removed from Cargo.toml, got:\n{cargo_toml}"
         );
+    }
+}
+
+mod dependencies_advanced_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_add_rejects_invalid_manifest_path() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "path/that/does/not/exist.json",
+                "--manifest-format",
+                "json",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        // The CLI does not validate manifest file existence at add time;
+        // it just writes the config. Errors surface at release time.
+        // Verify the config was written even with a nonexistent path.
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains("path/that/does/not/exist.json"),
+            "expected the invalid path to be stored in config, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn dependencies_add_rejects_unknown_package() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "totally-unknown-pkg",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .failure()
+            .stderr(contains("not found"));
+    }
+
+    #[test]
+    fn dependencies_add_rejects_duplicate_dependency() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        // The CLI does not reject duplicate dependency declarations at add time;
+        // duplicates are detected during release validation.
+        // Verify the second add also succeeds at the CLI level.
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "betaVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        let count = cargo_toml.matches("crate-a").count();
+        assert!(
+            count >= 2,
+            "expected at least two crate-a references (duplicate), got {count} in:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn dependencies_remove_one_of_many() {
+        let workspace = create_workspace_with_helm_chart();
+
+        fs::write(
+            workspace.path().join("charts/my-chart/Chart.yaml"),
+            "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nalphaVersion: \"1.0.0\"\nbetaVersion: \"1.0.0\"\ngammaVersion: \"1.0.0\"\n",
+        )
+        .expect("failed to write Chart.yaml");
+
+        add_helm_chart_config_with_three_deps(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "remove",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "dep-beta",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Removed version-tracking dependency"));
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            !cargo_toml.contains("dep-beta"),
+            "expected dep-beta removed from Cargo.toml, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains("dep-alpha"),
+            "expected dep-alpha to remain in Cargo.toml, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains("dep-gamma"),
+            "expected dep-gamma to remain in Cargo.toml, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn dependencies_list_shows_manifest_info() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "list",
+                "--package",
+                "my-helm-chart",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("crate-a"))
+            .stdout(contains("Chart.yaml"))
+            .stdout(contains("yaml"))
+            .stdout(contains("appVersion"));
+    }
+}
+
+mod help_and_ux_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_subcommand_shows_in_additional_packages_help() {
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "--help"])
+            .assert()
+            .success()
+            .stdout(contains("dependencies"));
+    }
+
+    #[test]
+    fn dependencies_add_shows_success_message() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+    }
+
+    #[test]
+    fn dependencies_remove_shows_success_message() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "remove",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Removed version-tracking dependency"));
     }
 }

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -29,7 +29,7 @@ mod add_tests {
                 "charts/my-chart/Chart.yaml",
                 "--manifest-format",
                 "yaml",
-                "--version-path",
+                "--version-field-path",
                 "version",
             ])
             .current_dir(dir.path())
@@ -41,7 +41,7 @@ mod add_tests {
             fs::read_to_string(dir.path().join("Cargo.toml")).expect("read Cargo.toml");
         assert!(cargo_toml.contains(r#"name = "my-helm-chart""#));
         assert!(cargo_toml.contains(r#"format = "yaml""#));
-        assert!(cargo_toml.contains(r#"version-path = "version""#));
+        assert!(cargo_toml.contains(r#"version-field-path = "version""#));
     }
 
     #[test]
@@ -63,7 +63,7 @@ mod add_tests {
                 "charts/my-chart/Chart.yaml",
                 "--manifest-format",
                 "yaml",
-                "--version-path",
+                "--version-field-path",
                 "version",
             ])
             .current_dir(dir.path())
@@ -90,7 +90,7 @@ mod add_tests {
                 "charts/my-chart/Chart.yaml",
                 "--manifest-format",
                 "yaml",
-                "--version-path",
+                "--version-field-path",
                 "version",
             ])
             .current_dir(dir.path())
@@ -117,7 +117,7 @@ mod add_tests {
                 "nonexistent/Chart.yaml",
                 "--manifest-format",
                 "yaml",
-                "--version-path",
+                "--version-field-path",
                 "version",
             ])
             .current_dir(dir.path())
@@ -143,7 +143,7 @@ mod add_tests {
                 "charts/my-chart/Chart.yaml",
                 "--manifest-format",
                 "yaml",
-                "--version-path",
+                "--version-field-path",
                 "version",
             ])
             .current_dir(dir.path())
@@ -285,7 +285,7 @@ mod workspace_rejection_tests {
                 "Cargo.toml",
                 "--manifest-format",
                 "toml",
-                "--version-path",
+                "--version-field-path",
                 "package.version",
                 "--influence",
                 "**",

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -1060,3 +1060,548 @@ mod help_and_ux_tests {
             .stdout(contains("Removed version-tracking dependency"));
     }
 }
+
+#[cfg(not(windows))]
+mod interactive_dependencies_tests {
+    use common::terminal_session::TerminalSession;
+    use indoc::indoc;
+
+    use super::*;
+
+    // --- dependencies add ---
+
+    #[test]
+    fn interactive_dep_add_shows_owner_package_menu() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu rendered",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+    }
+
+    #[test]
+    fn interactive_dep_add_cancel_on_owner_exits_cleanly() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+        let cargo_toml_before =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu before cancel",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+        session.assert_screen("clean exit after cancel", "");
+
+        let cargo_toml_after =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert_eq!(
+            cargo_toml_before, cargo_toml_after,
+            "Cargo.toml must not be modified after cancellation"
+        );
+    }
+
+    #[test]
+    fn interactive_dep_add_cancel_on_dependency_exits_cleanly() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+        let cargo_toml_before =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu before selecting",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("Select the dependency to track");
+        session.assert_screen(
+            "dep menu after owner selected",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track:
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+
+        let cargo_toml_after =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert_eq!(
+            cargo_toml_before, cargo_toml_after,
+            "Cargo.toml must not be modified after cancellation on dependency menu"
+        );
+    }
+
+    #[test]
+    fn interactive_dep_add_full_flow() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu rendered",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("Select the dependency to track");
+        session.assert_screen(
+            "dependency menu after selecting crate owner",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track:
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("version manifest file");
+        session.assert_screen(
+            "manifest path prompt has no default for crate owner",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track: my-helm-chart (additional: charts/my-chart)
+                Path to version manifest file:
+            "},
+        );
+        session.type_line("charts/my-chart/Chart.yaml");
+        session.wait_for("Manifest format");
+        session.assert_screen(
+            "manifest format menu with yaml auto-detected",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track: my-helm-chart (additional: charts/my-chart)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format:
+                  toml
+                > yaml
+                  json
+            "},
+        );
+        session.confirm();
+        session.wait_for("version field");
+        session.assert_screen(
+            "version field prompt after format confirmed",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track: my-helm-chart (additional: charts/my-chart)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format: yaml
+                Path to version field in manifest (e.g. 'version' or 'info.version'):
+            "},
+        );
+        session.type_line("appVersion");
+        session.wait_for("Added version-tracking dependency");
+        session.wait_for_exit();
+        session.assert_screen(
+            "full flow complete",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track: my-helm-chart (additional: charts/my-chart)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format: yaml
+                Path to version field in manifest (e.g. 'version' or 'info.version'): appVersion
+                Added version-tracking dependency 'my-helm-chart' to package 'crate-a'
+            "},
+        );
+
+        let cargo_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("read crate-a Cargo.toml");
+        assert!(
+            cargo_toml.contains(r#"dependency-name = "my-helm-chart""#),
+            "expected dependency-name stored, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains(r#"file-path = "charts/my-chart/Chart.yaml""#),
+            "expected manifest file-path stored, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains(r#"format = "yaml""#),
+            "expected auto-detected yaml format stored, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains(r#"version-field-path = "appVersion""#),
+            "expected version-field-path stored, got:\n{cargo_toml}"
+        );
+    }
+
+    #[test]
+    fn interactive_dep_add_self_filter() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu before selecting",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("Select the dependency to track");
+        session.assert_screen(
+            "dep menu filters out owner",
+            indoc! {"
+                Select the owner package: crate-a (crate)
+                Select the dependency to track:
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+    }
+
+    #[test]
+    fn interactive_dep_add_defaults_manifest_for_additional_package_owner() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        session.wait_for("Select the owner package");
+        session.assert_screen(
+            "owner menu rendered",
+            indoc! {"
+                Select the owner package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(1);
+        session.wait_for("Select the dependency to track");
+        session.assert_screen(
+            "dependency menu after selecting additional package owner",
+            indoc! {"
+                Select the owner package: my-helm-chart (additional: charts/my-chart)
+                Select the dependency to track:
+                  crate-a (crate)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("version manifest file");
+        session.assert_screen(
+            "manifest path prompt shows default from additional package",
+            indoc! {"
+                Select the owner package: my-helm-chart (additional: charts/my-chart)
+                Select the dependency to track: crate-a (crate)
+                Path to version manifest file [charts/my-chart/Chart.yaml]:
+            "},
+        );
+        session.confirm();
+        session.wait_for("Manifest format");
+        session.assert_screen(
+            "manifest format menu with yaml auto-detected from default",
+            indoc! {"
+                Select the owner package: my-helm-chart (additional: charts/my-chart)
+                Select the dependency to track: crate-a (crate)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format:
+                  toml
+                > yaml
+                  json
+            "},
+        );
+        session.confirm();
+        session.wait_for("version field");
+        session.assert_screen(
+            "version field prompt after format confirmed",
+            indoc! {"
+                Select the owner package: my-helm-chart (additional: charts/my-chart)
+                Select the dependency to track: crate-a (crate)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format: yaml
+                Path to version field in manifest (e.g. 'version' or 'info.version'):
+            "},
+        );
+        session.type_line("appVersion");
+        session.wait_for("Added version-tracking dependency");
+        session.wait_for_exit();
+        session.assert_screen(
+            "full flow with default manifest complete",
+            indoc! {"
+                Select the owner package: my-helm-chart (additional: charts/my-chart)
+                Select the dependency to track: crate-a (crate)
+                Path to version manifest file: charts/my-chart/Chart.yaml
+                Manifest format: yaml
+                Path to version field in manifest (e.g. 'version' or 'info.version'): appVersion
+                Added version-tracking dependency 'crate-a' to package 'my-helm-chart'
+            "},
+        );
+    }
+
+    // --- dependencies remove ---
+
+    #[test]
+    fn interactive_dep_remove_shows_package_menu() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+
+        let mut session = TerminalSession::spawn(
+            &workspace,
+            &["additional-packages", "dependencies", "remove"],
+        );
+        session.wait_for("Select package");
+        session.assert_screen(
+            "remove package menu",
+            indoc! {"
+                Select package:
+                  my-rust-crate (crate)
+                  my-helm-chart (additional: charts)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+    }
+
+    #[test]
+    fn interactive_dep_remove_cancel_exits_cleanly() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+        let cargo_toml_before =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+
+        let mut session = TerminalSession::spawn(
+            &workspace,
+            &["additional-packages", "dependencies", "remove"],
+        );
+        session.wait_for("Select package");
+        session.assert_screen(
+            "remove package menu before cancel",
+            indoc! {"
+                Select package:
+                  my-rust-crate (crate)
+                  my-helm-chart (additional: charts)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+        session.assert_screen("clean exit after remove cancel", "");
+
+        let cargo_toml_after =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert_eq!(
+            cargo_toml_before, cargo_toml_after,
+            "Cargo.toml must not be modified after remove cancellation"
+        );
+    }
+
+    #[test]
+    fn interactive_dep_remove_no_deps_shows_message() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+        let cargo_toml_before =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+
+        let mut session = TerminalSession::spawn(
+            &workspace,
+            &["additional-packages", "dependencies", "remove"],
+        );
+        session.wait_for("Select package");
+        session.assert_screen(
+            "remove package menu",
+            indoc! {"
+                Select package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("No version-tracking dependencies configured");
+        session.wait_for_exit();
+        session.assert_screen(
+            "no deps message",
+            indoc! {"
+                Select package: crate-a (crate)
+                No version-tracking dependencies configured for 'crate-a'.
+            "},
+        );
+
+        let cargo_toml_after =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert_eq!(
+            cargo_toml_before, cargo_toml_after,
+            "Cargo.toml must not be modified when no deps exist"
+        );
+    }
+
+    #[test]
+    fn interactive_dep_remove_shows_registered_deps() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+
+        let mut session = TerminalSession::spawn(
+            &workspace,
+            &["additional-packages", "dependencies", "remove"],
+        );
+        session.wait_for("Select package");
+        session.assert_screen(
+            "remove package menu",
+            indoc! {"
+                Select package:
+                  my-rust-crate (crate)
+                  my-helm-chart (additional: charts)
+            "},
+        );
+        session.select_item(1);
+        session.wait_for("Select dependency to remove");
+        session.assert_screen(
+            "dep removal menu",
+            indoc! {"
+                Select package: my-helm-chart (additional: charts)
+                Select dependency to remove:
+                  my-rust-crate
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+    }
+
+    #[test]
+    fn interactive_dep_remove_full_flow() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+
+        let mut session = TerminalSession::spawn(
+            &workspace,
+            &["additional-packages", "dependencies", "remove"],
+        );
+        session.wait_for("Select package");
+        session.assert_screen(
+            "remove package menu",
+            indoc! {"
+                Select package:
+                  my-rust-crate (crate)
+                  my-helm-chart (additional: charts)
+            "},
+        );
+        session.select_item(1);
+        session.wait_for("Select dependency to remove");
+        session.assert_screen(
+            "dependency removal menu after selecting package",
+            indoc! {"
+                Select package: my-helm-chart (additional: charts)
+                Select dependency to remove:
+                  my-rust-crate
+            "},
+        );
+        session.select_item(0);
+        session.wait_for("Removed version-tracking dependency");
+        session.wait_for_exit();
+        session.assert_screen(
+            "removal complete",
+            indoc! {"
+                Select package: my-helm-chart (additional: charts)
+                Select dependency to remove: my-rust-crate
+                Removed version-tracking dependency 'my-rust-crate' from package 'my-helm-chart'
+            "},
+        );
+
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(!cargo_toml.contains("dependency-name = \"my-rust-crate\""));
+    }
+
+    // --- dependencies list ---
+
+    #[test]
+    fn interactive_dep_list_shows_package_menu() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        session.wait_for("Select package");
+        session.assert_screen(
+            "list package menu",
+            indoc! {"
+                Select package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+    }
+
+    #[test]
+    fn interactive_dep_list_cancel_exits_cleanly() {
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        session.wait_for("Select package");
+        session.assert_screen(
+            "list package menu before cancel",
+            indoc! {"
+                Select package:
+                  crate-a (crate)
+                  my-helm-chart (additional: charts/my-chart)
+            "},
+        );
+        session.cancel();
+        session.wait_for_exit();
+        session.assert_screen("clean exit after list cancel", "");
+    }
+
+    #[test]
+    fn interactive_dep_list_full_flow() {
+        let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+
+        let mut session =
+            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        session.wait_for("Select package");
+        session.assert_screen(
+            "list package menu",
+            indoc! {"
+                Select package:
+                  my-rust-crate (crate)
+                  my-helm-chart (additional: charts)
+            "},
+        );
+        session.select_item(1);
+        session.wait_for("my-rust-crate");
+        session.wait_for_exit();
+        session.assert_screen(
+            "list output",
+            indoc! {"
+                Select package: my-helm-chart (additional: charts)
+
+                Version-tracking dependencies:
+                  my-rust-crate -> charts/Chart.yaml [yaml]
+                    version field: appVersion
+            "},
+        );
+    }
+}

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -1,0 +1,322 @@
+mod common;
+
+use std::fs;
+
+use predicates::str::contains;
+
+use common::workspaces::{
+    add_helm_chart_config, create_single_crate_workspace, create_workspace_with_helm_chart,
+};
+
+mod add_tests {
+    use super::*;
+
+    #[test]
+    fn add_helm_chart_via_cli_flags() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "charts/my-chart/**",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-path",
+                "version",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .success()
+            .stdout(contains("Added additional package 'my-helm-chart'"));
+
+        let cargo_toml =
+            fs::read_to_string(dir.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(cargo_toml.contains(r#"name = "my-helm-chart""#));
+        assert!(cargo_toml.contains(r#"format = "yaml""#));
+        assert!(cargo_toml.contains(r#"version-path = "version""#));
+    }
+
+    #[test]
+    fn add_rejects_duplicate_name() {
+        let dir = create_workspace_with_helm_chart();
+        add_helm_chart_config(&dir);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "charts/my-chart/**",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-path",
+                "version",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("already exists"));
+    }
+
+    #[test]
+    fn add_rejects_name_collision_with_rust_crate() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "crate-a",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "charts/my-chart/**",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-path",
+                "version",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("already exists"));
+    }
+
+    #[test]
+    fn add_rejects_nonexistent_manifest_file() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "charts/my-chart/**",
+                "--manifest-file",
+                "nonexistent/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-path",
+                "version",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn add_rejects_invalid_glob_pattern() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/my-chart",
+                "--influence",
+                "[invalid",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-path",
+                "version",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure();
+    }
+}
+
+mod remove_tests {
+    use super::*;
+
+    #[test]
+    fn remove_helm_chart() {
+        let dir = create_workspace_with_helm_chart();
+        add_helm_chart_config(&dir);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "remove", "--name", "my-helm-chart"])
+            .current_dir(dir.path())
+            .assert()
+            .success()
+            .stdout(contains("Removed additional package 'my-helm-chart'"));
+
+        let cargo_toml =
+            fs::read_to_string(dir.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(!cargo_toml.contains("my-helm-chart"));
+    }
+
+    #[test]
+    fn remove_nonexistent_package() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "remove", "--name", "nonexistent"])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("not found"));
+    }
+}
+
+mod edit_tests {
+    use super::*;
+
+    #[test]
+    fn edit_updates_path() {
+        let dir = create_workspace_with_helm_chart();
+        add_helm_chart_config(&dir);
+
+        fs::create_dir_all(dir.path().join("charts/new-path"))
+            .expect("failed to create charts/new-path dir");
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "edit",
+                "--name",
+                "my-helm-chart",
+                "--path",
+                "charts/new-path",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .success()
+            .stdout(contains("Updated"));
+
+        let cargo_toml =
+            fs::read_to_string(dir.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(cargo_toml.contains(r#"path = "charts/new-path""#));
+    }
+
+    #[test]
+    fn edit_nonexistent_package() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "edit",
+                "--name",
+                "nonexistent",
+                "--manifest-format",
+                "yaml",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("not found"));
+    }
+}
+
+mod list_tests {
+    use super::*;
+
+    #[test]
+    fn list_shows_configured_packages() {
+        let dir = create_workspace_with_helm_chart();
+        add_helm_chart_config(&dir);
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "list"])
+            .current_dir(dir.path())
+            .assert()
+            .success()
+            .stdout(contains("my-helm-chart"))
+            .stdout(contains("charts/my-chart"))
+            .stdout(contains("yaml"));
+    }
+
+    #[test]
+    fn list_shows_empty_message_when_none_configured() {
+        let dir = create_workspace_with_helm_chart();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "list"])
+            .current_dir(dir.path())
+            .assert()
+            .success()
+            .stdout(contains("No additional packages configured"));
+    }
+}
+
+mod workspace_rejection_tests {
+    use super::*;
+
+    #[test]
+    fn add_rejects_single_package_project() {
+        let dir = create_single_crate_workspace();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "add",
+                "--name",
+                "x",
+                "--path",
+                ".",
+                "--manifest-file",
+                "Cargo.toml",
+                "--manifest-format",
+                "toml",
+                "--version-path",
+                "package.version",
+                "--influence",
+                "**",
+            ])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("workspace"));
+    }
+
+    #[test]
+    fn remove_rejects_single_package_project() {
+        let dir = create_single_crate_workspace();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "remove", "--name", "x"])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("workspace"));
+    }
+
+    #[test]
+    fn list_rejects_single_package_project() {
+        let dir = create_single_crate_workspace();
+
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["additional-packages", "list"])
+            .current_dir(dir.path())
+            .assert()
+            .failure()
+            .stderr(contains("workspace"));
+    }
+}

--- a/crates/cargo-changeset/tests/cargo_dispatch.rs
+++ b/crates/cargo-changeset/tests/cargo_dispatch.rs
@@ -1,41 +1,9 @@
+mod common;
+
 use std::fs;
-use std::process::Command;
 
+use common::git::{git_add_and_commit, init_git_repo};
 use tempfile::TempDir;
-
-fn init_git_repo(dir: &TempDir) {
-    Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to init git repo");
-
-    Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git email");
-
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git name");
-}
-
-fn git_add_and_commit(dir: &TempDir, message: &str) {
-    Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git add");
-
-    Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git commit");
-}
 
 fn create_single_package_project() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
@@ -46,8 +14,7 @@ fn create_single_package_project() -> TempDir {
 
     fs::write(
         dir.path().join("Cargo.toml"),
-        r#"
-[package]
+        r#"[package]
 name = "my-crate"
 version = "0.1.0"
 edition = "2021"

--- a/crates/cargo-changeset/tests/common/changesets.rs
+++ b/crates/cargo-changeset/tests/common/changesets.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)]
+
 use std::fs;
 
 use tempfile::TempDir;
 
-#[allow(dead_code)]
 pub fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
     let changeset_dir = dir.path().join(".changeset/changesets");
     fs::create_dir_all(&changeset_dir).expect("failed to create .changeset/changesets dir");
@@ -17,7 +18,6 @@ pub fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str,
     fs::write(changeset_dir.join(filename), content).expect("failed to write changeset");
 }
 
-#[allow(dead_code)]
 pub fn write_multi_changeset(
     dir: &TempDir,
     filename: &str,

--- a/crates/cargo-changeset/tests/common/changesets.rs
+++ b/crates/cargo-changeset/tests/common/changesets.rs
@@ -1,0 +1,36 @@
+use std::fs;
+
+use tempfile::TempDir;
+
+#[allow(dead_code)]
+pub fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
+    let changeset_dir = dir.path().join(".changeset/changesets");
+    fs::create_dir_all(&changeset_dir).expect("failed to create .changeset/changesets dir");
+    let content = format!(
+        r#"---
+"{package}": {bump}
+---
+
+{summary}
+"#
+    );
+    fs::write(changeset_dir.join(filename), content).expect("failed to write changeset");
+}
+
+#[allow(dead_code)]
+pub fn write_multi_changeset(
+    dir: &TempDir,
+    filename: &str,
+    entries: &[(&str, &str)],
+    summary: &str,
+) {
+    let changeset_dir = dir.path().join(".changeset/changesets");
+    fs::create_dir_all(&changeset_dir).expect("failed to create .changeset/changesets dir");
+    let front_matter: String = entries
+        .iter()
+        .map(|(pkg, bump)| format!("\"{pkg}\": {bump}\n"))
+        .collect();
+    let content = format!("---\n{front_matter}---\n\n{summary}\n");
+    fs::write(changeset_dir.join(filename), content)
+        .expect("failed to write multi-package changeset");
+}

--- a/crates/cargo-changeset/tests/common/git.rs
+++ b/crates/cargo-changeset/tests/common/git.rs
@@ -10,6 +10,11 @@ pub fn init_git_repo(dir: &TempDir) {
         .output()
         .expect("failed to init git repo");
     Command::new("git")
+        .args(["config", "core.autocrlf", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to configure git autocrlf");
+    Command::new("git")
         .args(["config", "user.email", "test@example.com"])
         .current_dir(dir.path())
         .output()

--- a/crates/cargo-changeset/tests/common/git.rs
+++ b/crates/cargo-changeset/tests/common/git.rs
@@ -1,0 +1,54 @@
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[allow(dead_code)]
+pub fn init_git_repo(dir: &TempDir) {
+    Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to init git repo");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to configure git email");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to configure git name");
+}
+
+#[allow(dead_code)]
+pub fn git_add_and_commit(dir: &TempDir, message: &str) {
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to git add");
+    Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to git commit");
+}
+
+#[allow(dead_code)]
+pub fn create_branch(dir: &TempDir, name: &str) {
+    Command::new("git")
+        .args(["checkout", "-b", name])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to create branch");
+}
+
+#[allow(dead_code)]
+pub fn create_tag(dir: &TempDir, tag_name: &str, message: &str) {
+    Command::new("git")
+        .args(["tag", "-a", tag_name, "-m", message])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to create tag");
+}

--- a/crates/cargo-changeset/tests/common/git.rs
+++ b/crates/cargo-changeset/tests/common/git.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)]
+
 use std::process::Command;
 
 use tempfile::TempDir;
 
-#[allow(dead_code)]
 pub fn init_git_repo(dir: &TempDir) {
     Command::new("git")
         .args(["init", "--initial-branch=main"])
@@ -26,7 +27,6 @@ pub fn init_git_repo(dir: &TempDir) {
         .expect("failed to configure git name");
 }
 
-#[allow(dead_code)]
 pub fn git_add_and_commit(dir: &TempDir, message: &str) {
     Command::new("git")
         .args(["add", "-A"])
@@ -40,7 +40,6 @@ pub fn git_add_and_commit(dir: &TempDir, message: &str) {
         .expect("failed to git commit");
 }
 
-#[allow(dead_code)]
 pub fn create_branch(dir: &TempDir, name: &str) {
     Command::new("git")
         .args(["checkout", "-b", name])
@@ -49,7 +48,6 @@ pub fn create_branch(dir: &TempDir, name: &str) {
         .expect("failed to create branch");
 }
 
-#[allow(dead_code)]
 pub fn create_tag(dir: &TempDir, tag_name: &str, message: &str) {
     Command::new("git")
         .args(["tag", "-a", tag_name, "-m", message])

--- a/crates/cargo-changeset/tests/common/mod.rs
+++ b/crates/cargo-changeset/tests/common/mod.rs
@@ -1,3 +1,5 @@
 pub mod changesets;
 pub mod git;
+#[cfg(not(windows))]
+pub mod terminal_session;
 pub mod workspaces;

--- a/crates/cargo-changeset/tests/common/mod.rs
+++ b/crates/cargo-changeset/tests/common/mod.rs
@@ -1,0 +1,3 @@
+pub mod changesets;
+pub mod git;
+pub mod workspaces;

--- a/crates/cargo-changeset/tests/common/terminal_session.rs
+++ b/crates/cargo-changeset/tests/common/terminal_session.rs
@@ -1,0 +1,134 @@
+#![allow(dead_code)]
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use expectrl::Expect;
+use expectrl::session::OsSession;
+use tempfile::TempDir;
+
+const ARROW_DOWN: &str = "\x1b[B";
+const ENTER: &str = "\r";
+const ESC: &str = "\x1b";
+const TIMEOUT: Duration = Duration::from_secs(30);
+const KEY_DELAY: Duration = Duration::from_millis(50);
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub struct TerminalSession {
+    pty: OsSession,
+    vt: vt100::Parser,
+}
+
+impl TerminalSession {
+    pub fn spawn(workspace: &TempDir, args: &[&str]) -> Self {
+        let bin_path = assert_cmd::cargo::cargo_bin!("cargo-changeset");
+        let mut cmd = Command::new(bin_path);
+        cmd.args(args);
+        cmd.current_dir(workspace.path());
+        cmd.env("CARGO_CHANGESET_FORCE_TTY", "1");
+        let pty = OsSession::spawn(cmd).expect("failed to spawn session");
+        Self {
+            pty,
+            vt: vt100::Parser::new(24, 120, 100),
+        }
+    }
+
+    pub fn poll(&mut self) {
+        let mut buf = [0u8; 4096];
+        loop {
+            match self.pty.try_read(&mut buf) {
+                Ok(n) if n > 0 => self.vt.process(&buf[..n]),
+                _ => break,
+            }
+        }
+    }
+
+    pub fn screen(&mut self) -> String {
+        self.poll();
+        let raw = self.vt.screen().contents();
+        raw.lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim_end_matches('\n')
+            .to_owned()
+    }
+
+    pub fn wait_for(&mut self, needle: &str) -> &mut Self {
+        let start = Instant::now();
+        loop {
+            self.poll();
+            if self.vt.screen().contents().contains(needle) {
+                return self;
+            }
+            if start.elapsed() > TIMEOUT {
+                panic!(
+                    "Timed out waiting for {needle:?}\nScreen:\n{}",
+                    self.screen()
+                );
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    }
+
+    pub fn wait_for_exit(&mut self) {
+        let start = Instant::now();
+        let mut buf = [0u8; 4096];
+        loop {
+            match self.pty.try_read(&mut buf) {
+                Ok(0) => return,
+                Ok(n) => self.vt.process(&buf[..n]),
+                Err(e) if e.kind() == std::io::ErrorKind::Other => return,
+                Err(_) => {
+                    if start.elapsed() > TIMEOUT {
+                        return;
+                    }
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+            }
+        }
+    }
+
+    pub fn assert_screen(&mut self, message: &str, expected: &str) {
+        let actual = self.screen();
+        let expected_trimmed = expected
+            .lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim_end_matches('\n')
+            .to_owned();
+        assert_eq!(actual, expected_trimmed, "{message}");
+    }
+
+    /// Select an item from a `dialoguer::Select` menu by index.
+    ///
+    /// `dialoguer::Select` without `.default()` starts with `sel = !0`.
+    /// The first Down press moves from `!0` to `0`, so we need `index + 1`
+    /// presses. Delays between presses ensure the `console` crate's
+    /// zero-timeout poll parses `\x1b[B` as ArrowDown rather than bare ESC.
+    pub fn select_item(&mut self, index: usize) -> &mut Self {
+        for _ in 0..=index {
+            self.pty.send(ARROW_DOWN).expect("send arrow-down key");
+            std::thread::sleep(KEY_DELAY);
+        }
+        self.pty.send(ENTER).expect("send enter key");
+        self
+    }
+
+    pub fn cancel(&mut self) -> &mut Self {
+        self.pty.send(ESC).expect("send escape key");
+        self
+    }
+
+    pub fn type_line(&mut self, text: &str) -> &mut Self {
+        self.pty.send(text).expect("send text to PTY");
+        self.pty.send(ENTER).expect("send enter key");
+        self
+    }
+
+    pub fn confirm(&mut self) -> &mut Self {
+        self.pty.send(ENTER).expect("send enter key");
+        self
+    }
+}

--- a/crates/cargo-changeset/tests/common/workspaces.rs
+++ b/crates/cargo-changeset/tests/common/workspaces.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -5,7 +7,6 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
-#[allow(dead_code)]
 pub fn create_single_crate_workspace() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
     fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
@@ -22,7 +23,6 @@ edition = "2021"
     dir
 }
 
-#[allow(dead_code)]
 pub fn create_virtual_workspace() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -65,7 +65,6 @@ edition = "2021"
     dir
 }
 
-#[allow(dead_code)]
 pub fn create_workspace_with_helm_chart() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -120,7 +119,6 @@ appVersion: "1.0.0"
     dir
 }
 
-#[allow(dead_code)]
 pub fn add_helm_chart_config(dir: &TempDir) {
     let mut file = OpenOptions::new()
         .append(true)
@@ -144,7 +142,6 @@ version-field-path = "version"
     .expect("failed to append helm chart config to Cargo.toml");
 }
 
-#[allow(dead_code)]
 pub fn create_workspace_with_additional_package() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -199,7 +196,6 @@ version: "2.0.0"
     dir
 }
 
-#[allow(dead_code)]
 pub fn append_to_cargo_toml(dir: &TempDir, content: &str) {
     let mut file = OpenOptions::new()
         .append(true)
@@ -209,7 +205,6 @@ pub fn append_to_cargo_toml(dir: &TempDir, content: &str) {
     write!(file, "{content}").expect("failed to append to Cargo.toml");
 }
 
-#[allow(dead_code)]
 pub fn create_workspace_with_version_tracking_additional_to_cargo() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -268,7 +263,6 @@ edition = "2021"
     dir
 }
 
-#[allow(dead_code)]
 pub fn create_workspace_with_version_tracking_cargo_to_additional() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -335,7 +329,6 @@ version-field-path = "version"
     dir
 }
 
-#[allow(dead_code)]
 pub fn create_workspace_with_unknown_dependency() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
 
@@ -400,7 +393,599 @@ edition = "2021"
     dir
 }
 
-#[allow(dead_code)]
+pub fn create_workspace_with_circular_version_tracking() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts"
+influence = ["charts/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+
+[[package.metadata.changeset.additional-package-dependencies]]
+dependency-name = "my-helm-chart"
+
+[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
+file-path = "crates/crate-a/src/chart_version.json"
+format = "json"
+version-field-path = "chartVersion"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    write_file(
+        dir.path(),
+        "crates/crate-a/src/chart_version.json",
+        r#"{"chartVersion": "1.0.0"}"#,
+    );
+
+    fs::write(
+        dir.path().join("charts/Chart.yaml"),
+        "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    dir
+}
+
+pub fn create_workspace_with_duplicate_dependency() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts"
+influence = ["charts/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/upstream.json"
+format = "json"
+version-field-path = "version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/Chart.yaml"),
+        "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    write_file(
+        dir.path(),
+        "charts/upstream.json",
+        r#"{"version": "1.0.0"}"#,
+    );
+
+    dir
+}
+
+pub fn create_workspace_with_cascade_chain() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("packages/pkg-b"))
+        .expect("failed to create packages/pkg-b dir");
+    fs::create_dir_all(dir.path().join("packages/pkg-c"))
+        .expect("failed to create packages/pkg-c dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-b"
+path = "packages/pkg-b"
+influence = ["packages/pkg-b/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "upstreamVersion"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-c"
+path = "packages/pkg-c"
+influence = ["packages/pkg-c/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/pkg-c/manifest.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "pkg-b"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/pkg-c/manifest.json"
+format = "json"
+version-field-path = "upstreamVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("packages/pkg-b/manifest.json"),
+        r#"{"name": "pkg-b", "version": "2.0.0", "upstreamVersion": "1.0.0"}"#,
+    )
+    .expect("failed to write pkg-b manifest.json");
+
+    fs::write(
+        dir.path().join("packages/pkg-c/manifest.json"),
+        r#"{"name": "pkg-c", "version": "3.0.0", "upstreamVersion": "2.0.0"}"#,
+    )
+    .expect("failed to write pkg-c manifest.json");
+
+    dir
+}
+
+pub fn create_workspace_with_json_extra_fields() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("packages/my-app"))
+        .expect("failed to create packages/my-app dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-app"
+path = "packages/my-app"
+influence = ["packages/my-app/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/my-app/app.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/my-app/app.json"
+format = "json"
+version-field-path = "appVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("packages/my-app/app.json"),
+        r#"{
+  "version": "0.1.0",
+  "appVersion": "1.0.0",
+  "description": "my app",
+  "extraField": 42,
+  "nested": {
+    "key": "value"
+  }
+}"#,
+    )
+    .expect("failed to write app.json");
+
+    dir
+}
+
+pub fn create_workspace_with_multiple_deps_on_same_crate() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
+    fs::create_dir_all(dir.path().join("config")).expect("failed to create config dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-b"
+path = "charts"
+influence = ["charts/**", "config/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "config/deps.json"
+format = "json"
+version-field-path = "crateA.version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/Chart.yaml"),
+        "apiVersion: v2\nname: pkg-b\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("config/deps.json"),
+        r#"{"crateA": {"version": "1.0.0"}}"#,
+    )
+    .expect("failed to write deps.json");
+
+    dir
+}
+
+pub fn create_workspace_with_invalid_version_field_path() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("packages/pkg-b"))
+        .expect("failed to create packages/pkg-b dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-b"
+path = "packages/pkg-b"
+influence = ["packages/pkg-b/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "nonexistent.deeply.nested.path"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("packages/pkg-b/manifest.json"),
+        r#"{"name": "pkg-b", "version": "1.0.0"}"#,
+    )
+    .expect("failed to write manifest.json");
+
+    dir
+}
+
+pub fn create_workspace_with_prerelease_dependency() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("packages/pkg-b"))
+        .expect("failed to create packages/pkg-b dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-b"
+path = "packages/pkg-b"
+influence = ["packages/pkg-b/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "upstreamVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0-alpha.1"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("packages/pkg-b/manifest.json"),
+        r#"{"name": "pkg-b", "version": "1.0.0", "upstreamVersion": "1.0.0-alpha.1"}"#,
+    )
+    .expect("failed to write manifest.json");
+
+    dir
+}
+
+pub fn create_workspace_with_deeply_nested_json_field() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("packages/pkg-b"))
+        .expect("failed to create packages/pkg-b dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "pkg-b"
+path = "packages/pkg-b"
+influence = ["packages/pkg-b/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "packages/pkg-b/manifest.json"
+format = "json"
+version-field-path = "metadata.versions.upstream_crate"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("packages/pkg-b/manifest.json"),
+        r#"{"name": "pkg-b", "version": "1.0.0", "metadata": {"versions": {"upstream_crate": "1.0.0"}}}"#,
+    )
+    .expect("failed to write manifest.json");
+
+    dir
+}
+
+pub fn add_helm_chart_config_with_three_deps(dir: &TempDir) {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("Cargo.toml"))
+        .expect("failed to open Cargo.toml for appending");
+
+    write!(
+        file,
+        r#"
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "dep-alpha"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "alphaVersion"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "dep-beta"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "betaVersion"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "dep-gamma"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "gammaVersion"
+"#
+    )
+    .expect("failed to append helm chart config with three deps to Cargo.toml");
+}
+
 fn write_file(base: &Path, relative: &str, content: &str) {
     let path = base.join(relative);
     if let Some(parent) = path.parent() {

--- a/crates/cargo-changeset/tests/common/workspaces.rs
+++ b/crates/cargo-changeset/tests/common/workspaces.rs
@@ -1,0 +1,199 @@
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use tempfile::TempDir;
+
+#[allow(dead_code)]
+pub fn create_single_crate_workspace() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[package]
+name = "test-crate"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write Cargo.toml");
+    fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
+    dir
+}
+
+#[allow(dead_code)]
+pub fn create_virtual_workspace() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/a/src")).expect("failed to create crate a dir");
+    fs::create_dir_all(dir.path().join("crates/b/src")).expect("failed to create crate b dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/a/src/lib.rs"), "").expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("crates/b/Cargo.toml"),
+        r#"[package]
+name = "crate-b"
+version = "0.2.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-b Cargo.toml");
+
+    fs::write(dir.path().join("crates/b/src/lib.rs"), "").expect("failed to write crate-b lib.rs");
+
+    dir
+}
+
+#[allow(dead_code)]
+pub fn create_workspace_with_helm_chart() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        r#"# Helm chart for my-chart
+apiVersion: v2
+name: my-chart
+description: A test Helm chart
+# This comment should survive release
+version: "2.0.0"
+appVersion: "1.0.0"
+"#,
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("charts/my-chart/values.yaml"),
+        "replicaCount: 1\n",
+    )
+    .expect("failed to write values.yaml");
+
+    dir
+}
+
+#[allow(dead_code)]
+pub fn add_helm_chart_config(dir: &TempDir) {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("Cargo.toml"))
+        .expect("failed to open Cargo.toml for appending");
+
+    write!(
+        file,
+        r#"
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-path = "version"
+"#
+    )
+    .expect("failed to append helm chart config to Cargo.toml");
+}
+
+#[allow(dead_code)]
+pub fn create_workspace_with_additional_package() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-path = "version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        r#"apiVersion: v2
+name: my-chart
+version: "2.0.0"
+"#,
+    )
+    .expect("failed to write Chart.yaml");
+
+    dir
+}

--- a/crates/cargo-changeset/tests/common/workspaces.rs
+++ b/crates/cargo-changeset/tests/common/workspaces.rs
@@ -7,6 +7,8 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
+use super::git::{git_add_and_commit, init_git_repo};
+
 pub fn create_single_crate_workspace() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
     fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
@@ -984,6 +986,237 @@ version-field-path = "gammaVersion"
 "#
     )
     .expect("failed to append helm chart config with three deps to Cargo.toml");
+}
+
+pub fn create_virtual_workspace_with_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    init_git_repo(&dir);
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate a dir");
+    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
+        .expect("failed to create crate b dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"
+[package]
+name = "crate-a"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("crates/crate-b/Cargo.toml"),
+        r#"
+[package]
+name = "crate-b"
+version = "0.2.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-b Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "")
+        .expect("failed to write crate-b lib.rs");
+
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+pub fn create_workspace_with_three_crates_and_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    init_git_repo(&dir);
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate a dir");
+    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
+        .expect("failed to create crate b dir");
+    fs::create_dir_all(dir.path().join("crates/crate-c/src"))
+        .expect("failed to create crate c dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    for (name, version) in [
+        ("crate-a", "0.1.0"),
+        ("crate-b", "0.2.0"),
+        ("crate-c", "0.3.0"),
+    ] {
+        fs::write(
+            dir.path().join(format!("crates/{name}/Cargo.toml")),
+            format!(
+                r#"
+[package]
+name = "{name}"
+version = "{version}"
+edition = "2021"
+"#
+            ),
+        )
+        .expect("failed to write Cargo.toml");
+
+        fs::write(dir.path().join(format!("crates/{name}/src/lib.rs")), "")
+            .expect("failed to write lib.rs");
+    }
+
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+pub fn create_workspace_with_helm_chart_and_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a src dir");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        r#"# Helm chart for my-chart
+apiVersion: v2
+name: my-chart
+description: A test Helm chart
+# This comment should survive release
+version: "2.0.0"
+appVersion: "1.0.0"
+"#,
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("charts/my-chart/values.yaml"),
+        "replicaCount: 1",
+    )
+    .expect("failed to write values.yaml");
+
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    add_helm_chart_config(&dir);
+
+    init_git_repo(&dir);
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+pub fn create_workspace_with_version_tracking_and_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a src dir");
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("charts/my-chart/values.yaml"),
+        "replicaCount: 1\n",
+    )
+    .expect("failed to write values.yaml");
+
+    init_git_repo(&dir);
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
 }
 
 fn write_file(base: &Path, relative: &str, content: &str) {

--- a/crates/cargo-changeset/tests/common/workspaces.rs
+++ b/crates/cargo-changeset/tests/common/workspaces.rs
@@ -137,7 +137,7 @@ influence = ["charts/my-chart/**"]
 [workspace.metadata.changeset.additional-packages.manifest]
 file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
-version-path = "version"
+version-field-path = "version"
 "#
     )
     .expect("failed to append helm chart config to Cargo.toml");
@@ -168,7 +168,7 @@ influence = ["charts/my-chart/**"]
 [workspace.metadata.changeset.additional-packages.manifest]
 file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
-version-path = "version"
+version-field-path = "version"
 "#,
     )
     .expect("failed to write workspace Cargo.toml");

--- a/crates/cargo-changeset/tests/common/workspaces.rs
+++ b/crates/cargo-changeset/tests/common/workspaces.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::Path;
 
 use tempfile::TempDir;
 
@@ -196,4 +197,214 @@ version: "2.0.0"
     .expect("failed to write Chart.yaml");
 
     dir
+}
+
+#[allow(dead_code)]
+pub fn append_to_cargo_toml(dir: &TempDir, content: &str) {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("Cargo.toml"))
+        .expect("failed to open Cargo.toml for appending");
+
+    write!(file, "{content}").expect("failed to append to Cargo.toml");
+}
+
+#[allow(dead_code)]
+pub fn create_workspace_with_version_tracking_additional_to_cargo() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/my-rust-crate/src"))
+        .expect("failed to create my-rust-crate dir");
+    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts"
+influence = ["charts/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "my-rust-crate"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/my-rust-crate/Cargo.toml"),
+        r#"[package]
+name = "my-rust-crate"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write my-rust-crate Cargo.toml");
+
+    fs::write(dir.path().join("crates/my-rust-crate/src/lib.rs"), "")
+        .expect("failed to write my-rust-crate lib.rs");
+
+    fs::write(
+        dir.path().join("charts/Chart.yaml"),
+        "apiVersion: v2\nname: my-helm-chart\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    dir
+}
+
+#[allow(dead_code)]
+pub fn create_workspace_with_version_tracking_cargo_to_additional() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/my-rust-crate/src"))
+        .expect("failed to create my-rust-crate dir");
+    fs::create_dir_all(dir.path().join("packages/my-lib"))
+        .expect("failed to create packages/my-lib dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-lib"
+path = "packages/my-lib"
+influence = ["packages/my-lib/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "packages/my-lib/package.json"
+format = "json"
+version-field-path = "version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/my-rust-crate/Cargo.toml"),
+        r#"[package]
+name = "my-rust-crate"
+version = "1.0.0"
+edition = "2021"
+
+[[package.metadata.changeset.additional-package-dependencies]]
+dependency-name = "my-lib"
+
+[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
+file-path = "crates/my-rust-crate/src/upstream_version.json"
+format = "json"
+version-field-path = "version"
+"#,
+    )
+    .expect("failed to write my-rust-crate Cargo.toml");
+
+    fs::write(dir.path().join("crates/my-rust-crate/src/lib.rs"), "")
+        .expect("failed to write my-rust-crate lib.rs");
+
+    fs::write(
+        dir.path().join("packages/my-lib/package.json"),
+        r#"{"name": "my-lib", "version": "2.0.0"}"#,
+    )
+    .expect("failed to write package.json");
+
+    fs::write(
+        dir.path()
+            .join("crates/my-rust-crate/src/upstream_version.json"),
+        r#"{"version": "2.0.0"}"#,
+    )
+    .expect("failed to write upstream_version.json");
+
+    dir
+}
+
+#[allow(dead_code)]
+pub fn create_workspace_with_unknown_dependency() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a dir");
+    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-chart"
+path = "charts"
+influence = ["charts/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "unknown-pkg"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/upstream.json"
+format = "json"
+version-field-path = "version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/Chart.yaml"),
+        "apiVersion: v2\nname: my-chart\nversion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    write_file(
+        dir.path(),
+        "charts/upstream.json",
+        r#"{"version": "1.0.0"}"#,
+    );
+
+    dir
+}
+
+#[allow(dead_code)]
+fn write_file(base: &Path, relative: &str, content: &str) {
+    let path = base.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create parent dirs");
+    }
+    fs::write(&path, content).expect("failed to write file");
 }

--- a/crates/cargo-changeset/tests/init_command.rs
+++ b/crates/cargo-changeset/tests/init_command.rs
@@ -1,50 +1,11 @@
+mod common;
+
 use std::fs;
-use std::process::Command;
 
 use predicates::str::contains;
 use tempfile::TempDir;
 
-fn init_git_repo(dir: &TempDir) {
-    Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to init git repo");
-
-    Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git email");
-
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git name");
-}
-
-fn git_add_and_commit(dir: &TempDir, message: &str) {
-    Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git add");
-
-    Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git commit");
-}
-
-fn create_branch(dir: &TempDir, name: &str) {
-    Command::new("git")
-        .args(["checkout", "-b", name])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to create branch");
-}
+use common::git::{create_branch, git_add_and_commit, init_git_repo};
 
 fn setup_single_package() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");

--- a/crates/cargo-changeset/tests/integrated_workflow.rs
+++ b/crates/cargo-changeset/tests/integrated_workflow.rs
@@ -1,0 +1,238 @@
+mod common;
+
+use std::fs;
+use std::process::Command;
+
+use predicates::str::contains;
+
+use common::changesets::write_changeset;
+use common::git::{create_branch, git_add_and_commit, init_git_repo};
+use common::workspaces::{add_helm_chart_config, create_workspace_with_helm_chart};
+
+mod additional_packages {
+    use super::*;
+
+    #[test]
+    fn helm_chart_depending_on_crate_add_verify_changeset_status_release() {
+        // Step 1: Set up workspace with git and lockfile
+        let workspace = create_workspace_with_helm_chart();
+        add_helm_chart_config(&workspace);
+        init_git_repo(&workspace);
+
+        let lockfile_output = Command::new("cargo")
+            .args(["generate-lockfile"])
+            .current_dir(workspace.path())
+            .output()
+            .expect("failed to run cargo generate-lockfile");
+        assert!(
+            lockfile_output.status.success(),
+            "cargo generate-lockfile failed: {}",
+            String::from_utf8_lossy(&lockfile_output.stderr)
+        );
+
+        git_add_and_commit(&workspace, "Initial commit");
+
+        // Step 2: Create feature branch
+        create_branch(&workspace, "feature");
+
+        // Step 3: Assert crate-a starts at version 1.0.0
+        let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("failed to read crate-a Cargo.toml");
+        assert!(
+            crate_a_toml.contains("version = \"1.0.0\""),
+            "expected crate-a version 1.0.0, got:\n{crate_a_toml}"
+        );
+
+        // Step 4: Assert Chart.yaml starts at version 2.0.0 with appVersion 1.0.0
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+            .expect("failed to read Chart.yaml");
+        assert!(
+            chart_yaml.contains("version: \"2.0.0\""),
+            "expected Chart.yaml version 2.0.0, got:\n{chart_yaml}"
+        );
+        assert!(
+            chart_yaml.contains("appVersion: \"1.0.0\""),
+            "expected Chart.yaml appVersion 1.0.0, got:\n{chart_yaml}"
+        );
+
+        // Step 5: Add version-tracking dependency from my-helm-chart to crate-a
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args([
+                "additional-packages",
+                "dependencies",
+                "add",
+                "--package",
+                "my-helm-chart",
+                "--dependency",
+                "crate-a",
+                "--manifest-file",
+                "charts/my-chart/Chart.yaml",
+                "--manifest-format",
+                "yaml",
+                "--version-field-path",
+                "appVersion",
+            ])
+            .current_dir(workspace.path())
+            .assert()
+            .success()
+            .stdout(contains("Added version-tracking dependency"));
+
+        // Step 6: Assert workspace Cargo.toml now contains the dependency config
+        let cargo_toml =
+            fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
+        assert!(
+            cargo_toml.contains("dependency-name = \"crate-a\""),
+            "expected dependency-name = \"crate-a\" in Cargo.toml, got:\n{cargo_toml}"
+        );
+        assert!(
+            cargo_toml.contains("version-field-path = \"appVersion\""),
+            "expected version-field-path = \"appVersion\" in Cargo.toml, got:\n{cargo_toml}"
+        );
+
+        // Step 7: Assert crate-a Cargo.toml unchanged
+        let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("failed to read crate-a Cargo.toml");
+        assert!(
+            crate_a_toml.contains("version = \"1.0.0\""),
+            "expected crate-a still at 1.0.0, got:\n{crate_a_toml}"
+        );
+
+        // Step 8: Assert Chart.yaml unchanged
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+            .expect("failed to read Chart.yaml");
+        assert!(
+            chart_yaml.contains("version: \"2.0.0\""),
+            "expected Chart.yaml still at 2.0.0, got:\n{chart_yaml}"
+        );
+        assert!(
+            chart_yaml.contains("appVersion: \"1.0.0\""),
+            "expected Chart.yaml appVersion still 1.0.0, got:\n{chart_yaml}"
+        );
+
+        // Step 9: Modify crate-a source
+        fs::write(
+            workspace.path().join("crates/crate-a/src/lib.rs"),
+            "pub fn new_feature() {}\n",
+        )
+        .expect("failed to write lib.rs");
+
+        // Step 10: Commit the change
+        git_add_and_commit(&workspace, "Add feature");
+
+        // Step 11: Verify fails (no changeset coverage)
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["verify", "--base", "main"])
+            .current_dir(workspace.path())
+            .assert()
+            .failure();
+
+        // Step 12: Assert all manifests unchanged after verify
+        let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("failed to read crate-a Cargo.toml");
+        assert!(
+            crate_a_toml.contains("version = \"1.0.0\""),
+            "verify should not change crate-a version, got:\n{crate_a_toml}"
+        );
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+            .expect("failed to read Chart.yaml");
+        assert!(
+            chart_yaml.contains("version: \"2.0.0\""),
+            "verify should not change Chart.yaml version, got:\n{chart_yaml}"
+        );
+
+        // Step 13: Add a changeset for crate-a
+        write_changeset(
+            &workspace,
+            "bump-crate-a.md",
+            "crate-a",
+            "patch",
+            "Add new feature",
+        );
+
+        // Step 14: Commit the changeset
+        git_add_and_commit(&workspace, "Add changeset");
+
+        // Step 15: Verify now passes
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .args(["verify", "--base", "main"])
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        // Step 16: Assert changeset file exists
+        assert!(
+            workspace
+                .path()
+                .join(".changeset/changesets/bump-crate-a.md")
+                .exists(),
+            "changeset file should exist before release"
+        );
+
+        // Step 17: Assert all manifests still unchanged
+        let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("failed to read crate-a Cargo.toml");
+        assert!(
+            crate_a_toml.contains("version = \"1.0.0\""),
+            "manifests should not change before release, got:\n{crate_a_toml}"
+        );
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+            .expect("failed to read Chart.yaml");
+        assert!(
+            chart_yaml.contains("version: \"2.0.0\""),
+            "Chart.yaml should not change before release, got:\n{chart_yaml}"
+        );
+
+        // Step 18: Status shows projected versions
+        let status_output = assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("status")
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        let status_stdout = String::from_utf8_lossy(&status_output.get_output().stdout);
+        assert!(
+            status_stdout.contains("crate-a: 1.0.0 -> 1.0.1"),
+            "expected crate-a projected release in status output, got:\n{status_stdout}"
+        );
+        assert!(
+            status_stdout.contains("my-helm-chart"),
+            "expected my-helm-chart in status output, got:\n{status_stdout}"
+        );
+
+        // Step 19: Release
+        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+            .arg("release")
+            .current_dir(workspace.path())
+            .assert()
+            .success();
+
+        // Step 20: Assert crate-a bumped to 1.0.1
+        let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+            .expect("failed to read crate-a Cargo.toml after release");
+        assert!(
+            crate_a_toml.contains("version = \"1.0.1\""),
+            "expected crate-a version 1.0.1 after release, got:\n{crate_a_toml}"
+        );
+
+        // Step 21: Assert Chart.yaml auto-patched and appVersion tracked
+        let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+            .expect("failed to read Chart.yaml after release");
+        assert!(
+            chart_yaml.contains(r"version: 2.0.1"),
+            "expected Chart.yaml auto-patched to 2.0.1, got:\n{chart_yaml}"
+        );
+        assert!(
+            chart_yaml.contains(r"appVersion: 1.0.1"),
+            "expected appVersion tracked to 1.0.1, got:\n{chart_yaml}"
+        );
+
+        // Step 22: Assert changeset file consumed
+        assert!(
+            !workspace
+                .path()
+                .join(".changeset/changesets/bump-crate-a.md")
+                .exists(),
+            "changeset file should be consumed after release"
+        );
+    }
+}

--- a/crates/cargo-changeset/tests/manage_integration.rs
+++ b/crates/cargo-changeset/tests/manage_integration.rs
@@ -1,52 +1,11 @@
+mod common;
+
 use std::fs;
 
 use predicates::str::contains;
 use tempfile::TempDir;
 
-fn create_virtual_workspace() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/a/src")).expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/b/src")).expect("failed to create crate b dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/a/Cargo.toml"),
-        r#"
-[package]
-name = "crate-a"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/a/src/lib.rs"), "").expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/b/Cargo.toml"),
-        r#"
-[package]
-name = "crate-b"
-version = "0.2.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-b Cargo.toml");
-
-    fs::write(dir.path().join("crates/b/src/lib.rs"), "").expect("failed to write crate-b lib.rs");
-
-    dir
-}
+use common::workspaces::create_virtual_workspace;
 
 fn create_workspace_with_stable_version() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");

--- a/crates/cargo-changeset/tests/release_command.rs
+++ b/crates/cargo-changeset/tests/release_command.rs
@@ -1,0 +1,193 @@
+mod common;
+
+use std::fs;
+use std::process::Command;
+
+use common::changesets::{write_changeset, write_multi_changeset};
+use common::git::{git_add_and_commit, init_git_repo};
+use common::workspaces::{add_helm_chart_config, create_workspace_with_helm_chart};
+
+#[test]
+fn release_bumps_chart_yaml_version_and_preserves_inline_comments() {
+    let workspace = create_workspace_with_helm_chart();
+    init_git_repo(&workspace);
+    add_helm_chart_config(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    write_changeset(
+        &workspace,
+        "helm-feat.md",
+        "my-helm-chart",
+        "minor",
+        "Add feature",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+
+    assert!(
+        chart_yaml.contains("version: 2.1.0"),
+        "expected bumped version 2.1.0 in Chart.yaml, got:\n{chart_yaml}"
+    );
+    assert!(
+        chart_yaml.contains("# This comment should survive release"),
+        "expected inline comment to be preserved in Chart.yaml, got:\n{chart_yaml}"
+    );
+
+    assert!(
+        !workspace
+            .path()
+            .join(".changeset/changesets/helm-feat.md")
+            .exists(),
+        "changeset file should have been consumed by release"
+    );
+}
+
+#[test]
+fn release_mixed_rust_and_helm_chart() {
+    let workspace = create_workspace_with_helm_chart();
+    init_git_repo(&workspace);
+    add_helm_chart_config(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Add lockfile");
+
+    write_multi_changeset(
+        &workspace,
+        "mixed.md",
+        &[("crate-a", "patch"), ("my-helm-chart", "minor")],
+        "Mixed release",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+        .expect("failed to read crate-a Cargo.toml");
+    assert!(
+        crate_a_toml.contains("version = \"1.0.1\""),
+        "expected crate-a version 1.0.1, got:\n{crate_a_toml}"
+    );
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+    assert!(
+        chart_yaml.contains("version: 2.1.0"),
+        "expected Chart.yaml version 2.1.0, got:\n{chart_yaml}"
+    );
+}
+
+#[test]
+fn release_dry_run_does_not_modify_chart_yaml() {
+    let workspace = create_workspace_with_helm_chart();
+    init_git_repo(&workspace);
+    add_helm_chart_config(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    write_changeset(
+        &workspace,
+        "helm-feat.md",
+        "my-helm-chart",
+        "minor",
+        "Add feature",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .args(["release", "--dry-run"])
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+    assert!(
+        chart_yaml.contains("version: \"2.0.0\""),
+        "expected Chart.yaml version to remain 2.0.0 after dry-run, got:\n{chart_yaml}"
+    );
+}
+
+#[test]
+fn release_only_additional_package_no_rust_crates() {
+    let workspace = create_workspace_with_helm_chart();
+    init_git_repo(&workspace);
+    add_helm_chart_config(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    write_changeset(
+        &workspace,
+        "helm-only.md",
+        "my-helm-chart",
+        "patch",
+        "Fix chart configuration",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+    assert!(
+        chart_yaml.contains("version: 2.0.1"),
+        "expected patch-bumped version 2.0.1 in Chart.yaml, got:\n{chart_yaml}"
+    );
+
+    let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+        .expect("failed to read crate-a Cargo.toml");
+    assert!(
+        crate_a_toml.contains("version = \"1.0.0\""),
+        "expected crate-a version to remain 1.0.0, got:\n{crate_a_toml}"
+    );
+}
+
+#[test]
+fn release_major_bump_on_additional_package() {
+    let workspace = create_workspace_with_helm_chart();
+    init_git_repo(&workspace);
+    add_helm_chart_config(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    write_changeset(
+        &workspace,
+        "helm-major.md",
+        "my-helm-chart",
+        "major",
+        "Breaking chart API change",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+    assert!(
+        chart_yaml.contains("version: 3.0.0"),
+        "expected major-bumped version 3.0.0 in Chart.yaml, got:\n{chart_yaml}"
+    );
+}

--- a/crates/cargo-changeset/tests/release_command.rs
+++ b/crates/cargo-changeset/tests/release_command.rs
@@ -3,9 +3,19 @@ mod common;
 use std::fs;
 use std::process::Command;
 
+use predicates::str::is_match;
+
 use common::changesets::{write_changeset, write_multi_changeset};
 use common::git::{git_add_and_commit, init_git_repo};
-use common::workspaces::{add_helm_chart_config, create_workspace_with_helm_chart};
+use common::workspaces::{
+    add_helm_chart_config, create_workspace_with_cascade_chain,
+    create_workspace_with_circular_version_tracking,
+    create_workspace_with_deeply_nested_json_field, create_workspace_with_duplicate_dependency,
+    create_workspace_with_helm_chart, create_workspace_with_invalid_version_field_path,
+    create_workspace_with_json_extra_fields, create_workspace_with_multiple_deps_on_same_crate,
+    create_workspace_with_prerelease_dependency,
+    create_workspace_with_version_tracking_additional_to_cargo,
+};
 
 #[test]
 fn release_bumps_chart_yaml_version_and_preserves_inline_comments() {
@@ -189,5 +199,482 @@ fn release_major_bump_on_additional_package() {
     assert!(
         chart_yaml.contains("version: 3.0.0"),
         "expected major-bumped version 3.0.0 in Chart.yaml, got:\n{chart_yaml}"
+    );
+}
+
+#[test]
+fn release_dry_run_does_not_update_version_tracking_manifests() {
+    let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-rust.md",
+        "my-rust-crate",
+        "patch",
+        "Fix a bug",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    let chart_before = fs::read_to_string(workspace.path().join("charts/Chart.yaml"))
+        .expect("failed to read Chart.yaml before dry-run");
+    let rust_toml_before =
+        fs::read_to_string(workspace.path().join("crates/my-rust-crate/Cargo.toml"))
+            .expect("failed to read Cargo.toml before dry-run");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .args(["release", "--dry-run"])
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_after = fs::read_to_string(workspace.path().join("charts/Chart.yaml"))
+        .expect("failed to read Chart.yaml after dry-run");
+    let rust_toml_after =
+        fs::read_to_string(workspace.path().join("crates/my-rust-crate/Cargo.toml"))
+            .expect("failed to read Cargo.toml after dry-run");
+
+    assert_eq!(
+        chart_before, chart_after,
+        "Chart.yaml should not be modified by dry-run"
+    );
+    assert_eq!(
+        rust_toml_before, rust_toml_after,
+        "Cargo.toml should not be modified by dry-run"
+    );
+}
+
+#[test]
+fn release_detects_circular_dependency_fails_with_clear_error() {
+    let workspace = create_workspace_with_circular_version_tracking();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(&workspace, "bump-a.md", "crate-a", "patch", "Some fix");
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(is_match(r"(?i)circular").expect("valid regex"));
+}
+
+#[test]
+fn release_detects_duplicate_dependency_declarations() {
+    let workspace = create_workspace_with_duplicate_dependency();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(&workspace, "bump-a.md", "crate-a", "patch", "Some fix");
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(is_match(r"(?i)duplicate").expect("valid regex"));
+}
+
+#[test]
+fn release_dep_chain_cascading_auto_patch() {
+    let workspace = create_workspace_with_cascade_chain();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let crate_a_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+        .expect("failed to read crate-a Cargo.toml");
+    assert!(
+        crate_a_toml.contains("version = \"1.0.1\""),
+        "expected crate-a bumped to 1.0.1, got:\n{crate_a_toml}"
+    );
+
+    let pkg_b_manifest = fs::read_to_string(workspace.path().join("packages/pkg-b/manifest.json"))
+        .expect("failed to read pkg-b manifest.json");
+    assert!(
+        pkg_b_manifest.contains("\"version\": \"2.0.1\"")
+            || pkg_b_manifest.contains("\"version\":\"2.0.1\""),
+        "expected pkg-b auto-bumped to 2.0.1, got:\n{pkg_b_manifest}"
+    );
+    assert!(
+        pkg_b_manifest.contains("\"upstreamVersion\": \"1.0.1\"")
+            || pkg_b_manifest.contains("\"upstreamVersion\":\"1.0.1\""),
+        "expected pkg-b upstreamVersion updated to 1.0.1, got:\n{pkg_b_manifest}"
+    );
+
+    let pkg_c_manifest = fs::read_to_string(workspace.path().join("packages/pkg-c/manifest.json"))
+        .expect("failed to read pkg-c manifest.json");
+    assert!(
+        pkg_c_manifest.contains("\"version\": \"3.0.1\"")
+            || pkg_c_manifest.contains("\"version\":\"3.0.1\""),
+        "expected pkg-c auto-bumped to 3.0.1, got:\n{pkg_c_manifest}"
+    );
+    assert!(
+        pkg_c_manifest.contains("\"upstreamVersion\": \"2.0.1\"")
+            || pkg_c_manifest.contains("\"upstreamVersion\":\"2.0.1\""),
+        "expected pkg-c upstreamVersion updated to 2.0.1, got:\n{pkg_c_manifest}"
+    );
+}
+
+#[test]
+fn release_no_auto_patch_when_dependency_not_released() {
+    let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-chart.md",
+        "my-helm-chart",
+        "minor",
+        "Add chart feature",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let chart_yaml = fs::read_to_string(workspace.path().join("charts/Chart.yaml"))
+        .expect("failed to read Chart.yaml");
+    assert!(
+        chart_yaml.contains("version: 0.1.1"),
+        "expected my-helm-chart patched to 0.1.1, got:\n{chart_yaml}"
+    );
+    assert!(
+        chart_yaml.contains("appVersion: 1.0.0") || chart_yaml.contains("appVersion: \"1.0.0\""),
+        "expected appVersion to remain 1.0.0 since my-rust-crate was not released, got:\n{chart_yaml}"
+    );
+
+    let rust_toml = fs::read_to_string(workspace.path().join("crates/my-rust-crate/Cargo.toml"))
+        .expect("failed to read my-rust-crate Cargo.toml");
+    assert!(
+        rust_toml.contains("version = \"1.0.0\""),
+        "expected my-rust-crate to remain at 1.0.0, got:\n{rust_toml}"
+    );
+}
+
+#[test]
+fn release_preserves_structure_in_json_version_tracking_manifest() {
+    let workspace = create_workspace_with_json_extra_fields();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let app_json_content = fs::read_to_string(workspace.path().join("packages/my-app/app.json"))
+        .expect("failed to read app.json");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&app_json_content).expect("app.json should be valid JSON");
+
+    assert_eq!(
+        parsed.get("appVersion").and_then(|v| v.as_str()),
+        Some("1.0.1"),
+        "expected appVersion updated to 1.0.1, got:\n{app_json_content}"
+    );
+
+    assert_eq!(
+        parsed.get("description").and_then(|v| v.as_str()),
+        Some("my app"),
+        "expected description field preserved, got:\n{app_json_content}"
+    );
+
+    assert_eq!(
+        parsed.get("extraField").and_then(|v| v.as_i64()),
+        Some(42),
+        "expected extraField preserved, got:\n{app_json_content}"
+    );
+
+    let nested = parsed
+        .get("nested")
+        .expect("expected nested field to be present");
+    assert_eq!(
+        nested.get("key").and_then(|v| v.as_str()),
+        Some("value"),
+        "expected nested.key to be 'value', got:\n{app_json_content}"
+    );
+
+    assert_eq!(
+        parsed.get("version").and_then(|v| v.as_str()),
+        Some("0.1.1"),
+        "expected my-app version auto-patched to 0.1.1, got:\n{app_json_content}"
+    );
+}
+
+#[test]
+fn release_version_tracking_with_multiple_deps_on_same_package() {
+    let workspace = create_workspace_with_multiple_deps_on_same_crate();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    // The workspace declares duplicate dependency-name = "crate-a", which
+    // triggers the duplicate dependency validation at release time.
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(is_match(r"(?i)duplicate").expect("valid regex"));
+}
+
+#[test]
+fn release_invalid_version_field_path_fails_gracefully() {
+    let workspace = create_workspace_with_invalid_version_field_path();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(is_match(r"(?i)(not found|path|field)").expect("valid regex"));
+}
+
+#[test]
+fn release_version_tracking_with_prerelease_versions() {
+    let workspace = create_workspace_with_prerelease_dependency();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let rust_toml = fs::read_to_string(workspace.path().join("crates/crate-a/Cargo.toml"))
+        .expect("failed to read crate-a Cargo.toml");
+    // A patch bump on a prerelease version strips the prerelease tag:
+    // 1.0.0-alpha.1 + patch -> 1.0.0
+    assert!(
+        rust_toml.contains("version = \"1.0.0\""),
+        "expected crate-a version 1.0.0 (prerelease stripped), got:\n{rust_toml}"
+    );
+
+    let manifest_json = fs::read_to_string(workspace.path().join("packages/pkg-b/manifest.json"))
+        .expect("failed to read manifest.json");
+    assert!(
+        manifest_json.contains("\"1.0.0\""),
+        "expected tracking manifest upstreamVersion updated to 1.0.0, got:\n{manifest_json}"
+    );
+}
+
+#[test]
+fn release_version_tracking_deeply_nested_field_paths() {
+    let workspace = create_workspace_with_deeply_nested_json_field();
+    init_git_repo(&workspace);
+
+    let lockfile_output = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("failed to run cargo generate-lockfile");
+    assert!(
+        lockfile_output.status.success(),
+        "cargo generate-lockfile failed: {}",
+        String::from_utf8_lossy(&lockfile_output.stderr)
+    );
+
+    git_add_and_commit(&workspace, "Initial commit");
+
+    write_changeset(
+        &workspace,
+        "bump-a.md",
+        "crate-a",
+        "patch",
+        "Fix in crate-a",
+    );
+    git_add_and_commit(&workspace, "Add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("release")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let manifest_json = fs::read_to_string(workspace.path().join("packages/pkg-b/manifest.json"))
+        .expect("failed to read manifest.json");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&manifest_json).expect("manifest.json should be valid JSON");
+
+    let upstream_version = parsed
+        .get("metadata")
+        .and_then(|m| m.get("versions"))
+        .and_then(|v| v.get("upstream_crate"))
+        .and_then(|v| v.as_str());
+    assert_eq!(
+        upstream_version,
+        Some("1.0.1"),
+        "expected deeply nested upstream_crate version updated to 1.0.1, got:\n{manifest_json}"
     );
 }

--- a/crates/cargo-changeset/tests/release_lockfile.rs
+++ b/crates/cargo-changeset/tests/release_lockfile.rs
@@ -1,41 +1,12 @@
+mod common;
+
 use std::fs;
 use std::process::Command;
 
 use tempfile::TempDir;
 
-fn init_git_repo(dir: &TempDir) {
-    Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to init git repo");
-
-    Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git email");
-
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git name");
-}
-
-fn git_add_and_commit(dir: &TempDir, message: &str) {
-    Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git add");
-
-    Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git commit");
-}
+use common::changesets::write_changeset;
+use common::git::{git_add_and_commit, init_git_repo};
 
 fn lockfile_hash(dir: &TempDir) -> Vec<u8> {
     let output = Command::new("git")
@@ -45,22 +16,6 @@ fn lockfile_hash(dir: &TempDir) -> Vec<u8> {
         .expect("failed to hash Cargo.lock");
 
     output.stdout
-}
-
-fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
-    let content = format!(
-        r#"---
-"{package}": {bump}
----
-
-{summary}
-"#
-    );
-    fs::write(
-        dir.path().join(".changeset/changesets").join(filename),
-        content,
-    )
-    .expect("write changeset");
 }
 
 fn setup_workspace_with_dependency() -> TempDir {
@@ -126,19 +81,13 @@ crate-a = { workspace = true }
     dir
 }
 
-macro_rules! cargo_changeset {
-    () => {
-        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
-    };
-}
-
 #[test]
 fn release_lockfile_not_dirtied_by_cargo_check() {
     let workspace = setup_workspace_with_dependency();
     write_changeset(&workspace, "fix.md", "crate-a", "patch", "Fix a bug");
     git_add_and_commit(&workspace, "Add changeset");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()
@@ -172,7 +121,7 @@ fn release_lockfile_correct_after_minor_bump_with_workspace_dep() {
     write_changeset(&workspace, "feat.md", "crate-a", "minor", "Add a feature");
     git_add_and_commit(&workspace, "Add changeset");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()

--- a/crates/cargo-changeset/tests/saga_error_display.rs
+++ b/crates/cargo-changeset/tests/saga_error_display.rs
@@ -1,50 +1,12 @@
+mod common;
+
 use std::fs;
-use std::process::Command;
 
 use predicates::str::contains;
 use tempfile::TempDir;
 
-fn init_git_repo(dir: &TempDir) {
-    Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to init git repo");
-
-    Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git email");
-
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git name");
-}
-
-fn git_add_and_commit(dir: &TempDir, message: &str) {
-    Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git add");
-
-    Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git commit");
-}
-
-fn create_tag(dir: &TempDir, tag_name: &str, message: &str) {
-    Command::new("git")
-        .args(["tag", "-a", tag_name, "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to create tag");
-}
+use common::changesets::{write_changeset, write_multi_changeset};
+use common::git::{create_tag, git_add_and_commit, init_git_repo};
 
 fn create_single_package_with_git() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");
@@ -118,55 +80,6 @@ edition = "2021"
     dir
 }
 
-fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
-    let content = format!(
-        r#"---
-"{package}": {bump}
----
-
-{summary}
-"#
-    );
-    fs::write(
-        dir.path().join(".changeset/changesets").join(filename),
-        content,
-    )
-    .expect("write changeset");
-}
-
-fn write_multi_package_changeset(
-    dir: &TempDir,
-    filename: &str,
-    packages: &[(&str, &str)],
-    summary: &str,
-) {
-    let package_entries: String = packages
-        .iter()
-        .map(|(pkg, bump)| format!("\"{pkg}\": {bump}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let content = format!(
-        r#"---
-{package_entries}
----
-
-{summary}
-"#
-    );
-    fs::write(
-        dir.path().join(".changeset/changesets").join(filename),
-        content,
-    )
-    .expect("write changeset");
-}
-
-macro_rules! cargo_changeset {
-    () => {
-        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
-    };
-}
-
 #[test]
 fn release_saga_failure_shows_failed_step_and_rollback_message() {
     let workspace = create_single_package_with_git();
@@ -175,7 +88,7 @@ fn release_saga_failure_shows_failed_step_and_rollback_message() {
 
     create_tag(&workspace, "v1.0.1", "Pre-existing conflicting tag");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()
@@ -194,7 +107,7 @@ fn release_saga_failure_message_includes_step_name() {
 
     create_tag(&workspace, "v1.0.1", "Pre-existing conflicting tag");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()
@@ -210,7 +123,7 @@ fn release_saga_failure_with_rollback_restores_version_in_manifest() {
 
     create_tag(&workspace, "v1.0.1", "Pre-existing conflicting tag");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()
@@ -227,7 +140,7 @@ fn release_saga_failure_with_rollback_restores_version_in_manifest() {
 #[test]
 fn release_saga_failure_multi_package_shows_proper_error_format() {
     let workspace = create_workspace_with_two_crates();
-    write_multi_package_changeset(
+    write_multi_changeset(
         &workspace,
         "multi.md",
         &[("crate-a", "patch"), ("crate-b", "patch")],
@@ -241,7 +154,7 @@ fn release_saga_failure_multi_package_shows_proper_error_format() {
         "Pre-existing conflicting tag for crate-b",
     );
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()
@@ -258,7 +171,7 @@ fn release_saga_failure_error_includes_cause_chain() {
 
     create_tag(&workspace, "v1.0.1", "Pre-existing conflicting tag");
 
-    cargo_changeset!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("release")
         .current_dir(workspace.path())
         .assert()

--- a/crates/cargo-changeset/tests/status_command.rs
+++ b/crates/cargo-changeset/tests/status_command.rs
@@ -6,7 +6,10 @@ use predicates::str::contains;
 use tempfile::TempDir;
 
 use common::changesets::write_changeset;
-use common::workspaces::create_workspace_with_additional_package;
+use common::workspaces::{
+    create_workspace_with_additional_package,
+    create_workspace_with_version_tracking_additional_to_cargo,
+};
 
 fn create_single_package_project() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");
@@ -280,4 +283,51 @@ fn status_lists_additional_package_without_changeset() {
         .success()
         .stdout(contains("Packages without changesets:"))
         .stdout(contains("my-helm-chart (2.0.0)"));
+}
+
+#[test]
+fn status_shows_projected_auto_patch_for_version_tracking_deps() {
+    let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+    write_changeset(
+        &workspace,
+        "bump-rust.md",
+        "my-rust-crate",
+        "patch",
+        "Fix a bug",
+    );
+
+    let output = assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("status")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+
+    assert!(
+        stdout.contains("my-rust-crate: 1.0.0 -> 1.0.1"),
+        "expected my-rust-crate projected release in status output, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("my-helm-chart"),
+        "expected my-helm-chart (auto-patch dependent) in status output, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn status_untracked_dep_not_releasing_does_not_auto_patch() {
+    let workspace = create_workspace_with_version_tracking_additional_to_cargo();
+
+    let output = assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("status")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+
+    assert!(
+        !stdout.contains("my-helm-chart: 0.1.0 ->"),
+        "expected my-helm-chart NOT to have a projected release when its dependency is not releasing, got:\n{stdout}"
+    );
 }

--- a/crates/cargo-changeset/tests/status_command.rs
+++ b/crates/cargo-changeset/tests/status_command.rs
@@ -1,7 +1,12 @@
+mod common;
+
 use std::fs;
 
 use predicates::str::contains;
 use tempfile::TempDir;
+
+use common::changesets::write_changeset;
+use common::workspaces::create_workspace_with_additional_package;
 
 fn create_single_package_project() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");
@@ -101,33 +106,11 @@ edition.workspace = true
     dir
 }
 
-fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str, summary: &str) {
-    let content = format!(
-        r#"---
-"{package}": {bump}
----
-
-{summary}
-"#
-    );
-    fs::write(
-        dir.path().join(".changeset/changesets").join(filename),
-        content,
-    )
-    .expect("write changeset");
-}
-
-macro_rules! cargo_changeset_status {
-    () => {
-        assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
-    };
-}
-
 #[test]
 fn status_with_no_changesets() {
     let workspace = create_single_package_project();
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -140,7 +123,7 @@ fn status_shows_single_changeset() {
     let workspace = create_single_package_project();
     write_changeset(&workspace, "fix-bug.md", "my-crate", "patch", "Fix a bug");
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -158,7 +141,7 @@ fn status_shows_multiple_changesets() {
     write_changeset(&workspace, "fix.md", "my-crate", "patch", "Fix bug");
     write_changeset(&workspace, "feature.md", "my-crate", "minor", "Add feature");
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -173,7 +156,7 @@ fn status_shows_workspace_packages() {
     let workspace = create_workspace_project();
     write_changeset(&workspace, "fix-a.md", "crate-a", "patch", "Fix A");
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -187,7 +170,7 @@ fn status_shows_workspace_packages() {
 fn status_shows_inherited_version_warning() {
     let workspace = create_workspace_with_inherited_versions();
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -203,7 +186,7 @@ fn status_shows_inherited_version_warning_with_changesets() {
     let workspace = create_workspace_with_inherited_versions();
     write_changeset(&workspace, "fix.md", "crate-a", "patch", "Fix");
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -224,7 +207,7 @@ fn status_shows_unknown_package_warning() {
         "Fix typo",
     );
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -246,7 +229,7 @@ fn status_multiple_packages_multiple_bumps() {
         "Breaking B",
     );
 
-    cargo_changeset_status!()
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("status")
         .current_dir(workspace.path())
         .assert()
@@ -257,4 +240,44 @@ fn status_multiple_packages_multiple_bumps() {
         ))
         .stdout(contains("crate-b: 2.0.0 -> 3.0.0 (major)"))
         .stdout(contains("Summary: 3 changeset(s), 2 package(s) to release"));
+}
+
+#[test]
+fn status_shows_additional_package_with_changeset() {
+    let workspace = create_workspace_with_additional_package();
+    write_changeset(
+        &workspace,
+        "helm-feat.md",
+        "my-helm-chart",
+        "minor",
+        "Add feature",
+    );
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("status")
+        .current_dir(workspace.path())
+        .assert()
+        .success()
+        .stdout(contains("my-helm-chart"))
+        .stdout(contains("2.0.0 -> 2.1.0 (minor)"));
+}
+
+#[test]
+fn status_lists_additional_package_without_changeset() {
+    let workspace = create_workspace_with_additional_package();
+    write_changeset(
+        &workspace,
+        "crate-fix.md",
+        "crate-a",
+        "patch",
+        "Fix crate-a",
+    );
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("status")
+        .current_dir(workspace.path())
+        .assert()
+        .success()
+        .stdout(contains("Packages without changesets:"))
+        .stdout(contains("my-helm-chart (2.0.0)"));
 }

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -1377,12 +1377,14 @@ fn verify_both_rust_and_additional_package_uncovered() {
         .open(workspace.path().join("crates/crate-a/src/lib.rs"))
         .expect("failed to open lib.rs for appending");
     writeln!(lib, "// changed").expect("failed to append to lib.rs");
+    drop(lib);
 
     let mut values = OpenOptions::new()
         .append(true)
         .open(workspace.path().join("charts/my-chart/values.yaml"))
         .expect("failed to open values.yaml for appending");
     writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+    drop(values);
 
     git_add_and_commit(&workspace, "Modify both");
 
@@ -1407,12 +1409,14 @@ fn verify_mixed_coverage_only_rust_uncovered() {
         .open(workspace.path().join("crates/crate-a/src/lib.rs"))
         .expect("failed to open lib.rs for appending");
     writeln!(lib, "// changed").expect("failed to append to lib.rs");
+    drop(lib);
 
     let mut values = OpenOptions::new()
         .append(true)
         .open(workspace.path().join("charts/my-chart/values.yaml"))
         .expect("failed to open values.yaml for appending");
     writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+    drop(values);
 
     add_changeset(&workspace, "my-helm-chart");
     git_add_and_commit(&workspace, "Add helm changeset only");

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -1434,3 +1434,204 @@ fn verify_mixed_coverage_only_rust_uncovered() {
         .stderr(contains("crate-a"))
         .stderr(contains("✗ my-helm-chart").not());
 }
+
+fn create_workspace_with_version_tracking_and_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a src dir");
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "appVersion"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("charts/my-chart/values.yaml"),
+        "replicaCount: 1\n",
+    )
+    .expect("failed to write values.yaml");
+
+    init_git_repo(&dir);
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+#[test]
+fn verify_detects_change_in_version_tracking_manifest_requires_coverage() {
+    let workspace = create_workspace_with_version_tracking_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut chart = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to open Chart.yaml for appending");
+    writeln!(chart, "extraField: true").expect("failed to append to Chart.yaml");
+    drop(chart);
+
+    git_add_and_commit(&workspace, "Modify version-tracking manifest");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("my-helm-chart"));
+}
+
+#[test]
+fn verify_changeset_covers_version_tracking_manifest_change() {
+    let workspace = create_workspace_with_version_tracking_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut chart = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/Chart.yaml"))
+        .expect("failed to open Chart.yaml for appending");
+    writeln!(chart, "extraField: true").expect("failed to append to Chart.yaml");
+    drop(chart);
+
+    add_changeset(&workspace, "my-helm-chart");
+    git_add_and_commit(&workspace, "Modify manifest and add changeset");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn verify_ignores_changes_outside_version_tracking_manifests() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a src dir");
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+    fs::create_dir_all(dir.path().join("external")).expect("failed to create external dir");
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "crate-a"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "external/tracking.json"
+format = "json"
+version-field-path = "version"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\n",
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("external/tracking.json"),
+        r#"{"version": "1.0.0"}"#,
+    )
+    .expect("failed to write tracking.json");
+
+    init_git_repo(&dir);
+    git_add_and_commit(&dir, "Initial commit");
+    create_branch(&dir, "feature");
+
+    fs::write(
+        dir.path().join("external/tracking.json"),
+        r#"{"version": "1.0.1"}"#,
+    )
+    .expect("failed to modify tracking.json");
+
+    git_add_and_commit(&dir, "Modify tracking file outside influence");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -10,130 +10,25 @@ use tempfile::TempDir;
 
 use common::changesets::write_multi_changeset;
 use common::git::{create_branch, git_add_and_commit, init_git_repo};
-use common::workspaces::add_helm_chart_config;
-
-fn create_virtual_workspace_with_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
-        .expect("failed to create crate b dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"
-[package]
-name = "crate-a"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/crate-b/Cargo.toml"),
-        r#"
-[package]
-name = "crate-b"
-version = "0.2.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-b Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "")
-        .expect("failed to write crate-b lib.rs");
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
-}
+use common::workspaces::{
+    create_virtual_workspace_with_git, create_workspace_with_circular_version_tracking,
+    create_workspace_with_duplicate_dependency, create_workspace_with_helm_chart_and_git,
+    create_workspace_with_three_crates_and_git, create_workspace_with_unknown_dependency,
+    create_workspace_with_version_tracking_and_git,
+};
 
 fn add_changeset(dir: &TempDir, package_name: &str) {
     add_changeset_with_name(dir, package_name, &format!("{package_name}-changeset"));
 }
 
 fn add_changeset_with_name(dir: &TempDir, package_name: &str, changeset_name: &str) {
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-    let filename = format!(".changeset/changesets/{changeset_name}.md");
-    fs::write(
-        dir.path().join(&filename),
-        format!(
-            r#"---
-"{package_name}": patch
----
-
-Test changeset for {package_name}.
-"#
-        ),
-    )
-    .expect("failed to write changeset");
-}
-
-fn create_workspace_with_three_crates() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
-        .expect("failed to create crate b dir");
-    fs::create_dir_all(dir.path().join("crates/crate-c/src"))
-        .expect("failed to create crate c dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    for (name, version) in [
-        ("crate-a", "0.1.0"),
-        ("crate-b", "0.2.0"),
-        ("crate-c", "0.3.0"),
-    ] {
-        fs::write(
-            dir.path().join(format!("crates/{name}/Cargo.toml")),
-            format!(
-                r#"
-[package]
-name = "{name}"
-version = "{version}"
-edition = "2021"
-"#
-            ),
-        )
-        .expect("failed to write Cargo.toml");
-
-        fs::write(dir.path().join(format!("crates/{name}/src/lib.rs")), "")
-            .expect("failed to write lib.rs");
-    }
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+    common::changesets::write_changeset(
+        dir,
+        &format!("{changeset_name}.md"),
+        package_name,
+        "patch",
+        &format!("Test changeset for {package_name}."),
+    );
 }
 
 #[test]
@@ -636,7 +531,7 @@ fn verify_deleted_changeset_with_allow_flag_passes() {
 
 #[test]
 fn verify_multiple_commits_on_feature_branch_all_covered() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -675,7 +570,7 @@ fn verify_multiple_commits_on_feature_branch_all_covered() {
 
 #[test]
 fn verify_multiple_commits_on_feature_branch_last_uncovered() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -713,7 +608,7 @@ fn verify_multiple_commits_on_feature_branch_last_uncovered() {
 
 #[test]
 fn verify_main_has_unreleased_changesets_feature_has_different_changes() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "unreleased-on-main");
     git_add_and_commit(&workspace, "Add unreleased changeset for crate-a on main");
@@ -740,7 +635,7 @@ fn verify_main_has_unreleased_changesets_feature_has_different_changes() {
 
 #[test]
 fn verify_main_has_unreleased_changesets_feature_modifies_same_crate_without_new_changeset() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "unreleased-on-main");
     git_add_and_commit(&workspace, "Add unreleased changeset for crate-a on main");
@@ -766,7 +661,7 @@ fn verify_main_has_unreleased_changesets_feature_modifies_same_crate_without_new
 
 #[test]
 fn verify_feature_modifies_existing_changeset_from_main() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "shared-changeset");
     git_add_and_commit(&workspace, "Add changeset on main");
@@ -805,7 +700,7 @@ Updated description with additional changes.
 
 #[test]
 fn verify_single_changeset_covers_multiple_packages() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -840,7 +735,7 @@ fn verify_single_changeset_covers_multiple_packages() {
 
 #[test]
 fn verify_single_changeset_covers_multiple_packages_but_misses_one() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -884,7 +779,7 @@ fn verify_single_changeset_covers_multiple_packages_but_misses_one() {
 
 #[test]
 fn verify_changeset_added_in_later_commit_covers_earlier_changes() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -916,7 +811,7 @@ fn verify_changeset_added_in_later_commit_covers_earlier_changes() {
 
 #[test]
 fn verify_multiple_changesets_for_same_package() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -941,7 +836,7 @@ fn verify_multiple_changesets_for_same_package() {
 
 #[test]
 fn verify_code_changes_across_multiple_commits_single_changeset() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -978,7 +873,7 @@ fn verify_code_changes_across_multiple_commits_single_changeset() {
 
 #[test]
 fn verify_changeset_added_then_code_changed_later_still_covered() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     add_changeset(&workspace, "crate-a");
@@ -1003,7 +898,7 @@ fn verify_changeset_added_then_code_changed_later_still_covered() {
 
 #[test]
 fn verify_mixed_scenario_some_from_main_some_new() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "main-changeset-a");
     add_changeset_with_name(&workspace, "crate-b", "main-changeset-b");
@@ -1039,7 +934,7 @@ fn verify_mixed_scenario_some_from_main_some_new() {
 
 #[test]
 fn verify_preexisting_changeset_for_different_package_does_not_help() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset(&workspace, "crate-a");
     git_add_and_commit(&workspace, "Add changeset for crate-a on main");
@@ -1065,7 +960,7 @@ fn verify_preexisting_changeset_for_different_package_does_not_help() {
 
 #[test]
 fn verify_changeset_covers_package_not_actually_changed() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -1094,7 +989,7 @@ fn verify_changeset_covers_package_not_actually_changed() {
 
 #[test]
 fn verify_feature_branch_deletes_code_needs_changeset() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     fs::write(
         workspace.path().join("crates/crate-a/src/lib.rs"),
@@ -1121,7 +1016,7 @@ fn verify_feature_branch_deletes_code_needs_changeset() {
 
 #[test]
 fn verify_feature_branch_deletes_code_with_changeset_passes() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     fs::write(
         workspace.path().join("crates/crate-a/src/lib.rs"),
@@ -1149,7 +1044,7 @@ fn verify_feature_branch_deletes_code_with_changeset_passes() {
 
 #[test]
 fn verify_new_file_in_package_needs_changeset() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
     create_branch(&workspace, "feature");
 
     fs::write(
@@ -1171,7 +1066,7 @@ fn verify_new_file_in_package_needs_changeset() {
 
 #[test]
 fn verify_deleted_and_added_changeset_in_same_branch() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "old-changeset");
     git_add_and_commit(&workspace, "Add old changeset");
@@ -1199,7 +1094,7 @@ fn verify_deleted_and_added_changeset_in_same_branch() {
 
 #[test]
 fn verify_deleted_and_added_changeset_with_allow_flag() {
-    let workspace = create_workspace_with_three_crates();
+    let workspace = create_workspace_with_three_crates_and_git();
 
     add_changeset_with_name(&workspace, "crate-a", "old-changeset");
     git_add_and_commit(&workspace, "Add old changeset");
@@ -1230,67 +1125,6 @@ fn verify_deleted_and_added_changeset_with_allow_flag() {
         .current_dir(workspace.path())
         .assert()
         .success();
-}
-
-fn create_workspace_with_helm_chart_and_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a src dir");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        r#"# Helm chart for my-chart
-apiVersion: v2
-name: my-chart
-description: A test Helm chart
-# This comment should survive release
-version: "2.0.0"
-appVersion: "1.0.0"
-"#,
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("charts/my-chart/values.yaml"),
-        "replicaCount: 1",
-    )
-    .expect("failed to write values.yaml");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    add_helm_chart_config(&dir);
-
-    init_git_repo(&dir);
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
 }
 
 #[test]
@@ -1435,74 +1269,6 @@ fn verify_mixed_coverage_only_rust_uncovered() {
         .stderr(contains("✗ my-helm-chart").not());
 }
 
-fn create_workspace_with_version_tracking_and_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a src dir");
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
-name = "my-helm-chart"
-path = "charts/my-chart"
-influence = ["charts/my-chart/**"]
-
-[workspace.metadata.changeset.additional-packages.manifest]
-file-path = "charts/my-chart/Chart.yaml"
-format = "yaml"
-version-field-path = "version"
-
-[[workspace.metadata.changeset.additional-packages.dependencies]]
-dependency-name = "crate-a"
-
-[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
-file-path = "charts/my-chart/Chart.yaml"
-format = "yaml"
-version-field-path = "appVersion"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("charts/my-chart/values.yaml"),
-        "replicaCount: 1\n",
-    )
-    .expect("failed to write values.yaml");
-
-    init_git_repo(&dir);
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
-}
-
 #[test]
 fn verify_detects_change_in_version_tracking_manifest_requires_coverage() {
     let workspace = create_workspace_with_version_tracking_and_git();
@@ -1634,4 +1400,55 @@ edition = "2021"
         .current_dir(dir.path())
         .assert()
         .success();
+}
+
+#[test]
+fn verify_rejects_unknown_version_tracking_dependency() {
+    let workspace = create_workspace_with_unknown_dependency();
+    init_git_repo(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    create_branch(&workspace, "feature");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("unknown-pkg"));
+}
+
+#[test]
+fn verify_rejects_circular_version_tracking_dependency() {
+    let workspace = create_workspace_with_circular_version_tracking();
+    init_git_repo(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    create_branch(&workspace, "feature");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("circular"));
+}
+
+#[test]
+fn verify_rejects_duplicate_version_tracking_dependency() {
+    let workspace = create_workspace_with_duplicate_dependency();
+    init_git_repo(&workspace);
+    git_add_and_commit(&workspace, "Initial commit");
+    create_branch(&workspace, "feature");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("duplicate").or(contains("crate-a")));
 }

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -1,50 +1,16 @@
-use std::fs;
-use std::process::Command;
+mod common;
 
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write as IoWrite;
+
+use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::contains;
 use tempfile::TempDir;
 
-fn init_git_repo(dir: &TempDir) {
-    Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to init git repo");
-
-    Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git email");
-
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to configure git name");
-}
-
-fn git_add_and_commit(dir: &TempDir, message: &str) {
-    Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git add");
-
-    Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to git commit");
-}
-
-fn create_branch(dir: &TempDir, name: &str) {
-    Command::new("git")
-        .args(["checkout", "-b", name])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to create branch");
-}
+use common::changesets::write_multi_changeset;
+use common::git::{create_branch, git_add_and_commit, init_git_repo};
+use common::workspaces::add_helm_chart_config;
 
 fn create_virtual_workspace_with_git() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
@@ -115,31 +81,6 @@ fn add_changeset_with_name(dir: &TempDir, package_name: &str, changeset_name: &s
 ---
 
 Test changeset for {package_name}.
-"#
-        ),
-    )
-    .expect("failed to write changeset");
-}
-
-fn add_multi_package_changeset(dir: &TempDir, packages: &[&str], changeset_name: &str) {
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-    let filename = format!(".changeset/changesets/{changeset_name}.md");
-
-    let package_entries: String = packages
-        .iter()
-        .map(|p| format!("\"{p}\": patch"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    fs::write(
-        dir.path().join(&filename),
-        format!(
-            r#"---
-{package_entries}
----
-
-Test changeset for multiple packages.
 "#
         ),
     )
@@ -879,7 +820,12 @@ fn verify_single_changeset_covers_multiple_packages() {
     )
     .expect("failed to modify lib.rs");
 
-    add_multi_package_changeset(&workspace, &["crate-a", "crate-b"], "multi-package-change");
+    write_multi_changeset(
+        &workspace,
+        "multi-package-change.md",
+        &[("crate-a", "patch"), ("crate-b", "patch")],
+        "Test changeset for multiple packages.",
+    );
     git_add_and_commit(&workspace, "Change multiple packages with single changeset");
 
     assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
@@ -915,7 +861,12 @@ fn verify_single_changeset_covers_multiple_packages_but_misses_one() {
     )
     .expect("failed to modify lib.rs");
 
-    add_multi_package_changeset(&workspace, &["crate-a", "crate-b"], "multi-package-change");
+    write_multi_changeset(
+        &workspace,
+        "multi-package-change.md",
+        &[("crate-a", "patch"), ("crate-b", "patch")],
+        "Test changeset for multiple packages.",
+    );
     git_add_and_commit(
         &workspace,
         "Change three packages but only two in changeset",
@@ -1123,10 +1074,11 @@ fn verify_changeset_covers_package_not_actually_changed() {
     )
     .expect("failed to modify lib.rs");
 
-    add_multi_package_changeset(
+    write_multi_changeset(
         &workspace,
-        &["crate-a", "crate-b"],
-        "overly-broad-changeset",
+        "overly-broad-changeset.md",
+        &[("crate-a", "patch"), ("crate-b", "patch")],
+        "Test changeset for multiple packages.",
     );
     git_add_and_commit(&workspace, "Changeset covers more than needed");
 
@@ -1278,4 +1230,200 @@ fn verify_deleted_and_added_changeset_with_allow_flag() {
         .current_dir(workspace.path())
         .assert()
         .success();
+}
+
+fn create_workspace_with_helm_chart_and_git() -> TempDir {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
+        .expect("failed to create crate-a src dir");
+
+    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
+        .expect("failed to write crate-a lib.rs");
+
+    fs::write(
+        dir.path().join("crates/crate-a/Cargo.toml"),
+        r#"[package]
+name = "crate-a"
+version = "1.0.0"
+edition = "2021"
+"#,
+    )
+    .expect("failed to write crate-a Cargo.toml");
+
+    fs::create_dir_all(dir.path().join("charts/my-chart"))
+        .expect("failed to create charts/my-chart dir");
+
+    fs::write(
+        dir.path().join("charts/my-chart/Chart.yaml"),
+        r#"# Helm chart for my-chart
+apiVersion: v2
+name: my-chart
+description: A test Helm chart
+# This comment should survive release
+version: "2.0.0"
+appVersion: "1.0.0"
+"#,
+    )
+    .expect("failed to write Chart.yaml");
+
+    fs::write(
+        dir.path().join("charts/my-chart/values.yaml"),
+        "replicaCount: 1",
+    )
+    .expect("failed to write values.yaml");
+
+    fs::create_dir_all(dir.path().join(".changeset/changesets"))
+        .expect("failed to create .changeset/changesets dir");
+
+    add_helm_chart_config(&dir);
+
+    init_git_repo(&dir);
+    git_add_and_commit(&dir, "Initial commit");
+
+    dir
+}
+
+#[test]
+fn verify_detects_additional_package_changes_requiring_coverage() {
+    let workspace = create_workspace_with_helm_chart_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut values = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/values.yaml"))
+        .expect("failed to open values.yaml for appending");
+    writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+
+    git_add_and_commit(&workspace, "Modify helm values");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("my-helm-chart"));
+}
+
+#[test]
+fn verify_passes_when_additional_package_change_covered() {
+    let workspace = create_workspace_with_helm_chart_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut values = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/values.yaml"))
+        .expect("failed to open values.yaml for appending");
+    writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+
+    add_changeset(&workspace, "my-helm-chart");
+    git_add_and_commit(&workspace, "Add changeset for helm chart");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn verify_ignores_files_outside_additional_package_influence() {
+    let workspace = create_workspace_with_helm_chart_and_git();
+
+    fs::create_dir_all(workspace.path().join("docs")).expect("failed to create docs dir");
+    fs::write(workspace.path().join("docs/README.md"), "# Documentation")
+        .expect("failed to write README.md");
+    git_add_and_commit(&workspace, "Add docs");
+
+    create_branch(&workspace, "feature");
+
+    let mut readme = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("docs/README.md"))
+        .expect("failed to open README.md for appending");
+    writeln!(readme, "## Additional section").expect("failed to append to README.md");
+
+    git_add_and_commit(&workspace, "Update docs");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn verify_both_rust_and_additional_package_uncovered() {
+    let workspace = create_workspace_with_helm_chart_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut lib = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("crates/crate-a/src/lib.rs"))
+        .expect("failed to open lib.rs for appending");
+    writeln!(lib, "// changed").expect("failed to append to lib.rs");
+
+    let mut values = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/values.yaml"))
+        .expect("failed to open values.yaml for appending");
+    writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+
+    git_add_and_commit(&workspace, "Modify both");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("crate-a"))
+        .stderr(contains("my-helm-chart"));
+}
+
+#[test]
+fn verify_mixed_coverage_only_rust_uncovered() {
+    let workspace = create_workspace_with_helm_chart_and_git();
+    create_branch(&workspace, "feature");
+
+    let mut lib = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("crates/crate-a/src/lib.rs"))
+        .expect("failed to open lib.rs for appending");
+    writeln!(lib, "// changed").expect("failed to append to lib.rs");
+
+    let mut values = OpenOptions::new()
+        .append(true)
+        .open(workspace.path().join("charts/my-chart/values.yaml"))
+        .expect("failed to open values.yaml for appending");
+    writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+
+    add_changeset(&workspace, "my-helm-chart");
+    git_add_and_commit(&workspace, "Add helm changeset only");
+
+    assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
+        .arg("verify")
+        .arg("--base")
+        .arg("main")
+        .current_dir(workspace.path())
+        .assert()
+        .failure()
+        .stderr(contains("crate-a"))
+        .stderr(contains("✗ my-helm-chart").not());
 }

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -1303,6 +1303,7 @@ fn verify_detects_additional_package_changes_requiring_coverage() {
         .open(workspace.path().join("charts/my-chart/values.yaml"))
         .expect("failed to open values.yaml for appending");
     writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+    drop(values);
 
     git_add_and_commit(&workspace, "Modify helm values");
 
@@ -1326,6 +1327,7 @@ fn verify_passes_when_additional_package_change_covered() {
         .open(workspace.path().join("charts/my-chart/values.yaml"))
         .expect("failed to open values.yaml for appending");
     writeln!(values, "image: nginx").expect("failed to append to values.yaml");
+    drop(values);
 
     add_changeset(&workspace, "my-helm-chart");
     git_add_and_commit(&workspace, "Add changeset for helm chart");
@@ -1355,6 +1357,7 @@ fn verify_ignores_files_outside_additional_package_influence() {
         .open(workspace.path().join("docs/README.md"))
         .expect("failed to open README.md for appending");
     writeln!(readme, "## Additional section").expect("failed to append to README.md");
+    drop(readme);
 
     git_add_and_commit(&workspace, "Update docs");
 

--- a/crates/changeset-changelog/src/changelog.rs
+++ b/crates/changeset-changelog/src/changelog.rs
@@ -116,10 +116,10 @@ impl Changelog {
             return first_version_pos + 1;
         }
 
-        if let Some(header_end) = self.content.find(HEADER_END_MARKER) {
-            if let Some(newline_after) = self.content[header_end..].find('\n') {
-                return header_end + newline_after + 1;
-            }
+        if let Some(header_end) = self.content.find(HEADER_END_MARKER)
+            && let Some(newline_after) = self.content[header_end..].find('\n')
+        {
+            return header_end + newline_after + 1;
         }
 
         self.content.len()

--- a/crates/changeset-core/Cargo.toml
+++ b/crates/changeset-core/Cargo.toml
@@ -21,3 +21,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+toml = { workspace = true }

--- a/crates/changeset-core/src/error.rs
+++ b/crates/changeset-core/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -21,5 +23,26 @@ pub enum PrereleaseSpecParseError {
     #[error("prerelease identifier '{0}' contains invalid character '{1}'")]
     InvalidCharacter(String, char),
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestFormatParseError(pub(crate) String);
+
+impl fmt::Display for ManifestFormatParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use clap::ValueEnum as _;
+        let valid = crate::types::ManifestFormat::value_variants()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            f,
+            "unknown manifest format '{}', expected one of: {valid}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ManifestFormatParseError {}
 
 pub type Result<T> = std::result::Result<T, ChangesetError>;

--- a/crates/changeset-core/src/lib.rs
+++ b/crates/changeset-core/src/lib.rs
@@ -5,5 +5,5 @@ pub use error::{ChangesetError, ManifestFormatParseError, PrereleaseSpecParseErr
 pub use types::{
     AdditionalPackageDeclaration, AdditionalPackageManifest, BumpType, CARGO_MANIFEST_FILENAME,
     ChangeCategory, Changeset, ManifestFormat, NoneBumpBehavior, PackageInfo, PackageRelease,
-    PrereleaseSpec, ZeroVersionBehavior,
+    PrereleaseSpec, VersionTrackingDependency, VersionTrackingManifest, ZeroVersionBehavior,
 };

--- a/crates/changeset-core/src/lib.rs
+++ b/crates/changeset-core/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod error;
 pub mod types;
 
-pub use error::{ChangesetError, PrereleaseSpecParseError, Result};
+pub use error::{ChangesetError, ManifestFormatParseError, PrereleaseSpecParseError, Result};
 pub use types::{
-    BumpType, ChangeCategory, Changeset, NoneBumpBehavior, PackageInfo, PackageRelease,
+    AdditionalPackageDeclaration, AdditionalPackageManifest, BumpType, CARGO_MANIFEST_FILENAME,
+    ChangeCategory, Changeset, ManifestFormat, NoneBumpBehavior, PackageInfo, PackageRelease,
     PrereleaseSpec, ZeroVersionBehavior,
 };

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -7,6 +7,64 @@ use gset::Getset;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
+pub const CARGO_MANIFEST_FILENAME: &str = "Cargo.toml";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ManifestFormat {
+    Toml,
+    Yaml,
+    Json,
+}
+
+impl fmt::Display for ManifestFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Toml => "toml",
+            Self::Yaml => "yaml",
+            Self::Json => "json",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for ManifestFormat {
+    type Err = crate::error::ManifestFormatParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "toml" => Ok(Self::Toml),
+            "yaml" => Ok(Self::Yaml),
+            "json" => Ok(Self::Json),
+            _ => Err(crate::error::ManifestFormatParseError(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct AdditionalPackageManifest {
+    #[getset(get, vis = "pub")]
+    file_path: PathBuf,
+    #[getset(get_copy, vis = "pub")]
+    format: ManifestFormat,
+    #[getset(get, vis = "pub")]
+    version_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct AdditionalPackageDeclaration {
+    #[getset(get, vis = "pub")]
+    name: String,
+    #[getset(get, vis = "pub")]
+    path: PathBuf,
+    #[getset(get, vis = "pub")]
+    influence: Vec<String>,
+    #[getset(get, vis = "pub")]
+    manifest: AdditionalPackageManifest,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BumpType {
@@ -445,5 +503,122 @@ mod tests {
         assert!("123".parse::<PrereleaseSpec>().is_ok());
         assert!("abc123".parse::<PrereleaseSpec>().is_ok());
         assert!("ABC-123-xyz".parse::<PrereleaseSpec>().is_ok());
+    }
+
+    #[test]
+    fn manifest_format_display() {
+        assert_eq!(format!("{}", ManifestFormat::Toml), "toml");
+        assert_eq!(format!("{}", ManifestFormat::Yaml), "yaml");
+        assert_eq!(format!("{}", ManifestFormat::Json), "json");
+    }
+
+    #[test]
+    fn manifest_format_from_str_case_insensitive() {
+        assert_eq!(
+            "toml".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Toml
+        );
+        assert_eq!(
+            "TOML".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Toml
+        );
+        assert_eq!(
+            "Toml".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Toml
+        );
+        assert_eq!(
+            "yaml".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Yaml
+        );
+        assert_eq!(
+            "YAML".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Yaml
+        );
+        assert_eq!(
+            "json".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Json
+        );
+        assert_eq!(
+            "JSON".parse::<ManifestFormat>().unwrap(),
+            ManifestFormat::Json
+        );
+    }
+
+    #[test]
+    fn manifest_format_from_str_rejects_unknown() {
+        let err = "xml".parse::<ManifestFormat>().unwrap_err();
+        assert_eq!(
+            err,
+            crate::error::ManifestFormatParseError("xml".to_string())
+        );
+    }
+
+    #[test]
+    fn manifest_format_serde_round_trip() {
+        for (variant, expected) in [
+            (ManifestFormat::Toml, r#""toml""#),
+            (ManifestFormat::Yaml, r#""yaml""#),
+            (ManifestFormat::Json, r#""json""#),
+        ] {
+            let serialized = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialized, expected);
+            let deserialized: ManifestFormat = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, variant);
+        }
+    }
+
+    #[test]
+    fn additional_package_manifest_serde_round_trip() {
+        let manifest = AdditionalPackageManifest {
+            file_path: PathBuf::from("charts/my-chart/Chart.yaml"),
+            format: ManifestFormat::Yaml,
+            version_path: "version".to_string(),
+        };
+        let serialized = serde_json::to_string(&manifest).unwrap();
+        assert!(serialized.contains(r#""file-path""#));
+        assert!(serialized.contains(r#""version-path""#));
+        let deserialized: AdditionalPackageManifest = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, manifest);
+    }
+
+    #[test]
+    fn additional_package_declaration_serde_round_trip() {
+        let decl = AdditionalPackageDeclaration {
+            name: "my-helm-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec!["charts/my-chart/**".to_string()],
+            manifest: AdditionalPackageManifest {
+                file_path: PathBuf::from("charts/my-chart/Chart.yaml"),
+                format: ManifestFormat::Yaml,
+                version_path: "version".to_string(),
+            },
+        };
+        let serialized = serde_json::to_string(&decl).unwrap();
+        let deserialized: AdditionalPackageDeclaration = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, decl);
+    }
+
+    #[test]
+    fn manifest_format_parse_error_display() {
+        let err = crate::error::ManifestFormatParseError("bad".to_string());
+        assert_eq!(
+            err.to_string(),
+            "unknown manifest format 'bad', expected one of: toml, yaml, json"
+        );
+    }
+
+    #[test]
+    fn additional_package_declaration_missing_required_field() {
+        let json = r#"{
+            "path": "charts/my-chart",
+            "influence": ["charts/my-chart/**"],
+            "manifest": {
+                "file-path": "charts/my-chart/Chart.yaml",
+                "format": "yaml",
+                "version-path": "version"
+            }
+        }"#;
+        let result = serde_json::from_str::<AdditionalPackageDeclaration>(json);
+        assert!(result.is_err());
     }
 }

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -52,6 +52,17 @@ pub struct AdditionalPackageManifest {
     version_path: String,
 }
 
+impl AdditionalPackageManifest {
+    #[must_use]
+    pub fn new(file_path: PathBuf, format: ManifestFormat, version_path: String) -> Self {
+        Self {
+            file_path,
+            format,
+            version_path,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
 #[serde(rename_all = "kebab-case")]
 pub struct AdditionalPackageDeclaration {
@@ -63,6 +74,23 @@ pub struct AdditionalPackageDeclaration {
     influence: Vec<String>,
     #[getset(get, vis = "pub")]
     manifest: AdditionalPackageManifest,
+}
+
+impl AdditionalPackageDeclaration {
+    #[must_use]
+    pub fn new(
+        name: String,
+        path: PathBuf,
+        influence: Vec<String>,
+        manifest: AdditionalPackageManifest,
+    ) -> Self {
+        Self {
+            name,
+            path,
+            influence,
+            manifest,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -17,6 +17,18 @@ pub enum ManifestFormat {
     Json,
 }
 
+impl ManifestFormat {
+    #[must_use]
+    pub fn from_path(path: &std::path::Path) -> Option<Self> {
+        match path.extension()?.to_str()? {
+            "toml" => Some(Self::Toml),
+            "yaml" | "yml" => Some(Self::Yaml),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for ManifestFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -41,58 +41,6 @@ impl FromStr for ManifestFormat {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
-#[serde(rename_all = "kebab-case")]
-pub struct AdditionalPackageManifest {
-    #[getset(get, vis = "pub")]
-    file_path: PathBuf,
-    #[getset(get_copy, vis = "pub")]
-    format: ManifestFormat,
-    #[getset(get, vis = "pub")]
-    version_field_path: String,
-}
-
-impl AdditionalPackageManifest {
-    #[must_use]
-    pub fn new(file_path: PathBuf, format: ManifestFormat, version_field_path: String) -> Self {
-        Self {
-            file_path,
-            format,
-            version_field_path,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
-#[serde(rename_all = "kebab-case")]
-pub struct AdditionalPackageDeclaration {
-    #[getset(get, vis = "pub")]
-    name: String,
-    #[getset(get, vis = "pub")]
-    path: PathBuf,
-    #[getset(get, vis = "pub")]
-    influence: Vec<String>,
-    #[getset(get, vis = "pub")]
-    manifest: AdditionalPackageManifest,
-}
-
-impl AdditionalPackageDeclaration {
-    #[must_use]
-    pub fn new(
-        name: String,
-        path: PathBuf,
-        influence: Vec<String>,
-        manifest: AdditionalPackageManifest,
-    ) -> Self {
-        Self {
-            name,
-            path,
-            influence,
-            manifest,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BumpType {
@@ -179,6 +127,169 @@ impl fmt::Display for ChangeCategory {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PrereleaseSpec {
+    Alpha,
+    Beta,
+    Rc,
+    Custom(String),
+}
+
+impl PrereleaseSpec {
+    #[must_use]
+    pub fn identifier(&self) -> &str {
+        match self {
+            Self::Alpha => "alpha",
+            Self::Beta => "beta",
+            Self::Rc => "rc",
+            Self::Custom(s) => s,
+        }
+    }
+}
+
+impl fmt::Display for PrereleaseSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.identifier())
+    }
+}
+
+impl FromStr for PrereleaseSpec {
+    type Err = crate::error::PrereleaseSpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(Self::Err::Empty);
+        }
+
+        if let Some(invalid_char) = s.chars().find(|c| !c.is_ascii_alphanumeric() && *c != '-') {
+            return Err(Self::Err::InvalidCharacter(s.to_string(), invalid_char));
+        }
+
+        Ok(match s.to_lowercase().as_str() {
+            "alpha" => Self::Alpha,
+            "beta" => Self::Beta,
+            "rc" => Self::Rc,
+            _ => Self::Custom(s.to_string()),
+        })
+    }
+}
+
+impl ValueEnum for PrereleaseSpec {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Alpha, Self::Beta, Self::Rc]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        match self {
+            Self::Alpha => Some(clap::builder::PossibleValue::new("alpha")),
+            Self::Beta => Some(clap::builder::PossibleValue::new("beta")),
+            Self::Rc => Some(clap::builder::PossibleValue::new("rc")),
+            Self::Custom(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct AdditionalPackageManifest {
+    #[getset(get, vis = "pub")]
+    file_path: PathBuf,
+    #[getset(get_copy, vis = "pub")]
+    format: ManifestFormat,
+    #[getset(get, vis = "pub")]
+    version_field_path: String,
+}
+
+impl AdditionalPackageManifest {
+    #[must_use]
+    pub fn new(file_path: PathBuf, format: ManifestFormat, version_field_path: String) -> Self {
+        Self {
+            file_path,
+            format,
+            version_field_path,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct VersionTrackingManifest {
+    #[getset(get, vis = "pub")]
+    file_path: PathBuf,
+    #[getset(get_copy, vis = "pub")]
+    format: ManifestFormat,
+    #[getset(get, vis = "pub")]
+    version_field_path: String,
+}
+
+impl VersionTrackingManifest {
+    #[must_use]
+    pub fn new(file_path: PathBuf, format: ManifestFormat, version_field_path: String) -> Self {
+        Self {
+            file_path,
+            format,
+            version_field_path,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct VersionTrackingDependency {
+    #[getset(get, vis = "pub")]
+    dependency_name: String,
+    #[getset(get, vis = "pub")]
+    version_tracking_manifest: VersionTrackingManifest,
+}
+
+impl VersionTrackingDependency {
+    #[must_use]
+    pub fn new(
+        dependency_name: String,
+        version_tracking_manifest: VersionTrackingManifest,
+    ) -> Self {
+        Self {
+            dependency_name,
+            version_tracking_manifest,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
+#[serde(rename_all = "kebab-case")]
+pub struct AdditionalPackageDeclaration {
+    #[getset(get, vis = "pub")]
+    name: String,
+    #[getset(get, vis = "pub")]
+    path: PathBuf,
+    #[getset(get, vis = "pub")]
+    influence: Vec<String>,
+    #[getset(get, vis = "pub")]
+    manifest: AdditionalPackageManifest,
+    #[serde(default)]
+    #[getset(get, vis = "pub")]
+    dependencies: Vec<VersionTrackingDependency>,
+}
+
+impl AdditionalPackageDeclaration {
+    #[must_use]
+    pub fn new(
+        name: String,
+        path: PathBuf,
+        influence: Vec<String>,
+        manifest: AdditionalPackageManifest,
+        dependencies: Vec<VersionTrackingDependency>,
+    ) -> Self {
+        Self {
+            name,
+            path,
+            influence,
+            manifest,
+            dependencies,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getset)]
 pub struct PackageRelease {
     #[getset(get, vis = "pub")]
@@ -261,68 +372,6 @@ impl PackageInfo {
             name,
             version,
             path,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PrereleaseSpec {
-    Alpha,
-    Beta,
-    Rc,
-    Custom(String),
-}
-
-impl PrereleaseSpec {
-    #[must_use]
-    pub fn identifier(&self) -> &str {
-        match self {
-            Self::Alpha => "alpha",
-            Self::Beta => "beta",
-            Self::Rc => "rc",
-            Self::Custom(s) => s,
-        }
-    }
-}
-
-impl fmt::Display for PrereleaseSpec {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.identifier())
-    }
-}
-
-impl FromStr for PrereleaseSpec {
-    type Err = crate::error::PrereleaseSpecParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty() {
-            return Err(Self::Err::Empty);
-        }
-
-        if let Some(invalid_char) = s.chars().find(|c| !c.is_ascii_alphanumeric() && *c != '-') {
-            return Err(Self::Err::InvalidCharacter(s.to_string(), invalid_char));
-        }
-
-        Ok(match s.to_lowercase().as_str() {
-            "alpha" => Self::Alpha,
-            "beta" => Self::Beta,
-            "rc" => Self::Rc,
-            _ => Self::Custom(s.to_string()),
-        })
-    }
-}
-
-impl ValueEnum for PrereleaseSpec {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Alpha, Self::Beta, Self::Rc]
-    }
-
-    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
-        match self {
-            Self::Alpha => Some(clap::builder::PossibleValue::new("alpha")),
-            Self::Beta => Some(clap::builder::PossibleValue::new("beta")),
-            Self::Rc => Some(clap::builder::PossibleValue::new("rc")),
-            Self::Custom(_) => None,
         }
     }
 }
@@ -620,6 +669,7 @@ mod tests {
                 format: ManifestFormat::Yaml,
                 version_field_path: "version".to_string(),
             },
+            dependencies: vec![],
         };
         let serialized = serde_json::to_string(&decl).unwrap();
         let deserialized: AdditionalPackageDeclaration = serde_json::from_str(&serialized).unwrap();
@@ -648,5 +698,80 @@ mod tests {
         }"#;
         let result = serde_json::from_str::<AdditionalPackageDeclaration>(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn version_tracking_manifest_serde_round_trip() {
+        let manifest = VersionTrackingManifest::new(
+            PathBuf::from("charts/app/Chart.yaml"),
+            ManifestFormat::Yaml,
+            "appVersion".to_string(),
+        );
+        let serialized = toml::to_string(&manifest).expect("serialize to TOML");
+        let deserialized: VersionTrackingManifest =
+            toml::from_str(&serialized).expect("deserialize from TOML");
+        assert_eq!(deserialized, manifest);
+    }
+
+    #[test]
+    fn version_tracking_dependency_serde_round_trip() {
+        let dep = VersionTrackingDependency::new(
+            "my-lib".to_string(),
+            VersionTrackingManifest::new(
+                PathBuf::from("charts/app/Chart.yaml"),
+                ManifestFormat::Yaml,
+                "appVersion".to_string(),
+            ),
+        );
+        let serialized = toml::to_string(&dep).expect("serialize to TOML");
+        let deserialized: VersionTrackingDependency =
+            toml::from_str(&serialized).expect("deserialize from TOML");
+        assert_eq!(deserialized, dep);
+    }
+
+    #[test]
+    fn additional_package_declaration_with_dependencies_serde_round_trip() {
+        let decl = AdditionalPackageDeclaration::new(
+            "my-helm-chart".to_string(),
+            PathBuf::from("charts/my-chart"),
+            vec!["charts/my-chart/**".to_string()],
+            AdditionalPackageManifest::new(
+                PathBuf::from("charts/my-chart/Chart.yaml"),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            vec![VersionTrackingDependency::new(
+                "my-lib".to_string(),
+                VersionTrackingManifest::new(
+                    PathBuf::from("charts/my-chart/Chart.yaml"),
+                    ManifestFormat::Yaml,
+                    "appVersion".to_string(),
+                ),
+            )],
+        );
+        let serialized = toml::to_string(&decl).expect("serialize to TOML");
+        let deserialized: AdditionalPackageDeclaration =
+            toml::from_str(&serialized).expect("deserialize from TOML");
+        assert_eq!(deserialized, decl);
+        assert_eq!(deserialized.dependencies().len(), 1);
+        assert_eq!(deserialized.dependencies()[0].dependency_name(), "my-lib");
+    }
+
+    #[test]
+    fn additional_package_declaration_without_dependencies_defaults_to_empty() {
+        let toml_str = r#"
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+"#;
+        let deserialized: AdditionalPackageDeclaration =
+            toml::from_str(toml_str).expect("deserialize from TOML");
+        assert!(deserialized.dependencies().is_empty());
+        assert_eq!(deserialized.name(), "my-helm-chart");
     }
 }

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -758,6 +758,101 @@ mod tests {
     }
 
     #[test]
+    fn version_tracking_manifest_serde_key_names() {
+        let manifest = VersionTrackingManifest::new(
+            PathBuf::from("path/to/manifest.json"),
+            ManifestFormat::Json,
+            "version".to_string(),
+        );
+        let serialized = serde_json::to_string(&manifest).expect("serialize to JSON");
+        assert!(
+            serialized.contains(r#""file-path""#),
+            "expected kebab-case key 'file-path' in JSON output: {serialized}"
+        );
+        assert!(
+            serialized.contains(r#""version-field-path""#),
+            "expected kebab-case key 'version-field-path' in JSON output: {serialized}"
+        );
+    }
+
+    #[test]
+    fn version_tracking_dependency_serde_key_names() {
+        let dep = VersionTrackingDependency::new(
+            "some-dep".to_string(),
+            VersionTrackingManifest::new(
+                PathBuf::from("tracking.json"),
+                ManifestFormat::Json,
+                "ver".to_string(),
+            ),
+        );
+        let serialized = serde_json::to_string(&dep).expect("serialize to JSON");
+        assert!(
+            serialized.contains(r#""dependency-name""#),
+            "expected kebab-case key 'dependency-name' in JSON output: {serialized}"
+        );
+        assert!(
+            serialized.contains(r#""version-tracking-manifest""#),
+            "expected kebab-case key 'version-tracking-manifest' in JSON output: {serialized}"
+        );
+    }
+
+    #[test]
+    fn additional_package_declaration_with_multiple_dependencies() {
+        let decl = AdditionalPackageDeclaration::new(
+            "multi-dep-pkg".to_string(),
+            PathBuf::from("packages/multi"),
+            vec!["packages/multi/**".to_string()],
+            AdditionalPackageManifest::new(
+                PathBuf::from("packages/multi/manifest.yaml"),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            vec![
+                VersionTrackingDependency::new(
+                    "dep-alpha".to_string(),
+                    VersionTrackingManifest::new(
+                        PathBuf::from("tracking/alpha.json"),
+                        ManifestFormat::Json,
+                        "alphaVersion".to_string(),
+                    ),
+                ),
+                VersionTrackingDependency::new(
+                    "dep-beta".to_string(),
+                    VersionTrackingManifest::new(
+                        PathBuf::from("tracking/beta.yaml"),
+                        ManifestFormat::Yaml,
+                        "betaVersion".to_string(),
+                    ),
+                ),
+            ],
+        );
+
+        let serialized = toml::to_string(&decl).expect("serialize to TOML");
+        let deserialized: AdditionalPackageDeclaration =
+            toml::from_str(&serialized).expect("deserialize from TOML");
+
+        assert_eq!(deserialized, decl);
+        assert_eq!(deserialized.dependencies().len(), 2);
+        assert_eq!(
+            deserialized.dependencies()[0].dependency_name(),
+            "dep-alpha"
+        );
+        assert_eq!(
+            deserialized.dependencies()[0]
+                .version_tracking_manifest()
+                .version_field_path(),
+            "alphaVersion"
+        );
+        assert_eq!(deserialized.dependencies()[1].dependency_name(), "dep-beta");
+        assert_eq!(
+            deserialized.dependencies()[1]
+                .version_tracking_manifest()
+                .version_field_path(),
+            "betaVersion"
+        );
+    }
+
+    #[test]
     fn additional_package_declaration_without_dependencies_defaults_to_empty() {
         let toml_str = r#"
 name = "my-helm-chart"

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -49,16 +49,16 @@ pub struct AdditionalPackageManifest {
     #[getset(get_copy, vis = "pub")]
     format: ManifestFormat,
     #[getset(get, vis = "pub")]
-    version_path: String,
+    version_field_path: String,
 }
 
 impl AdditionalPackageManifest {
     #[must_use]
-    pub fn new(file_path: PathBuf, format: ManifestFormat, version_path: String) -> Self {
+    pub fn new(file_path: PathBuf, format: ManifestFormat, version_field_path: String) -> Self {
         Self {
             file_path,
             format,
-            version_path,
+            version_field_path,
         }
     }
 }
@@ -600,11 +600,11 @@ mod tests {
         let manifest = AdditionalPackageManifest {
             file_path: PathBuf::from("charts/my-chart/Chart.yaml"),
             format: ManifestFormat::Yaml,
-            version_path: "version".to_string(),
+            version_field_path: "version".to_string(),
         };
         let serialized = serde_json::to_string(&manifest).unwrap();
         assert!(serialized.contains(r#""file-path""#));
-        assert!(serialized.contains(r#""version-path""#));
+        assert!(serialized.contains(r#""version-field-path""#));
         let deserialized: AdditionalPackageManifest = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, manifest);
     }
@@ -618,7 +618,7 @@ mod tests {
             manifest: AdditionalPackageManifest {
                 file_path: PathBuf::from("charts/my-chart/Chart.yaml"),
                 format: ManifestFormat::Yaml,
-                version_path: "version".to_string(),
+                version_field_path: "version".to_string(),
             },
         };
         let serialized = serde_json::to_string(&decl).unwrap();
@@ -643,7 +643,7 @@ mod tests {
             "manifest": {
                 "file-path": "charts/my-chart/Chart.yaml",
                 "format": "yaml",
-                "version-path": "version"
+                "version-field-path": "version"
             }
         }"#;
         let result = serde_json::from_str::<AdditionalPackageDeclaration>(json);

--- a/crates/changeset-core/src/types.rs
+++ b/crates/changeset-core/src/types.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 pub const CARGO_MANIFEST_FILENAME: &str = "Cargo.toml";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum ManifestFormat {
     Toml,

--- a/crates/changeset-manifest/Cargo.toml
+++ b/crates/changeset-manifest/Cargo.toml
@@ -13,9 +13,12 @@ keywords = ["cargo", "changeset", "toml", "manifest", "release"]
 categories = ["development-tools::cargo-plugins"]
 
 [dependencies]
+changeset-core = { workspace = true }
+jsonc-parser = { workspace = true }
 semver = { workspace = true }
 thiserror = { workspace = true }
 toml_edit = { workspace = true }
+yaml-edit = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.25"

--- a/crates/changeset-manifest/src/additional_packages.rs
+++ b/crates/changeset-manifest/src/additional_packages.rs
@@ -1,0 +1,610 @@
+use std::path::{Path, PathBuf};
+
+use changeset_core::{AdditionalPackageDeclaration, ManifestFormat};
+use toml_edit::{ArrayOfTables, Item, Table, Value, value};
+
+use crate::config::MetadataSection;
+use crate::error::ManifestError;
+use crate::reader::read_document;
+use crate::writer::navigate_to_changeset_table;
+
+pub struct AdditionalPackageUpdate {
+    pub path: Option<PathBuf>,
+    pub influence: Option<Vec<String>>,
+    pub manifest_file_path: Option<PathBuf>,
+    pub manifest_format: Option<ManifestFormat>,
+    pub manifest_version_path: Option<String>,
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written, or if the
+/// `additional-packages` key exists but is not an array-of-tables.
+pub fn add_additional_package(
+    path: &Path,
+    section: MetadataSection,
+    declaration: &AdditionalPackageDeclaration,
+) -> Result<(), ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
+
+    let aot = changeset_table
+        .entry("additional-packages")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
+
+    let Item::ArrayOfTables(aot) = aot else {
+        return Err(ManifestError::InvalidSectionType {
+            path: path.to_path_buf(),
+            section: "additional-packages".to_string(),
+        });
+    };
+
+    let mut table = Table::new();
+    table.insert("name", value(declaration.name().as_str()));
+    table.insert("path", value(declaration.path().to_string_lossy().as_ref()));
+
+    let mut influence_arr = toml_edit::Array::new();
+    for glob in declaration.influence() {
+        influence_arr.push(glob.as_str());
+    }
+    table.insert("influence", Item::Value(Value::Array(influence_arr)));
+
+    let mut manifest_table = Table::new();
+    manifest_table.insert(
+        "file-path",
+        value(
+            declaration
+                .manifest()
+                .file_path()
+                .to_string_lossy()
+                .as_ref(),
+        ),
+    );
+    manifest_table.insert(
+        "format",
+        value(declaration.manifest().format().to_string().as_str()),
+    );
+    manifest_table.insert(
+        "version-path",
+        value(declaration.manifest().version_path().as_str()),
+    );
+    table.insert("manifest", Item::Table(manifest_table));
+
+    aot.push(table);
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Returns `true` if the entry was found and removed, `false` if no entry matched `name`.
+///
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written.
+pub fn remove_additional_package(
+    path: &Path,
+    section: MetadataSection,
+    name: &str,
+) -> Result<bool, ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
+
+    let Some(aot_item) = changeset_table.get_mut("additional-packages") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(aot) = aot_item else {
+        return Ok(false);
+    };
+
+    let original_len = aot.len();
+    let indices_to_remove: Vec<usize> = aot
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            t.get("name")
+                .and_then(Item::as_str)
+                .is_some_and(|n| n == name)
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    if indices_to_remove.is_empty() {
+        return Ok(false);
+    }
+
+    for i in indices_to_remove.into_iter().rev() {
+        aot.remove(i);
+    }
+
+    let removed = aot.len() < original_len;
+    if removed {
+        std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+
+    Ok(removed)
+}
+
+/// Returns `true` if the entry was found and updated, `false` if no entry matched `name`.
+///
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written, or if the manifest
+/// sub-table is not a table type.
+pub fn update_additional_package(
+    path: &Path,
+    section: MetadataSection,
+    name: &str,
+    updates: &AdditionalPackageUpdate,
+) -> Result<bool, ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
+
+    let Some(aot_item) = changeset_table.get_mut("additional-packages") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(aot) = aot_item else {
+        return Ok(false);
+    };
+
+    let Some(table) = aot.iter_mut().find(|t| {
+        t.get("name")
+            .and_then(Item::as_str)
+            .is_some_and(|n| n == name)
+    }) else {
+        return Ok(false);
+    };
+
+    if let Some(ref new_path) = updates.path {
+        table.insert("path", value(new_path.to_string_lossy().as_ref()));
+    }
+
+    if let Some(ref new_influence) = updates.influence {
+        let mut arr = toml_edit::Array::new();
+        for glob in new_influence {
+            arr.push(glob.as_str());
+        }
+        table.insert("influence", Item::Value(Value::Array(arr)));
+    }
+
+    if updates.manifest_file_path.is_some()
+        || updates.manifest_format.is_some()
+        || updates.manifest_version_path.is_some()
+    {
+        let manifest_item = table
+            .entry("manifest")
+            .or_insert_with(|| Item::Table(Table::new()));
+
+        let manifest_table =
+            manifest_item
+                .as_table_mut()
+                .ok_or_else(|| ManifestError::InvalidSectionType {
+                    path: path.to_path_buf(),
+                    section: "additional-packages[].manifest".to_string(),
+                })?;
+
+        if let Some(ref new_file_path) = updates.manifest_file_path {
+            manifest_table.insert("file-path", value(new_file_path.to_string_lossy().as_ref()));
+        }
+
+        if let Some(new_format) = updates.manifest_format {
+            manifest_table.insert("format", value(new_format.to_string().as_str()));
+        }
+
+        if let Some(ref new_version_path) = updates.manifest_version_path {
+            manifest_table.insert("version-path", value(new_version_path.as_str()));
+        }
+    }
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use changeset_core::{AdditionalPackageManifest, ManifestFormat};
+    use std::path::PathBuf;
+
+    fn make_declaration(name: &str) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(format!("charts/{name}")),
+            vec![format!("charts/{name}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("charts/{name}/Chart.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+        )
+    }
+
+    fn write_temp_toml(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, content).expect("write test file");
+        (dir, path)
+    }
+
+    #[test]
+    fn add_creates_array_of_tables_entry() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        let decl = make_declaration("my-chart");
+
+        add_additional_package(&path, MetadataSection::Workspace, &decl)
+            .expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("[[workspace.metadata.changeset.additional-packages]]"));
+        assert!(content.contains(r#"name = "my-chart""#));
+    }
+
+    #[test]
+    fn add_appends_to_existing_array() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("chart-a"),
+        )
+        .expect("add first");
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("chart-b"),
+        )
+        .expect("add second");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"name = "chart-a""#));
+        assert!(content.contains(r#"name = "chart-b""#));
+    }
+
+    #[test]
+    fn add_preserves_existing_comments() {
+        let (_dir, path) = write_temp_toml(
+            r#"# Workspace config
+[workspace]
+# Members
+members = ["crates/*"]
+"#,
+        );
+        let decl = make_declaration("my-chart");
+
+        add_additional_package(&path, MetadataSection::Workspace, &decl)
+            .expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("# Workspace config"));
+        assert!(content.contains("# Members"));
+    }
+
+    #[test]
+    fn add_creates_nested_manifest_table() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        let decl = AdditionalPackageDeclaration::new(
+            "my-chart".to_string(),
+            PathBuf::from("charts/my-chart"),
+            vec![],
+            AdditionalPackageManifest::new(
+                PathBuf::from("charts/my-chart/Chart.yaml"),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+        );
+
+        add_additional_package(&path, MetadataSection::Workspace, &decl)
+            .expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"file-path = "charts/my-chart/Chart.yaml""#));
+        assert!(content.contains(r#"format = "yaml""#));
+        assert!(content.contains(r#"version-path = "version""#));
+    }
+
+    #[test]
+    fn add_serializes_influence_as_array() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        let decl = AdditionalPackageDeclaration::new(
+            "my-chart".to_string(),
+            PathBuf::from("charts/my-chart"),
+            vec!["charts/my-chart/**".to_string(), "helm/**".to_string()],
+            AdditionalPackageManifest::new(
+                PathBuf::from("charts/my-chart/Chart.yaml"),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+        );
+
+        add_additional_package(&path, MetadataSection::Workspace, &decl)
+            .expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("influence"));
+        assert!(content.contains(r#""charts/my-chart/**""#));
+        assert!(content.contains(r#""helm/**""#));
+    }
+
+    #[test]
+    fn remove_by_name_returns_true() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("my-chart"),
+        )
+        .expect("add should succeed");
+
+        let result = remove_additional_package(&path, MetadataSection::Workspace, "my-chart")
+            .expect("remove should succeed");
+
+        assert!(result);
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(!content.contains(r#"name = "my-chart""#));
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_false() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+
+        let result = remove_additional_package(&path, MetadataSection::Workspace, "nonexistent")
+            .expect("remove should succeed");
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn remove_preserves_other_entries() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("chart-a"),
+        )
+        .expect("add first");
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("chart-b"),
+        )
+        .expect("add second");
+
+        remove_additional_package(&path, MetadataSection::Workspace, "chart-a")
+            .expect("remove should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(!content.contains(r#"name = "chart-a""#));
+        assert!(content.contains(r#"name = "chart-b""#));
+    }
+
+    #[test]
+    fn remove_preserves_comments() {
+        let (_dir, path) = write_temp_toml(
+            r#"# Workspace config
+[workspace]
+# Members comment
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("chart-a"),
+        )
+        .expect("add");
+
+        remove_additional_package(&path, MetadataSection::Workspace, "chart-a").expect("remove");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("# Workspace config"));
+        assert!(content.contains("# Members comment"));
+    }
+
+    #[test]
+    fn update_modifies_path_field() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("my-chart"),
+        )
+        .expect("add");
+
+        let updates = AdditionalPackageUpdate {
+            path: Some(PathBuf::from("new/chart/path")),
+            influence: None,
+            manifest_file_path: None,
+            manifest_format: None,
+            manifest_version_path: None,
+        };
+        let result =
+            update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
+                .expect("update should succeed");
+
+        assert!(result);
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"path = "new/chart/path""#));
+    }
+
+    #[test]
+    fn update_modifies_influence() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("my-chart"),
+        )
+        .expect("add");
+
+        let updates = AdditionalPackageUpdate {
+            path: None,
+            influence: Some(vec!["new/pattern/**".to_string()]),
+            manifest_file_path: None,
+            manifest_format: None,
+            manifest_version_path: None,
+        };
+        update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
+            .expect("update should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#""new/pattern/**""#));
+    }
+
+    #[test]
+    fn update_modifies_manifest_fields() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("my-chart"),
+        )
+        .expect("add");
+
+        let updates = AdditionalPackageUpdate {
+            path: None,
+            influence: None,
+            manifest_file_path: None,
+            manifest_format: Some(ManifestFormat::Json),
+            manifest_version_path: Some("info.version".to_string()),
+        };
+        update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
+            .expect("update should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains(r#"format = "json""#));
+        assert!(content.contains(r#"version-path = "info.version""#));
+    }
+
+    #[test]
+    fn update_nonexistent_returns_false() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[workspace]
+members = ["crates/*"]
+"#,
+        );
+
+        let updates = AdditionalPackageUpdate {
+            path: Some(PathBuf::from("somewhere")),
+            influence: None,
+            manifest_file_path: None,
+            manifest_format: None,
+            manifest_version_path: None,
+        };
+        let result =
+            update_additional_package(&path, MetadataSection::Workspace, "nonexistent", &updates)
+                .expect("update should succeed");
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn update_preserves_comments() {
+        let (_dir, path) = write_temp_toml(
+            r#"# My project
+[workspace]
+# Workspace members
+members = ["crates/*"]
+"#,
+        );
+        add_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            &make_declaration("my-chart"),
+        )
+        .expect("add");
+
+        let updates = AdditionalPackageUpdate {
+            path: Some(PathBuf::from("new/path")),
+            influence: None,
+            manifest_file_path: None,
+            manifest_format: None,
+            manifest_version_path: None,
+        };
+        update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
+            .expect("update");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("# My project"));
+        assert!(content.contains("# Workspace members"));
+    }
+
+    #[test]
+    fn workspace_and_package_sections() {
+        let (_dir, path) = write_temp_toml(
+            r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+"#,
+        );
+        let decl = make_declaration("my-chart");
+
+        add_additional_package(&path, MetadataSection::Package, &decl).expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("[[package.metadata.changeset.additional-packages]]"));
+        assert!(!content.contains("[[workspace.metadata.changeset.additional-packages]]"));
+    }
+}

--- a/crates/changeset-manifest/src/additional_packages.rs
+++ b/crates/changeset-manifest/src/additional_packages.rs
@@ -197,8 +197,8 @@ pub fn update_additional_package(
             manifest_table.insert("format", value(new_format.to_string().as_str()));
         }
 
-        if let Some(ref new_version_path) = updates.manifest_version_field_path {
-            manifest_table.insert("version-field-path", value(new_version_path.as_str()));
+        if let Some(ref new_version_field_path) = updates.manifest_version_field_path {
+            manifest_table.insert("version-field-path", value(new_version_field_path.as_str()));
         }
     }
 

--- a/crates/changeset-manifest/src/additional_packages.rs
+++ b/crates/changeset-manifest/src/additional_packages.rs
@@ -226,6 +226,7 @@ mod tests {
                 ManifestFormat::Yaml,
                 "version".to_string(),
             ),
+            Vec::new(),
         )
     }
 
@@ -317,6 +318,7 @@ members = ["crates/*"]
                 ManifestFormat::Yaml,
                 "version".to_string(),
             ),
+            Vec::new(),
         );
 
         add_additional_package(&path, MetadataSection::Workspace, &decl)
@@ -345,6 +347,7 @@ members = ["crates/*"]
                 ManifestFormat::Yaml,
                 "version".to_string(),
             ),
+            Vec::new(),
         );
 
         add_additional_package(&path, MetadataSection::Workspace, &decl)

--- a/crates/changeset-manifest/src/additional_packages.rs
+++ b/crates/changeset-manifest/src/additional_packages.rs
@@ -13,7 +13,7 @@ pub struct AdditionalPackageUpdate {
     pub influence: Option<Vec<String>>,
     pub manifest_file_path: Option<PathBuf>,
     pub manifest_format: Option<ManifestFormat>,
-    pub manifest_version_path: Option<String>,
+    pub manifest_version_field_path: Option<String>,
 }
 
 /// # Errors
@@ -65,8 +65,8 @@ pub fn add_additional_package(
         value(declaration.manifest().format().to_string().as_str()),
     );
     manifest_table.insert(
-        "version-path",
-        value(declaration.manifest().version_path().as_str()),
+        "version-field-path",
+        value(declaration.manifest().version_field_path().as_str()),
     );
     table.insert("manifest", Item::Table(manifest_table));
 
@@ -175,7 +175,7 @@ pub fn update_additional_package(
 
     if updates.manifest_file_path.is_some()
         || updates.manifest_format.is_some()
-        || updates.manifest_version_path.is_some()
+        || updates.manifest_version_field_path.is_some()
     {
         let manifest_item = table
             .entry("manifest")
@@ -197,8 +197,8 @@ pub fn update_additional_package(
             manifest_table.insert("format", value(new_format.to_string().as_str()));
         }
 
-        if let Some(ref new_version_path) = updates.manifest_version_path {
-            manifest_table.insert("version-path", value(new_version_path.as_str()));
+        if let Some(ref new_version_path) = updates.manifest_version_field_path {
+            manifest_table.insert("version-field-path", value(new_version_path.as_str()));
         }
     }
 
@@ -325,7 +325,7 @@ members = ["crates/*"]
         let content = std::fs::read_to_string(&path).expect("read file");
         assert!(content.contains(r#"file-path = "charts/my-chart/Chart.yaml""#));
         assert!(content.contains(r#"format = "yaml""#));
-        assert!(content.contains(r#"version-path = "version""#));
+        assert!(content.contains(r#"version-field-path = "version""#));
     }
 
     #[test]
@@ -466,7 +466,7 @@ members = ["crates/*"]
             influence: None,
             manifest_file_path: None,
             manifest_format: None,
-            manifest_version_path: None,
+            manifest_version_field_path: None,
         };
         let result =
             update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
@@ -497,7 +497,7 @@ members = ["crates/*"]
             influence: Some(vec!["new/pattern/**".to_string()]),
             manifest_file_path: None,
             manifest_format: None,
-            manifest_version_path: None,
+            manifest_version_field_path: None,
         };
         update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
             .expect("update should succeed");
@@ -526,14 +526,14 @@ members = ["crates/*"]
             influence: None,
             manifest_file_path: None,
             manifest_format: Some(ManifestFormat::Json),
-            manifest_version_path: Some("info.version".to_string()),
+            manifest_version_field_path: Some("info.version".to_string()),
         };
         update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
             .expect("update should succeed");
 
         let content = std::fs::read_to_string(&path).expect("read file");
         assert!(content.contains(r#"format = "json""#));
-        assert!(content.contains(r#"version-path = "info.version""#));
+        assert!(content.contains(r#"version-field-path = "info.version""#));
     }
 
     #[test]
@@ -550,7 +550,7 @@ members = ["crates/*"]
             influence: None,
             manifest_file_path: None,
             manifest_format: None,
-            manifest_version_path: None,
+            manifest_version_field_path: None,
         };
         let result =
             update_additional_package(&path, MetadataSection::Workspace, "nonexistent", &updates)
@@ -580,7 +580,7 @@ members = ["crates/*"]
             influence: None,
             manifest_file_path: None,
             manifest_format: None,
-            manifest_version_path: None,
+            manifest_version_field_path: None,
         };
         update_additional_package(&path, MetadataSection::Workspace, "my-chart", &updates)
             .expect("update");

--- a/crates/changeset-manifest/src/error.rs
+++ b/crates/changeset-manifest/src/error.rs
@@ -48,4 +48,31 @@ pub enum ManifestError {
 
     #[error("expected '{section}' to be a table in manifest '{path}'")]
     InvalidSectionType { path: PathBuf, section: String },
+
+    #[error("failed to parse YAML at '{path}'")]
+    YamlParse {
+        path: PathBuf,
+        #[source]
+        source: yaml_edit::YamlError,
+    },
+
+    #[error("failed to parse JSON at '{path}'")]
+    JsonParse {
+        path: PathBuf,
+        #[source]
+        source: jsonc_parser::errors::ParseError,
+    },
+
+    #[error("failed to decode JSON string at '{path}'")]
+    JsonStringDecode {
+        path: PathBuf,
+        #[source]
+        source: jsonc_parser::ParseStringErrorKind,
+    },
+
+    #[error("version path '{version_path}' not found in manifest at '{path}'")]
+    VersionPathNotFound { path: PathBuf, version_path: String },
+
+    #[error("expected string at version path '{version_path}' in manifest at '{path}'")]
+    VersionNotString { path: PathBuf, version_path: String },
 }

--- a/crates/changeset-manifest/src/error.rs
+++ b/crates/changeset-manifest/src/error.rs
@@ -70,9 +70,15 @@ pub enum ManifestError {
         source: jsonc_parser::ParseStringErrorKind,
     },
 
-    #[error("version path '{version_path}' not found in manifest at '{path}'")]
-    VersionPathNotFound { path: PathBuf, version_path: String },
+    #[error("version path '{version_field_path}' not found in manifest at '{path}'")]
+    VersionPathNotFound {
+        path: PathBuf,
+        version_field_path: String,
+    },
 
-    #[error("expected string at version path '{version_path}' in manifest at '{path}'")]
-    VersionNotString { path: PathBuf, version_path: String },
+    #[error("expected string at version path '{version_field_path}' in manifest at '{path}'")]
+    VersionNotString {
+        path: PathBuf,
+        version_field_path: String,
+    },
 }

--- a/crates/changeset-manifest/src/external.rs
+++ b/crates/changeset-manifest/src/external.rs
@@ -1,0 +1,574 @@
+use std::path::Path;
+
+use changeset_core::types::ManifestFormat;
+use jsonc_parser::ParseOptions;
+use jsonc_parser::cst::{CstInputValue, CstObject, CstRootNode};
+use semver::Version;
+use toml_edit::DocumentMut;
+use yaml_edit::Document;
+
+use crate::error::ManifestError;
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read, updated, or written.
+pub fn write_external_version(
+    path: &Path,
+    format: ManifestFormat,
+    version_path: &str,
+    version: &Version,
+) -> Result<(), ManifestError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let new_content = match format {
+        ManifestFormat::Toml => write_toml_version(&content, path, version_path, version)?,
+        ManifestFormat::Yaml => write_yaml_version(&content, path, version_path, version)?,
+        ManifestFormat::Json => write_json_version(&content, path, version_path, version)?,
+    };
+
+    std::fs::write(path, new_content).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// # Errors
+///
+/// Returns `ManifestError::VerificationFailed` if the version does not match the expected value.
+pub fn verify_external_version(
+    path: &Path,
+    format: ManifestFormat,
+    version_path: &str,
+    expected: &Version,
+) -> Result<(), ManifestError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let version_str = match format {
+        ManifestFormat::Toml => read_toml_version(&content, path, version_path)?,
+        ManifestFormat::Yaml => read_yaml_version(&content, path, version_path)?,
+        ManifestFormat::Json => read_json_version(&content, path, version_path)?,
+    };
+
+    let actual =
+        version_str
+            .parse::<Version>()
+            .map_err(|source| ManifestError::InvalidVersion {
+                path: path.to_path_buf(),
+                version: version_str,
+                source,
+            })?;
+
+    if actual != *expected {
+        return Err(ManifestError::VerificationFailed {
+            path: path.to_path_buf(),
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn write_toml_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+    version: &Version,
+) -> Result<String, ManifestError> {
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .map_err(|source| ManifestError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let segments: Vec<&str> = version_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    let mut current = doc.as_item_mut();
+    for segment in parent_segments {
+        current = current
+            .get_mut(*segment)
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+    }
+
+    let table = current
+        .as_table_like_mut()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    if table.get(leaf_key).is_none() {
+        return Err(ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        });
+    }
+
+    table.insert(leaf_key, toml_edit::value(version.to_string()));
+
+    Ok(doc.to_string())
+}
+
+fn read_toml_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+) -> Result<String, ManifestError> {
+    let doc = content
+        .parse::<DocumentMut>()
+        .map_err(|source| ManifestError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let mut current = doc.as_item();
+    for segment in version_path.split('.') {
+        current = current
+            .get(segment)
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+    }
+
+    current
+        .as_str()
+        .map(String::from)
+        .ok_or_else(|| ManifestError::VersionNotString {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })
+}
+
+fn write_yaml_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+    version: &Version,
+) -> Result<String, ManifestError> {
+    let doc = content
+        .parse::<Document>()
+        .map_err(|source| ManifestError::YamlParse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let segments: Vec<&str> = version_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    let mapping = doc
+        .as_mapping()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let mut current_mapping = mapping;
+    for segment in parent_segments {
+        current_mapping = current_mapping.get_mapping(*segment).ok_or_else(|| {
+            ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            }
+        })?;
+    }
+
+    if !current_mapping.contains_key(*leaf_key) {
+        return Err(ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        });
+    }
+
+    current_mapping.set(*leaf_key, version.to_string().as_str());
+
+    Ok(doc.to_string())
+}
+
+fn read_yaml_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+) -> Result<String, ManifestError> {
+    let doc = content
+        .parse::<Document>()
+        .map_err(|source| ManifestError::YamlParse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let segments: Vec<&str> = version_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    let mapping = doc
+        .as_mapping()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let mut current_mapping = mapping;
+    for segment in parent_segments {
+        current_mapping = current_mapping.get_mapping(*segment).ok_or_else(|| {
+            ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            }
+        })?;
+    }
+
+    let node =
+        current_mapping
+            .get(*leaf_key)
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    node.as_scalar()
+        .map(yaml_edit::Scalar::as_string)
+        .ok_or_else(|| ManifestError::VersionNotString {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })
+}
+
+fn navigate_json_to_object(
+    root_obj: &CstObject,
+    path: &Path,
+    version_path: &str,
+    parent_segments: &[&str],
+) -> Result<CstObject, ManifestError> {
+    let mut current = root_obj.clone();
+    for segment in parent_segments {
+        current =
+            current
+                .object_value(segment)
+                .ok_or_else(|| ManifestError::VersionPathNotFound {
+                    path: path.to_path_buf(),
+                    version_path: version_path.to_string(),
+                })?;
+    }
+    Ok(current)
+}
+
+fn write_json_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+    version: &Version,
+) -> Result<String, ManifestError> {
+    let root = CstRootNode::parse(content, &ParseOptions::default()).map_err(|source| {
+        ManifestError::JsonParse {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+
+    let root_obj = root
+        .object_value()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let segments: Vec<&str> = version_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    let target_obj = navigate_json_to_object(&root_obj, path, version_path, parent_segments)?;
+
+    let prop = target_obj
+        .get(leaf_key)
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    prop.set_value(CstInputValue::String(version.to_string()));
+
+    Ok(root.to_string())
+}
+
+fn read_json_version(
+    content: &str,
+    path: &Path,
+    version_path: &str,
+) -> Result<String, ManifestError> {
+    let root = CstRootNode::parse(content, &ParseOptions::default()).map_err(|source| {
+        ManifestError::JsonParse {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+
+    let root_obj = root
+        .object_value()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let segments: Vec<&str> = version_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            })?;
+
+    let target_obj = navigate_json_to_object(&root_obj, path, version_path, parent_segments)?;
+
+    let prop = target_obj
+        .get(leaf_key)
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let node = prop
+        .value()
+        .ok_or_else(|| ManifestError::VersionNotString {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    let string_lit = node
+        .as_string_lit()
+        .ok_or_else(|| ManifestError::VersionNotString {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })?;
+
+    string_lit
+        .decoded_value()
+        .map_err(|source| ManifestError::JsonStringDecode {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::Version;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn writes_toml_version_preserving_comments() {
+        let content = "# package info\n[package]\nname = \"foo\"\nversion = \"1.0.0\"\n# after version\nedition = \"2024\"\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(2, 0, 0),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("# package info"));
+        assert!(result.contains("# after version"));
+        assert!(result.contains(r#"version = "2.0.0""#));
+    }
+
+    #[test]
+    fn writes_yaml_version_preserving_comments() {
+        let content = "name: my-chart # chart name\nversion: \"1.0.0\" # current version\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Yaml,
+            "version",
+            &Version::new(2, 0, 0),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("# chart name"));
+        assert!(result.contains("2.0.0"));
+    }
+
+    #[test]
+    fn writes_json_version_preserving_formatting() {
+        let content = "{\n  \"version\": \"1.0.0\",\n  \"name\": \"my-pkg\"\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "version",
+            &Version::new(2, 0, 0),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("  \"version\""));
+        assert!(result.contains("\"2.0.0\""));
+    }
+
+    #[test]
+    fn writes_jsonc_version_preserving_comments() {
+        let content = "{\n  // version field\n  \"version\": \"1.0.0\"\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "version",
+            &Version::new(2, 0, 0),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("// version field"));
+        assert!(result.contains("\"2.0.0\""));
+    }
+
+    #[test]
+    fn writes_yaml_version_flat_path() {
+        let content = "version: \"1.0.0\"\nname: my-chart\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Yaml,
+            "version",
+            &Version::new(3, 1, 4),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("3.1.4"));
+    }
+
+    #[test]
+    fn writes_toml_version_nested_path() {
+        let content = "[package]\nname = \"my-crate\"\nversion = \"1.0.0\"\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(1, 2, 3),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains(r#"version = "1.2.3""#));
+    }
+
+    #[test]
+    fn writes_json_version_nested_path() {
+        let content = "{\n  \"metadata\": {\n    \"version\": \"1.0.0\"\n  }\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        write_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "metadata.version",
+            &Version::new(2, 0, 0),
+        )
+        .expect("write version");
+
+        let result = std::fs::read_to_string(file.path()).expect("read file");
+        assert!(result.contains("\"2.0.0\""));
+    }
+
+    #[test]
+    fn verifies_matching_version() {
+        let content = "{\n  \"version\": \"1.2.3\"\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        verify_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "version",
+            &Version::new(1, 2, 3),
+        )
+        .expect("verify version");
+    }
+
+    #[test]
+    fn verifies_returns_error_on_mismatch() {
+        let content = "{\n  \"version\": \"1.0.0\"\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        let result = verify_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "version",
+            &Version::new(2, 0, 0),
+        );
+        assert!(matches!(
+            result,
+            Err(ManifestError::VerificationFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn returns_error_for_missing_version_path() {
+        let content = "{\n  \"name\": \"my-pkg\"\n}\n";
+        let file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(file.path(), content).expect("write file");
+
+        let result = write_external_version(
+            file.path(),
+            ManifestFormat::Json,
+            "version",
+            &Version::new(1, 0, 0),
+        );
+        assert!(matches!(
+            result,
+            Err(ManifestError::VersionPathNotFound { .. })
+        ));
+    }
+}

--- a/crates/changeset-manifest/src/external.rs
+++ b/crates/changeset-manifest/src/external.rs
@@ -15,7 +15,7 @@ use crate::error::ManifestError;
 pub fn write_external_version(
     path: &Path,
     format: ManifestFormat,
-    version_path: &str,
+    version_field_path: &str,
     version: &Version,
 ) -> Result<(), ManifestError> {
     let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
@@ -24,9 +24,9 @@ pub fn write_external_version(
     })?;
 
     let new_content = match format {
-        ManifestFormat::Toml => write_toml_version(&content, path, version_path, version)?,
-        ManifestFormat::Yaml => write_yaml_version(&content, path, version_path, version)?,
-        ManifestFormat::Json => write_json_version(&content, path, version_path, version)?,
+        ManifestFormat::Toml => write_toml_version(&content, path, version_field_path, version)?,
+        ManifestFormat::Yaml => write_yaml_version(&content, path, version_field_path, version)?,
+        ManifestFormat::Json => write_json_version(&content, path, version_field_path, version)?,
     };
 
     std::fs::write(path, new_content).map_err(|source| ManifestError::Write {
@@ -41,7 +41,7 @@ pub fn write_external_version(
 pub fn verify_external_version(
     path: &Path,
     format: ManifestFormat,
-    version_path: &str,
+    version_field_path: &str,
     expected: &Version,
 ) -> Result<(), ManifestError> {
     let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
@@ -50,9 +50,9 @@ pub fn verify_external_version(
     })?;
 
     let version_str = match format {
-        ManifestFormat::Toml => read_toml_version(&content, path, version_path)?,
-        ManifestFormat::Yaml => read_yaml_version(&content, path, version_path)?,
-        ManifestFormat::Json => read_json_version(&content, path, version_path)?,
+        ManifestFormat::Toml => read_toml_version(&content, path, version_field_path)?,
+        ManifestFormat::Yaml => read_yaml_version(&content, path, version_field_path)?,
+        ManifestFormat::Json => read_json_version(&content, path, version_field_path)?,
     };
 
     let actual =
@@ -78,7 +78,7 @@ pub fn verify_external_version(
 fn write_toml_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
     version: &Version,
 ) -> Result<String, ManifestError> {
     let mut doc = content
@@ -88,13 +88,13 @@ fn write_toml_version(
             source,
         })?;
 
-    let segments: Vec<&str> = version_path.split('.').collect();
+    let segments: Vec<&str> = version_field_path.split('.').collect();
     let (leaf_key, parent_segments) =
         segments
             .split_last()
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
     let mut current = doc.as_item_mut();
@@ -103,7 +103,7 @@ fn write_toml_version(
             .get_mut(*segment)
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
     }
 
@@ -111,13 +111,13 @@ fn write_toml_version(
         .as_table_like_mut()
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     if table.get(leaf_key).is_none() {
         return Err(ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         });
     }
 
@@ -129,7 +129,7 @@ fn write_toml_version(
 fn read_toml_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
 ) -> Result<String, ManifestError> {
     let doc = content
         .parse::<DocumentMut>()
@@ -139,12 +139,12 @@ fn read_toml_version(
         })?;
 
     let mut current = doc.as_item();
-    for segment in version_path.split('.') {
+    for segment in version_field_path.split('.') {
         current = current
             .get(segment)
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
     }
 
@@ -153,14 +153,14 @@ fn read_toml_version(
         .map(String::from)
         .ok_or_else(|| ManifestError::VersionNotString {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })
 }
 
 fn write_yaml_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
     version: &Version,
 ) -> Result<String, ManifestError> {
     let doc = content
@@ -170,20 +170,20 @@ fn write_yaml_version(
             source,
         })?;
 
-    let segments: Vec<&str> = version_path.split('.').collect();
+    let segments: Vec<&str> = version_field_path.split('.').collect();
     let (leaf_key, parent_segments) =
         segments
             .split_last()
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
     let mapping = doc
         .as_mapping()
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     let mut current_mapping = mapping;
@@ -191,7 +191,7 @@ fn write_yaml_version(
         current_mapping = current_mapping.get_mapping(*segment).ok_or_else(|| {
             ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             }
         })?;
     }
@@ -199,7 +199,7 @@ fn write_yaml_version(
     if !current_mapping.contains_key(*leaf_key) {
         return Err(ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         });
     }
 
@@ -211,7 +211,7 @@ fn write_yaml_version(
 fn read_yaml_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
 ) -> Result<String, ManifestError> {
     let doc = content
         .parse::<Document>()
@@ -220,20 +220,20 @@ fn read_yaml_version(
             source,
         })?;
 
-    let segments: Vec<&str> = version_path.split('.').collect();
+    let segments: Vec<&str> = version_field_path.split('.').collect();
     let (leaf_key, parent_segments) =
         segments
             .split_last()
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
     let mapping = doc
         .as_mapping()
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     let mut current_mapping = mapping;
@@ -241,7 +241,7 @@ fn read_yaml_version(
         current_mapping = current_mapping.get_mapping(*segment).ok_or_else(|| {
             ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             }
         })?;
     }
@@ -251,21 +251,21 @@ fn read_yaml_version(
             .get(*leaf_key)
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
     node.as_scalar()
         .map(yaml_edit::Scalar::as_string)
         .ok_or_else(|| ManifestError::VersionNotString {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })
 }
 
 fn navigate_json_to_object(
     root_obj: &CstObject,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
     parent_segments: &[&str],
 ) -> Result<CstObject, ManifestError> {
     let mut current = root_obj.clone();
@@ -275,7 +275,7 @@ fn navigate_json_to_object(
                 .object_value(segment)
                 .ok_or_else(|| ManifestError::VersionPathNotFound {
                     path: path.to_path_buf(),
-                    version_path: version_path.to_string(),
+                    version_field_path: version_field_path.to_string(),
                 })?;
     }
     Ok(current)
@@ -284,7 +284,7 @@ fn navigate_json_to_object(
 fn write_json_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
     version: &Version,
 ) -> Result<String, ManifestError> {
     let root = CstRootNode::parse(content, &ParseOptions::default()).map_err(|source| {
@@ -298,25 +298,25 @@ fn write_json_version(
         .object_value()
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
-    let segments: Vec<&str> = version_path.split('.').collect();
+    let segments: Vec<&str> = version_field_path.split('.').collect();
     let (leaf_key, parent_segments) =
         segments
             .split_last()
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
-    let target_obj = navigate_json_to_object(&root_obj, path, version_path, parent_segments)?;
+    let target_obj = navigate_json_to_object(&root_obj, path, version_field_path, parent_segments)?;
 
     let prop = target_obj
         .get(leaf_key)
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     prop.set_value(CstInputValue::String(version.to_string()));
@@ -327,7 +327,7 @@ fn write_json_version(
 fn read_json_version(
     content: &str,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
 ) -> Result<String, ManifestError> {
     let root = CstRootNode::parse(content, &ParseOptions::default()).map_err(|source| {
         ManifestError::JsonParse {
@@ -340,39 +340,39 @@ fn read_json_version(
         .object_value()
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
-    let segments: Vec<&str> = version_path.split('.').collect();
+    let segments: Vec<&str> = version_field_path.split('.').collect();
     let (leaf_key, parent_segments) =
         segments
             .split_last()
             .ok_or_else(|| ManifestError::VersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             })?;
 
-    let target_obj = navigate_json_to_object(&root_obj, path, version_path, parent_segments)?;
+    let target_obj = navigate_json_to_object(&root_obj, path, version_field_path, parent_segments)?;
 
     let prop = target_obj
         .get(leaf_key)
         .ok_or_else(|| ManifestError::VersionPathNotFound {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     let node = prop
         .value()
         .ok_or_else(|| ManifestError::VersionNotString {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     let string_lit = node
         .as_string_lit()
         .ok_or_else(|| ManifestError::VersionNotString {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })?;
 
     string_lit
@@ -555,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_error_for_missing_version_path() {
+    fn returns_error_for_missing_version_field_path() {
         let content = "{\n  \"name\": \"my-pkg\"\n}\n";
         let file = NamedTempFile::new().expect("create temp file");
         std::fs::write(file.path(), content).expect("write file");

--- a/crates/changeset-manifest/src/external.rs
+++ b/crates/changeset-manifest/src/external.rs
@@ -37,6 +37,59 @@ pub fn write_external_version(
 
 /// # Errors
 ///
+/// Returns an error if the manifest cannot be read, updated, or written.
+pub fn restore_external_version(
+    path: &Path,
+    format: ManifestFormat,
+    version_field_path: &str,
+    version_str: &str,
+) -> Result<(), ManifestError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let new_content = match format {
+        ManifestFormat::Toml => {
+            restore_toml_version(&content, path, version_field_path, version_str)?
+        }
+        ManifestFormat::Yaml => {
+            restore_yaml_version(&content, path, version_field_path, version_str)?
+        }
+        ManifestFormat::Json => {
+            restore_json_version(&content, path, version_field_path, version_str)?
+        }
+    };
+
+    std::fs::write(path, new_content).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read or the version field path
+/// does not resolve to a string value.
+pub fn read_external_version_string(
+    path: &Path,
+    format: ManifestFormat,
+    version_field_path: &str,
+) -> Result<String, ManifestError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    match format {
+        ManifestFormat::Toml => read_toml_version(&content, path, version_field_path),
+        ManifestFormat::Yaml => read_yaml_version(&content, path, version_field_path),
+        ManifestFormat::Json => read_json_version(&content, path, version_field_path),
+    }
+}
+
+/// # Errors
+///
 /// Returns `ManifestError::VerificationFailed` if the version does not match the expected value.
 pub fn verify_external_version(
     path: &Path,
@@ -381,6 +434,151 @@ fn read_json_version(
             path: path.to_path_buf(),
             source,
         })
+}
+
+fn restore_toml_version(
+    content: &str,
+    path: &Path,
+    version_field_path: &str,
+    version_str: &str,
+) -> Result<String, ManifestError> {
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .map_err(|source| ManifestError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let segments: Vec<&str> = version_field_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_field_path: version_field_path.to_string(),
+            })?;
+
+    let mut current = doc.as_item_mut();
+    for segment in parent_segments {
+        current = current
+            .get_mut(*segment)
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_field_path: version_field_path.to_string(),
+            })?;
+    }
+
+    let table = current
+        .as_table_like_mut()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        })?;
+
+    if table.get(leaf_key).is_none() {
+        return Err(ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        });
+    }
+
+    table.insert(leaf_key, toml_edit::value(version_str));
+
+    Ok(doc.to_string())
+}
+
+fn restore_yaml_version(
+    content: &str,
+    path: &Path,
+    version_field_path: &str,
+    version_str: &str,
+) -> Result<String, ManifestError> {
+    let doc = content
+        .parse::<Document>()
+        .map_err(|source| ManifestError::YamlParse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let segments: Vec<&str> = version_field_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_field_path: version_field_path.to_string(),
+            })?;
+
+    let mapping = doc
+        .as_mapping()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        })?;
+
+    let mut current_mapping = mapping;
+    for segment in parent_segments {
+        current_mapping = current_mapping.get_mapping(*segment).ok_or_else(|| {
+            ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_field_path: version_field_path.to_string(),
+            }
+        })?;
+    }
+
+    if !current_mapping.contains_key(*leaf_key) {
+        return Err(ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        });
+    }
+
+    current_mapping.set(*leaf_key, version_str);
+
+    Ok(doc.to_string())
+}
+
+fn restore_json_version(
+    content: &str,
+    path: &Path,
+    version_field_path: &str,
+    version_str: &str,
+) -> Result<String, ManifestError> {
+    let root = CstRootNode::parse(content, &ParseOptions::default()).map_err(|source| {
+        ManifestError::JsonParse {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+
+    let root_obj = root
+        .object_value()
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        })?;
+
+    let segments: Vec<&str> = version_field_path.split('.').collect();
+    let (leaf_key, parent_segments) =
+        segments
+            .split_last()
+            .ok_or_else(|| ManifestError::VersionPathNotFound {
+                path: path.to_path_buf(),
+                version_field_path: version_field_path.to_string(),
+            })?;
+
+    let target_obj = navigate_json_to_object(&root_obj, path, version_field_path, parent_segments)?;
+
+    let prop = target_obj
+        .get(leaf_key)
+        .ok_or_else(|| ManifestError::VersionPathNotFound {
+            path: path.to_path_buf(),
+            version_field_path: version_field_path.to_string(),
+        })?;
+
+    prop.set_value(CstInputValue::String(version_str.to_string()));
+
+    Ok(root.to_string())
 }
 
 #[cfg(test)]

--- a/crates/changeset-manifest/src/lib.rs
+++ b/crates/changeset-manifest/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod error;
 mod external;
 mod reader;
+mod version_tracking_deps;
 mod writer;
 
 pub use additional_packages::{
@@ -14,10 +15,19 @@ pub use config::{
     ZeroVersionBehavior,
 };
 pub use error::ManifestError;
-pub use external::{verify_external_version, write_external_version};
+pub use external::{
+    read_external_version_string, restore_external_version, verify_external_version,
+    write_external_version,
+};
 pub use reader::{
     has_inherited_version, has_workspace_package_version, read_document, read_version,
     read_workspace_version,
+};
+pub use version_tracking_deps::{
+    add_version_tracking_dependency_to_additional_package,
+    add_version_tracking_dependency_to_crate,
+    remove_version_tracking_dependency_from_additional_package,
+    remove_version_tracking_dependency_from_crate,
 };
 pub use writer::{
     remove_workspace_version, update_dependency_version, verify_version, write_metadata_section,

--- a/crates/changeset-manifest/src/lib.rs
+++ b/crates/changeset-manifest/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod error;
+mod external;
 mod reader;
 mod writer;
 
@@ -8,6 +9,7 @@ pub use config::{
     ZeroVersionBehavior,
 };
 pub use error::ManifestError;
+pub use external::{verify_external_version, write_external_version};
 pub use reader::{
     has_inherited_version, has_workspace_package_version, read_document, read_version,
     read_workspace_version,

--- a/crates/changeset-manifest/src/lib.rs
+++ b/crates/changeset-manifest/src/lib.rs
@@ -1,9 +1,14 @@
+mod additional_packages;
 mod config;
 mod error;
 mod external;
 mod reader;
 mod writer;
 
+pub use additional_packages::{
+    AdditionalPackageUpdate, add_additional_package, remove_additional_package,
+    update_additional_package,
+};
 pub use config::{
     ChangelogLocation, ComparisonLinks, InitConfig, MetadataSection, NoneBumpBehavior, TagFormat,
     ZeroVersionBehavior,

--- a/crates/changeset-manifest/src/version_tracking_deps.rs
+++ b/crates/changeset-manifest/src/version_tracking_deps.rs
@@ -1,0 +1,418 @@
+use std::path::Path;
+
+use changeset_core::VersionTrackingDependency;
+use toml_edit::{ArrayOfTables, Item, Table, value};
+
+use crate::config::MetadataSection;
+use crate::error::ManifestError;
+use crate::reader::read_document;
+use crate::writer::navigate_to_changeset_table;
+
+fn build_dependency_table(dependency: &VersionTrackingDependency) -> Table {
+    let mut table = Table::new();
+    table.insert(
+        "dependency-name",
+        value(dependency.dependency_name().as_str()),
+    );
+
+    let mut manifest_table = Table::new();
+    manifest_table.insert(
+        "file-path",
+        value(
+            dependency
+                .version_tracking_manifest()
+                .file_path()
+                .to_string_lossy()
+                .as_ref(),
+        ),
+    );
+    manifest_table.insert(
+        "format",
+        value(
+            dependency
+                .version_tracking_manifest()
+                .format()
+                .to_string()
+                .as_str(),
+        ),
+    );
+    manifest_table.insert(
+        "version-field-path",
+        value(
+            dependency
+                .version_tracking_manifest()
+                .version_field_path()
+                .as_str(),
+        ),
+    );
+    table.insert("version-tracking-manifest", Item::Table(manifest_table));
+
+    table
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written.
+pub fn add_version_tracking_dependency_to_additional_package(
+    path: &Path,
+    section: MetadataSection,
+    package_name: &str,
+    dependency: &VersionTrackingDependency,
+) -> Result<bool, ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
+
+    let Some(aot_item) = changeset_table.get_mut("additional-packages") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(aot) = aot_item else {
+        return Ok(false);
+    };
+
+    let Some(pkg_table) = aot.iter_mut().find(|t| {
+        t.get("name")
+            .and_then(Item::as_str)
+            .is_some_and(|n| n == package_name)
+    }) else {
+        return Ok(false);
+    };
+
+    let deps_aot = pkg_table
+        .entry("dependencies")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
+
+    let Item::ArrayOfTables(deps) = deps_aot else {
+        return Err(ManifestError::InvalidSectionType {
+            path: path.to_path_buf(),
+            section: "additional-packages[].dependencies".to_string(),
+        });
+    };
+
+    deps.push(build_dependency_table(dependency));
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    Ok(true)
+}
+
+/// Returns `true` if the dependency was found and removed, `false` if not found.
+///
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written.
+pub fn remove_version_tracking_dependency_from_additional_package(
+    path: &Path,
+    section: MetadataSection,
+    package_name: &str,
+    dependency_name: &str,
+) -> Result<bool, ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
+
+    let Some(aot_item) = changeset_table.get_mut("additional-packages") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(aot) = aot_item else {
+        return Ok(false);
+    };
+
+    let Some(pkg_table) = aot.iter_mut().find(|t| {
+        t.get("name")
+            .and_then(Item::as_str)
+            .is_some_and(|n| n == package_name)
+    }) else {
+        return Ok(false);
+    };
+
+    let Some(deps_item) = pkg_table.get_mut("dependencies") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(deps) = deps_item else {
+        return Ok(false);
+    };
+
+    let original_len = deps.len();
+    let indices_to_remove: Vec<usize> = deps
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            t.get("dependency-name")
+                .and_then(Item::as_str)
+                .is_some_and(|n| n == dependency_name)
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    if indices_to_remove.is_empty() {
+        return Ok(false);
+    }
+
+    for i in indices_to_remove.into_iter().rev() {
+        deps.remove(i);
+    }
+
+    let removed = deps.len() < original_len;
+    if removed {
+        std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+
+    Ok(removed)
+}
+
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written.
+pub fn add_version_tracking_dependency_to_crate(
+    path: &Path,
+    dependency: &VersionTrackingDependency,
+) -> Result<(), ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, MetadataSection::Package, path)?;
+
+    let deps_aot = changeset_table
+        .entry("additional-package-dependencies")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
+
+    let Item::ArrayOfTables(deps) = deps_aot else {
+        return Err(ManifestError::InvalidSectionType {
+            path: path.to_path_buf(),
+            section: "additional-package-dependencies".to_string(),
+        });
+    };
+
+    deps.push(build_dependency_table(dependency));
+
+    std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Returns `true` if the dependency was found and removed, `false` if not found.
+///
+/// # Errors
+///
+/// Returns an error if the manifest file cannot be read or written.
+pub fn remove_version_tracking_dependency_from_crate(
+    path: &Path,
+    dependency_name: &str,
+) -> Result<bool, ManifestError> {
+    let mut doc = read_document(path)?;
+    let changeset_table = navigate_to_changeset_table(&mut doc, MetadataSection::Package, path)?;
+
+    let Some(deps_item) = changeset_table.get_mut("additional-package-dependencies") else {
+        return Ok(false);
+    };
+
+    let Item::ArrayOfTables(deps) = deps_item else {
+        return Ok(false);
+    };
+
+    let original_len = deps.len();
+    let indices_to_remove: Vec<usize> = deps
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            t.get("dependency-name")
+                .and_then(Item::as_str)
+                .is_some_and(|n| n == dependency_name)
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    if indices_to_remove.is_empty() {
+        return Ok(false);
+    }
+
+    for i in indices_to_remove.into_iter().rev() {
+        deps.remove(i);
+    }
+
+    let removed = deps.len() < original_len;
+    if removed {
+        std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use changeset_core::{ManifestFormat, VersionTrackingManifest};
+
+    use super::*;
+
+    fn make_dependency(dep_name: &str) -> VersionTrackingDependency {
+        VersionTrackingDependency::new(
+            dep_name.to_string(),
+            VersionTrackingManifest::new(
+                PathBuf::from("charts/dep/Chart.yaml"),
+                ManifestFormat::Yaml,
+                "appVersion".to_string(),
+            ),
+        )
+    }
+
+    fn write_temp_toml(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, content).expect("write test file");
+        (dir, path)
+    }
+
+    fn workspace_toml_with_additional_package() -> String {
+        r#"
+[workspace]
+members = ["crates/*"]
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+"#
+        .to_string()
+    }
+
+    fn package_toml() -> String {
+        r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn add_dependency_to_additional_package_creates_entry() {
+        let (_dir, path) = write_temp_toml(&workspace_toml_with_additional_package());
+        let dep = make_dependency("my-rust-crate");
+
+        let result = add_version_tracking_dependency_to_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            "my-chart",
+            &dep,
+        )
+        .expect("add should succeed");
+
+        assert!(result);
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("dependency-name"));
+        assert!(content.contains("my-rust-crate"));
+        assert!(content.contains("appVersion"));
+    }
+
+    #[test]
+    fn add_dependency_to_missing_package_returns_false() {
+        let (_dir, path) = write_temp_toml(&workspace_toml_with_additional_package());
+        let dep = make_dependency("my-rust-crate");
+
+        let result = add_version_tracking_dependency_to_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            "nonexistent",
+            &dep,
+        )
+        .expect("should not error");
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn remove_dependency_from_additional_package() {
+        let (_dir, path) = write_temp_toml(&workspace_toml_with_additional_package());
+        let dep = make_dependency("my-rust-crate");
+
+        add_version_tracking_dependency_to_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            "my-chart",
+            &dep,
+        )
+        .expect("add should succeed");
+
+        let removed = remove_version_tracking_dependency_from_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            "my-chart",
+            "my-rust-crate",
+        )
+        .expect("remove should succeed");
+
+        assert!(removed);
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(!content.contains("my-rust-crate"));
+    }
+
+    #[test]
+    fn remove_nonexistent_dependency_returns_false() {
+        let (_dir, path) = write_temp_toml(&workspace_toml_with_additional_package());
+
+        let removed = remove_version_tracking_dependency_from_additional_package(
+            &path,
+            MetadataSection::Workspace,
+            "my-chart",
+            "nonexistent",
+        )
+        .expect("should not error");
+
+        assert!(!removed);
+    }
+
+    #[test]
+    fn add_dependency_to_crate_creates_entry() {
+        let (_dir, path) = write_temp_toml(&package_toml());
+        let dep = make_dependency("my-helm-chart");
+
+        add_version_tracking_dependency_to_crate(&path, &dep).expect("add should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(content.contains("additional-package-dependencies"));
+        assert!(content.contains("my-helm-chart"));
+        assert!(content.contains("appVersion"));
+    }
+
+    #[test]
+    fn remove_dependency_from_crate() {
+        let (_dir, path) = write_temp_toml(&package_toml());
+        let dep = make_dependency("my-helm-chart");
+
+        add_version_tracking_dependency_to_crate(&path, &dep).expect("add should succeed");
+
+        let removed = remove_version_tracking_dependency_from_crate(&path, "my-helm-chart")
+            .expect("remove should succeed");
+
+        assert!(removed);
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert!(!content.contains("my-helm-chart"));
+    }
+
+    #[test]
+    fn remove_nonexistent_dependency_from_crate_returns_false() {
+        let (_dir, path) = write_temp_toml(&package_toml());
+
+        let removed = remove_version_tracking_dependency_from_crate(&path, "nonexistent")
+            .expect("should not error");
+
+        assert!(!removed);
+    }
+}

--- a/crates/changeset-manifest/src/writer.rs
+++ b/crates/changeset-manifest/src/writer.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use semver::Version;
-use toml_edit::{Item, Table, value};
+use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::config::{InitConfig, MetadataSection};
 use crate::error::ManifestError;
@@ -143,48 +143,7 @@ pub fn write_metadata_section(
 
     let mut doc = read_document(path)?;
 
-    let root_key = match section {
-        MetadataSection::Workspace => "workspace",
-        MetadataSection::Package => "package",
-    };
-
-    let root = doc
-        .entry(root_key)
-        .or_insert_with(|| Item::Table(Table::new()));
-
-    let root_table = root
-        .as_table_mut()
-        .ok_or_else(|| ManifestError::InvalidSectionType {
-            path: path.to_path_buf(),
-            section: root_key.to_string(),
-        })?;
-
-    let metadata = root_table
-        .entry("metadata")
-        .or_insert_with(|| Item::Table(Table::new()));
-
-    let metadata_table =
-        metadata
-            .as_table_mut()
-            .ok_or_else(|| ManifestError::InvalidSectionType {
-                path: path.to_path_buf(),
-                section: format!("{root_key}.metadata"),
-            })?;
-
-    let changeset = metadata_table
-        .entry("changeset")
-        .or_insert_with(|| Item::Table(Table::new()));
-
-    let changeset_table =
-        changeset
-            .as_table_mut()
-            .ok_or_else(|| ManifestError::InvalidSectionType {
-                path: path.to_path_buf(),
-                section: format!("{root_key}.metadata.changeset"),
-            })?;
-
-    changeset_table.set_implicit(true);
-
+    let changeset_table = navigate_to_changeset_table(&mut doc, section, path)?;
     populate_changeset_table(changeset_table, config);
 
     std::fs::write(path, doc.to_string()).map_err(|source| ManifestError::Write {
@@ -257,6 +216,56 @@ fn update_dep_entry(deps: &mut Item, dep_name: &str, new_version: &Version) -> b
     }
 
     false
+}
+
+pub(crate) fn navigate_to_changeset_table<'a>(
+    doc: &'a mut DocumentMut,
+    section: MetadataSection,
+    path: &Path,
+) -> Result<&'a mut Table, ManifestError> {
+    let root_key = match section {
+        MetadataSection::Workspace => "workspace",
+        MetadataSection::Package => "package",
+    };
+
+    let root = doc
+        .entry(root_key)
+        .or_insert_with(|| Item::Table(Table::new()));
+
+    let root_table = root
+        .as_table_mut()
+        .ok_or_else(|| ManifestError::InvalidSectionType {
+            path: path.to_path_buf(),
+            section: root_key.to_string(),
+        })?;
+
+    let metadata = root_table
+        .entry("metadata")
+        .or_insert_with(|| Item::Table(Table::new()));
+
+    let metadata_table =
+        metadata
+            .as_table_mut()
+            .ok_or_else(|| ManifestError::InvalidSectionType {
+                path: path.to_path_buf(),
+                section: format!("{root_key}.metadata"),
+            })?;
+
+    let changeset = metadata_table
+        .entry("changeset")
+        .or_insert_with(|| Item::Table(Table::new()));
+
+    let changeset_table =
+        changeset
+            .as_table_mut()
+            .ok_or_else(|| ManifestError::InvalidSectionType {
+                path: path.to_path_buf(),
+                section: format!("{root_key}.metadata.changeset"),
+            })?;
+
+    changeset_table.set_implicit(true);
+
+    Ok(changeset_table)
 }
 
 fn populate_changeset_table(changeset_table: &mut Table, config: &InitConfig) {

--- a/crates/changeset-manifest/src/writer.rs
+++ b/crates/changeset-manifest/src/writer.rs
@@ -169,19 +169,18 @@ pub fn update_dependency_version(
     let mut doc = read_document(path)?;
     let mut changed = false;
 
-    if let Some(workspace) = doc.get_mut("workspace") {
-        if let Some(deps) = workspace.get_mut("dependencies") {
-            if update_dep_entry(deps, dependency_name, new_version) {
-                changed = true;
-            }
-        }
+    if let Some(workspace) = doc.get_mut("workspace")
+        && let Some(deps) = workspace.get_mut("dependencies")
+        && update_dep_entry(deps, dependency_name, new_version)
+    {
+        changed = true;
     }
 
     for section in &DEPENDENCY_SECTIONS {
-        if let Some(deps) = doc.get_mut(section) {
-            if update_dep_entry(deps, dependency_name, new_version) {
-                changed = true;
-            }
+        if let Some(deps) = doc.get_mut(section)
+            && update_dep_entry(deps, dependency_name, new_version)
+        {
+            changed = true;
         }
     }
 
@@ -342,14 +341,14 @@ fn populate_changeset_table(changeset_table: &mut Table, config: &InitConfig) {
         );
     }
 
-    if let Some(ref ignored_files) = config.ignored_files {
-        if !ignored_files.is_empty() {
-            let mut arr = toml_edit::Array::new();
-            for pattern in ignored_files {
-                arr.push(pattern.as_str());
-            }
-            changeset_table.insert("ignored-files", Item::Value(toml_edit::Value::Array(arr)));
+    if let Some(ref ignored_files) = config.ignored_files
+        && !ignored_files.is_empty()
+    {
+        let mut arr = toml_edit::Array::new();
+        for pattern in ignored_files {
+            arr.push(pattern.as_str());
         }
+        changeset_table.insert("ignored-files", Item::Value(toml_edit::Value::Array(arr)));
     }
 }
 

--- a/crates/changeset-operations/Cargo.toml
+++ b/crates/changeset-operations/Cargo.toml
@@ -36,6 +36,7 @@ derive_builder = { workspace = true }
 anyhow = "1.0.101"
 changeset-project = { workspace = true, features = ["testing"] }
 git2 = { workspace = true }
+serde_json = { workspace = true }
 tempfile = "3.25"
 toml_edit = { workspace = true }
 

--- a/crates/changeset-operations/Cargo.toml
+++ b/crates/changeset-operations/Cargo.toml
@@ -31,6 +31,7 @@ toml = { workspace = true }
 tracing = { workspace = true }
 gset = { workspace = true }
 derive_builder = { workspace = true }
+globset = "0.4.18"
 
 [dev-dependencies]
 anyhow = "1.0.101"

--- a/crates/changeset-operations/src/error.rs
+++ b/crates/changeset-operations/src/error.rs
@@ -163,6 +163,9 @@ pub enum OperationError {
     #[error("failed to delete {} tag(s) during compensation: {}", failed_tags.len(), failed_tags.join(", "))]
     TagDeletionFailed { failed_tags: Vec<String> },
 
+    #[error("additional packages are only supported in Cargo workspace projects")]
+    AdditionalPackagesRequireWorkspace,
+
     #[error("additional package '{name}' already exists")]
     AdditionalPackageAlreadyExists { name: String },
 

--- a/crates/changeset-operations/src/error.rs
+++ b/crates/changeset-operations/src/error.rs
@@ -163,6 +163,23 @@ pub enum OperationError {
     #[error("failed to delete {} tag(s) during compensation: {}", failed_tags.len(), failed_tags.join(", "))]
     TagDeletionFailed { failed_tags: Vec<String> },
 
+    #[error("additional package '{name}' already exists")]
+    AdditionalPackageAlreadyExists { name: String },
+
+    #[error("additional package '{name}' not found")]
+    AdditionalPackageNotFound { name: String },
+
+    #[error("manifest file for package '{name}' not found at '{}'", path.display())]
+    AdditionalPackageManifestNotFound { name: String, path: PathBuf },
+
+    #[error("invalid glob pattern '{pattern}' for package '{name}'")]
+    AdditionalPackageInvalidGlob {
+        name: String,
+        pattern: String,
+        #[source]
+        source: globset::Error,
+    },
+
     #[error("package '{name}' not found in workspace")]
     PackageNotFound { name: String },
 
@@ -333,5 +350,32 @@ mod tests {
             err,
             OperationError::InvalidPrereleaseTag { ref tag, .. } if tag == "bad.tag"
         ));
+    }
+
+    #[test]
+    fn additional_package_already_exists_error_includes_name() {
+        let err = OperationError::AdditionalPackageAlreadyExists {
+            name: "my-chart".to_string(),
+        };
+        assert!(err.to_string().contains("my-chart"));
+    }
+
+    #[test]
+    fn additional_package_not_found_error_includes_name() {
+        let err = OperationError::AdditionalPackageNotFound {
+            name: "missing-chart".to_string(),
+        };
+        assert!(err.to_string().contains("missing-chart"));
+    }
+
+    #[test]
+    fn additional_package_manifest_not_found_includes_name_and_path() {
+        let err = OperationError::AdditionalPackageManifestNotFound {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("/charts/my-chart/Chart.yaml"),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("my-chart"));
+        assert!(msg.contains("/charts/my-chart/Chart.yaml"));
     }
 }

--- a/crates/changeset-operations/src/error.rs
+++ b/crates/changeset-operations/src/error.rs
@@ -160,14 +160,6 @@ pub enum OperationError {
     #[error("release validation failed")]
     ValidationFailed(#[from] crate::operations::ValidationErrors),
 
-    #[error("failed to parse version '{version}' during {context}")]
-    VersionParse {
-        version: String,
-        context: String,
-        #[source]
-        source: semver::Error,
-    },
-
     #[error("failed to delete {} tag(s) during compensation: {}", failed_tags.len(), failed_tags.join(", "))]
     TagDeletionFailed { failed_tags: Vec<String> },
 
@@ -324,17 +316,6 @@ mod tests {
             source: std::io::Error::other("test"),
         };
         assert!(err.to_string().contains("/some/path"));
-    }
-
-    #[test]
-    fn version_parse_error_includes_version_and_context() {
-        let err = OperationError::VersionParse {
-            version: "not-a-version".to_string(),
-            context: "test context".to_string(),
-            source: "bad".parse::<semver::Version>().expect_err("should fail"),
-        };
-        assert!(err.to_string().contains("not-a-version"));
-        assert!(err.to_string().contains("test context"));
     }
 
     #[test]

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -15,17 +15,20 @@ use changeset_project::{
 use semver::Version;
 
 use crate::Result;
+use changeset_core::VersionTrackingDependency;
+
 use crate::traits::{
     AdditionalPackageConfigWriter, AdditionalPackageField, AdditionalPackageInteractionProvider,
     BumpSelection, CategorySelection, ChangelogSettingsInput, ChangelogWriteResult,
     ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider, DescriptionInput,
-    ExternalManifestVersionWriter, FilteringSettingsInput, GitCommitProvider, GitDiffProvider,
-    GitSettingsInput, GitStagingProvider, GitStatusProvider, GitTagProvider,
-    GitWorkdirDiffProvider, GraduationAction, GraduationInteractionProvider,
+    ExternalManifestVersionReader, ExternalManifestVersionWriter, FilteringSettingsInput,
+    GitCommitProvider, GitDiffProvider, GitSettingsInput, GitStagingProvider, GitStatusProvider,
+    GitTagProvider, GitWorkdirDiffProvider, GraduationAction, GraduationInteractionProvider,
     InheritedVersionChecker, InitInteractionProvider, InteractionProvider, LockfileUpdater,
     ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter, MenuSelection,
     PackageSelection, PrereleaseAction, PrereleaseInteractionProvider, ProjectContext,
-    ProjectProvider, ReleaseStateIO, VersionSettingsInput, WorkspaceVersionManager,
+    ProjectProvider, ReleaseStateIO, VersionSettingsInput, VersionTrackingDependencyWriter,
+    WorkspaceVersionManager,
 };
 
 macro_rules! impl_arc_delegation {
@@ -908,6 +911,7 @@ struct MockManifestState {
     lockfile_restored: Option<Vec<u8>>,
     lockfile_removed: bool,
     external_written_versions: Vec<ExternalVersionWrite>,
+    external_version_to_read: HashMap<(PathBuf, ManifestFormat, String), String>,
 }
 
 pub struct MockManifestWriter {
@@ -930,9 +934,26 @@ impl MockManifestWriter {
                 lockfile_restored: None,
                 lockfile_removed: false,
                 external_written_versions: Vec::new(),
+                external_version_to_read: HashMap::new(),
             }),
             inherited_paths: HashSet::new(),
         }
+    }
+
+    #[must_use]
+    pub fn with_external_version_to_read(
+        self,
+        path: PathBuf,
+        format: ManifestFormat,
+        version_field_path: String,
+        version: String,
+    ) -> Self {
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .external_version_to_read
+            .insert((path, format, version_field_path), version);
+        self
     }
 
     #[must_use]
@@ -1143,6 +1164,29 @@ impl ManifestMetadataWriter for MockManifestWriter {
     }
 }
 
+impl ExternalManifestVersionReader for MockManifestWriter {
+    fn read_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+    ) -> Result<String> {
+        let key = (
+            manifest_path.to_path_buf(),
+            format,
+            version_field_path.to_string(),
+        );
+        Ok(self
+            .state
+            .lock()
+            .expect("lock poisoned")
+            .external_version_to_read
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| "0.0.0".to_string()))
+    }
+}
+
 impl ExternalManifestVersionWriter for MockManifestWriter {
     fn write_external_version(
         &self,
@@ -1170,6 +1214,16 @@ impl ExternalManifestVersionWriter for MockManifestWriter {
         _format: ManifestFormat,
         _version_field_path: &str,
         _expected: &Version,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn restore_external_version(
+        &self,
+        _manifest_path: &Path,
+        _format: ManifestFormat,
+        _version_field_path: &str,
+        _version_str: &str,
     ) -> Result<()> {
         Ok(())
     }
@@ -1218,9 +1272,63 @@ impl_arc_delegation! {
 }
 
 impl_arc_delegation! {
+    impl ExternalManifestVersionReader for Arc<MockManifestWriter> {
+        fn read_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str) -> Result<String>;
+    }
+}
+
+impl_arc_delegation! {
     impl ExternalManifestVersionWriter for Arc<MockManifestWriter> {
         fn write_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str, new_version: &Version) -> Result<()>;
         fn verify_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str, expected: &Version) -> Result<()>;
+        fn restore_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str, version_str: &str) -> Result<()>;
+    }
+}
+
+impl VersionTrackingDependencyWriter for MockManifestWriter {
+    fn add_dependency_to_additional_package(
+        &self,
+        _manifest_path: &Path,
+        _section: MetadataSection,
+        _package_name: &str,
+        _dependency: &VersionTrackingDependency,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn remove_dependency_from_additional_package(
+        &self,
+        _manifest_path: &Path,
+        _section: MetadataSection,
+        _package_name: &str,
+        _dependency_name: &str,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn add_dependency_to_crate(
+        &self,
+        _manifest_path: &Path,
+        _dependency: &VersionTrackingDependency,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn remove_dependency_from_crate(
+        &self,
+        _manifest_path: &Path,
+        _dependency_name: &str,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+impl_arc_delegation! {
+    impl VersionTrackingDependencyWriter for Arc<MockManifestWriter> {
+        fn add_dependency_to_additional_package(&self, manifest_path: &Path, section: MetadataSection, package_name: &str, dependency: &VersionTrackingDependency) -> Result<bool>;
+        fn remove_dependency_from_additional_package(&self, manifest_path: &Path, section: MetadataSection, package_name: &str, dependency_name: &str) -> Result<bool>;
+        fn add_dependency_to_crate(&self, manifest_path: &Path, dependency: &VersionTrackingDependency) -> Result<()>;
+        fn remove_dependency_from_crate(&self, manifest_path: &Path, dependency_name: &str) -> Result<bool>;
     }
 }
 

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -900,6 +900,14 @@ pub struct ExternalVersionWrite {
     pub version: Version,
 }
 
+#[derive(Clone)]
+pub struct ExternalVersionRestore {
+    pub manifest_path: PathBuf,
+    pub format: ManifestFormat,
+    pub version_field_path: String,
+    pub version_str: String,
+}
+
 struct MockManifestState {
     written_versions: Vec<(PathBuf, Version)>,
     dependency_version_updates: Vec<(PathBuf, String, Version)>,
@@ -912,6 +920,7 @@ struct MockManifestState {
     lockfile_removed: bool,
     external_written_versions: Vec<ExternalVersionWrite>,
     external_version_to_read: HashMap<(PathBuf, ManifestFormat, String), String>,
+    restore_calls: Vec<ExternalVersionRestore>,
 }
 
 pub struct MockManifestWriter {
@@ -935,6 +944,7 @@ impl MockManifestWriter {
                 lockfile_removed: false,
                 external_written_versions: Vec::new(),
                 external_version_to_read: HashMap::new(),
+                restore_calls: Vec::new(),
             }),
             inherited_paths: HashSet::new(),
         }
@@ -1047,6 +1057,15 @@ impl MockManifestWriter {
             .lock()
             .expect("lock poisoned")
             .external_written_versions
+            .clone()
+    }
+
+    #[must_use]
+    pub fn restore_calls(&self) -> Vec<ExternalVersionRestore> {
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .restore_calls
             .clone()
     }
 }
@@ -1220,11 +1239,21 @@ impl ExternalManifestVersionWriter for MockManifestWriter {
 
     fn restore_external_version(
         &self,
-        _manifest_path: &Path,
-        _format: ManifestFormat,
-        _version_field_path: &str,
-        _version_str: &str,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+        version_str: &str,
     ) -> Result<()> {
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .restore_calls
+            .push(ExternalVersionRestore {
+                manifest_path: manifest_path.to_path_buf(),
+                format,
+                version_field_path: version_field_path.to_string(),
+                version_str: version_str.to_string(),
+            });
         Ok(())
     }
 }

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -3,9 +3,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 
 use changeset_changelog::{RepositoryInfo, VersionRelease};
-use changeset_core::{BumpType, ChangeCategory, Changeset, ManifestFormat, PackageInfo};
+use changeset_core::{
+    AdditionalPackageDeclaration, BumpType, ChangeCategory, Changeset, ManifestFormat, PackageInfo,
+};
 use changeset_git::{CommitInfo, FileChange, TagInfo};
-use changeset_manifest::{InitConfig, MetadataSection};
+use changeset_manifest::{AdditionalPackageUpdate, InitConfig, MetadataSection};
 use changeset_project::{
     CargoProject, GraduationState, PackageChangesetConfig, PrereleaseState, ProjectKind,
     RootChangesetConfig, WorkspaceDependencyGraph,
@@ -14,6 +16,7 @@ use semver::Version;
 
 use crate::Result;
 use crate::traits::{
+    AdditionalPackageConfigWriter, AdditionalPackageField, AdditionalPackageInteractionProvider,
     BumpSelection, CategorySelection, ChangelogSettingsInput, ChangelogWriteResult,
     ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider, DescriptionInput,
     ExternalManifestVersionWriter, FilteringSettingsInput, GitCommitProvider, GitDiffProvider,
@@ -1718,6 +1721,131 @@ impl_arc_delegation! {
         fn select_graduation_action(&self) -> Result<MenuSelection<GraduationAction>>;
         fn select_package_for_graduation(&self, eligible: &[&PackageInfo]) -> Result<MenuSelection<usize>>;
         fn select_package_to_remove_graduation(&self, items: &[String]) -> Result<MenuSelection<usize>>;
+    }
+}
+
+pub struct MockAdditionalPackageConfigWriter {
+    pub add_result: bool,
+    pub remove_result: bool,
+    pub update_result: Option<bool>,
+}
+
+impl MockAdditionalPackageConfigWriter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            add_result: true,
+            remove_result: true,
+            update_result: Some(true),
+        }
+    }
+}
+
+impl Default for MockAdditionalPackageConfigWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AdditionalPackageConfigWriter for MockAdditionalPackageConfigWriter {
+    fn add_additional_package(
+        &self,
+        _manifest_path: &Path,
+        _section: MetadataSection,
+        _declaration: &AdditionalPackageDeclaration,
+    ) -> Result<()> {
+        if self.add_result {
+            Ok(())
+        } else {
+            Err(crate::OperationError::Cancelled)
+        }
+    }
+
+    fn remove_additional_package(
+        &self,
+        _manifest_path: &Path,
+        _section: MetadataSection,
+        _name: &str,
+    ) -> Result<bool> {
+        if self.remove_result {
+            Ok(true)
+        } else {
+            Err(crate::OperationError::Cancelled)
+        }
+    }
+
+    fn update_additional_package(
+        &self,
+        _manifest_path: &Path,
+        _section: MetadataSection,
+        _name: &str,
+        _updates: &AdditionalPackageUpdate,
+    ) -> Result<bool> {
+        match self.update_result {
+            Some(v) => Ok(v),
+            None => Err(crate::OperationError::Cancelled),
+        }
+    }
+}
+
+pub struct MockAdditionalPackageInteractionProvider {
+    pub package_name: String,
+    pub package_path: PathBuf,
+    pub influence_patterns: Vec<String>,
+    pub manifest_file_path: PathBuf,
+    pub manifest_format: ManifestFormat,
+    pub manifest_version_path: String,
+    pub select_remove_result: MenuSelection<usize>,
+    pub select_edit_result: MenuSelection<usize>,
+    pub select_field_result: MenuSelection<AdditionalPackageField>,
+    pub confirm_removal_result: bool,
+}
+
+impl AdditionalPackageInteractionProvider for MockAdditionalPackageInteractionProvider {
+    fn prompt_package_name(&self) -> Result<String> {
+        Ok(self.package_name.clone())
+    }
+
+    fn prompt_package_path(&self) -> Result<PathBuf> {
+        Ok(self.package_path.clone())
+    }
+
+    fn prompt_influence_patterns(&self) -> Result<Vec<String>> {
+        Ok(self.influence_patterns.clone())
+    }
+
+    fn prompt_manifest_file_path(&self) -> Result<PathBuf> {
+        Ok(self.manifest_file_path.clone())
+    }
+
+    fn prompt_manifest_format(&self) -> Result<ManifestFormat> {
+        Ok(self.manifest_format)
+    }
+
+    fn prompt_manifest_version_path(&self) -> Result<String> {
+        Ok(self.manifest_version_path.clone())
+    }
+
+    fn select_package_to_remove(
+        &self,
+        _packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>> {
+        Ok(self.select_remove_result.clone())
+    }
+
+    fn select_package_to_edit(
+        &self,
+        _packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>> {
+        Ok(self.select_edit_result.clone())
+    }
+
+    fn select_field_to_edit(&self) -> Result<MenuSelection<AdditionalPackageField>> {
+        Ok(self.select_field_result.clone())
+    }
+
+    fn confirm_removal(&self, _name: &str) -> Result<bool> {
+        Ok(self.confirm_removal_result)
     }
 }
 

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -343,6 +343,21 @@ impl ChangesetWriter for MockChangesetReader {
         }
         Ok(())
     }
+
+    fn restore_consumed_for_prerelease(
+        &self,
+        _changeset_dir: &Path,
+        paths: &[&Path],
+        version: &str,
+    ) -> Result<()> {
+        let mut changesets = self.changesets.lock().expect("lock poisoned");
+        for path in paths {
+            if let Some(changeset) = changesets.get_mut(*path) {
+                changeset.set_consumed_for_prerelease(Some(version.to_owned()));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl_arc_delegation! {
@@ -360,6 +375,7 @@ impl_arc_delegation! {
         fn filename_exists(&self, changeset_dir: &Path, filename: &str) -> bool;
         fn mark_consumed_for_prerelease(&self, changeset_dir: &Path, paths: &[&Path], version: &Version) -> Result<()>;
         fn clear_consumed_for_prerelease(&self, changeset_dir: &Path, paths: &[&Path]) -> Result<()>;
+        fn restore_consumed_for_prerelease(&self, changeset_dir: &Path, paths: &[&Path], version: &str) -> Result<()>;
     }
 }
 
@@ -426,6 +442,15 @@ impl ChangesetWriter for MockChangesetWriter {
     }
 
     fn clear_consumed_for_prerelease(&self, _changeset_dir: &Path, _paths: &[&Path]) -> Result<()> {
+        Ok(())
+    }
+
+    fn restore_consumed_for_prerelease(
+        &self,
+        _changeset_dir: &Path,
+        _paths: &[&Path],
+        _version: &str,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 
 use changeset_changelog::{RepositoryInfo, VersionRelease};
-use changeset_core::{BumpType, ChangeCategory, Changeset, PackageInfo};
+use changeset_core::{BumpType, ChangeCategory, Changeset, ManifestFormat, PackageInfo};
 use changeset_git::{CommitInfo, FileChange, TagInfo};
 use changeset_manifest::{InitConfig, MetadataSection};
 use changeset_project::{
@@ -16,13 +16,13 @@ use crate::Result;
 use crate::traits::{
     BumpSelection, CategorySelection, ChangelogSettingsInput, ChangelogWriteResult,
     ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider, DescriptionInput,
-    FilteringSettingsInput, GitCommitProvider, GitDiffProvider, GitSettingsInput,
-    GitStagingProvider, GitStatusProvider, GitTagProvider, GitWorkdirDiffProvider,
-    GraduationAction, GraduationInteractionProvider, InheritedVersionChecker,
-    InitInteractionProvider, InteractionProvider, LockfileUpdater, ManifestDependencyWriter,
-    ManifestMetadataWriter, ManifestVersionWriter, MenuSelection, PackageSelection,
-    PrereleaseAction, PrereleaseInteractionProvider, ProjectContext, ProjectProvider,
-    ReleaseStateIO, VersionSettingsInput, WorkspaceVersionManager,
+    ExternalManifestVersionWriter, FilteringSettingsInput, GitCommitProvider, GitDiffProvider,
+    GitSettingsInput, GitStagingProvider, GitStatusProvider, GitTagProvider,
+    GitWorkdirDiffProvider, GraduationAction, GraduationInteractionProvider,
+    InheritedVersionChecker, InitInteractionProvider, InteractionProvider, LockfileUpdater,
+    ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter, MenuSelection,
+    PackageSelection, PrereleaseAction, PrereleaseInteractionProvider, ProjectContext,
+    ProjectProvider, ReleaseStateIO, VersionSettingsInput, WorkspaceVersionManager,
 };
 
 macro_rules! impl_arc_delegation {
@@ -48,6 +48,7 @@ pub struct MockProjectProvider {
     changeset_dir: PathBuf,
     root_config: RootChangesetConfig,
     dependency_edges: Vec<(String, String)>,
+    additional_packages: Vec<PackageInfo>,
 }
 
 impl MockProjectProvider {
@@ -59,6 +60,7 @@ impl MockProjectProvider {
             changeset_dir,
             root_config: RootChangesetConfig::default(),
             dependency_edges: Vec::new(),
+            additional_packages: Vec::new(),
         }
     }
 
@@ -97,6 +99,12 @@ impl MockProjectProvider {
             .into_iter()
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect();
+        self
+    }
+
+    #[must_use]
+    pub fn with_additional_packages(mut self, packages: Vec<PackageInfo>) -> Self {
+        self.additional_packages = packages;
         self
     }
 
@@ -158,6 +166,14 @@ impl ProjectProvider for MockProjectProvider {
         _config: &RootChangesetConfig,
     ) -> Result<PathBuf> {
         Ok(self.changeset_dir.clone())
+    }
+
+    fn discover_additional_packages(
+        &self,
+        _project_root: &Path,
+        _config: &RootChangesetConfig,
+    ) -> Result<Vec<PackageInfo>> {
+        Ok(self.additional_packages.clone())
     }
 }
 
@@ -832,6 +848,14 @@ impl InteractionProvider for MockInteractionProvider {
     }
 }
 
+#[derive(Clone)]
+pub struct ExternalVersionWrite {
+    pub manifest_path: PathBuf,
+    pub format: ManifestFormat,
+    pub version_path: String,
+    pub version: Version,
+}
+
 struct MockManifestState {
     written_versions: Vec<(PathBuf, Version)>,
     dependency_version_updates: Vec<(PathBuf, String, Version)>,
@@ -842,6 +866,7 @@ struct MockManifestState {
     lockfile_content: Option<Vec<u8>>,
     lockfile_restored: Option<Vec<u8>>,
     lockfile_removed: bool,
+    external_written_versions: Vec<ExternalVersionWrite>,
 }
 
 pub struct MockManifestWriter {
@@ -863,6 +888,7 @@ impl MockManifestWriter {
                 lockfile_content: None,
                 lockfile_restored: None,
                 lockfile_removed: false,
+                external_written_versions: Vec::new(),
             }),
             inherited_paths: HashSet::new(),
         }
@@ -951,6 +977,15 @@ impl MockManifestWriter {
     #[must_use]
     pub fn lockfile_removed(&self) -> bool {
         self.state.lock().expect("lock poisoned").lockfile_removed
+    }
+
+    #[must_use]
+    pub fn external_written_versions(&self) -> Vec<ExternalVersionWrite> {
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .external_written_versions
+            .clone()
     }
 }
 
@@ -1067,6 +1102,38 @@ impl ManifestMetadataWriter for MockManifestWriter {
     }
 }
 
+impl ExternalManifestVersionWriter for MockManifestWriter {
+    fn write_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_path: &str,
+        new_version: &Version,
+    ) -> Result<()> {
+        self.state
+            .lock()
+            .expect("lock poisoned")
+            .external_written_versions
+            .push(ExternalVersionWrite {
+                manifest_path: manifest_path.to_path_buf(),
+                format,
+                version_path: version_path.to_string(),
+                version: new_version.clone(),
+            });
+        Ok(())
+    }
+
+    fn verify_external_version(
+        &self,
+        _manifest_path: &Path,
+        _format: ManifestFormat,
+        _version_path: &str,
+        _expected: &Version,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
 impl_arc_delegation! {
     impl InheritedVersionChecker for Arc<MockManifestWriter> {
         fn has_inherited_version(&self, manifest_path: &Path) -> Result<bool>;
@@ -1106,6 +1173,13 @@ impl_arc_delegation! {
 impl_arc_delegation! {
     impl ManifestMetadataWriter for Arc<MockManifestWriter> {
         fn write_metadata(&self, manifest_path: &Path, section: MetadataSection, config: &InitConfig) -> Result<()>;
+    }
+}
+
+impl_arc_delegation! {
+    impl ExternalManifestVersionWriter for Arc<MockManifestWriter> {
+        fn write_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_path: &str, new_version: &Version) -> Result<()>;
+        fn verify_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_path: &str, expected: &Version) -> Result<()>;
     }
 }
 

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -893,7 +893,7 @@ impl InteractionProvider for MockInteractionProvider {
 pub struct ExternalVersionWrite {
     pub manifest_path: PathBuf,
     pub format: ManifestFormat,
-    pub version_path: String,
+    pub version_field_path: String,
     pub version: Version,
 }
 
@@ -1148,7 +1148,7 @@ impl ExternalManifestVersionWriter for MockManifestWriter {
         &self,
         manifest_path: &Path,
         format: ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
         new_version: &Version,
     ) -> Result<()> {
         self.state
@@ -1158,7 +1158,7 @@ impl ExternalManifestVersionWriter for MockManifestWriter {
             .push(ExternalVersionWrite {
                 manifest_path: manifest_path.to_path_buf(),
                 format,
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
                 version: new_version.clone(),
             });
         Ok(())
@@ -1168,7 +1168,7 @@ impl ExternalManifestVersionWriter for MockManifestWriter {
         &self,
         _manifest_path: &Path,
         _format: ManifestFormat,
-        _version_path: &str,
+        _version_field_path: &str,
         _expected: &Version,
     ) -> Result<()> {
         Ok(())
@@ -1219,8 +1219,8 @@ impl_arc_delegation! {
 
 impl_arc_delegation! {
     impl ExternalManifestVersionWriter for Arc<MockManifestWriter> {
-        fn write_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_path: &str, new_version: &Version) -> Result<()>;
-        fn verify_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_path: &str, expected: &Version) -> Result<()>;
+        fn write_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str, new_version: &Version) -> Result<()>;
+        fn verify_external_version(&self, manifest_path: &Path, format: ManifestFormat, version_field_path: &str, expected: &Version) -> Result<()>;
     }
 }
 
@@ -1807,7 +1807,7 @@ pub struct MockAdditionalPackageInteractionProvider {
     pub influence_patterns: Vec<String>,
     pub manifest_file_path: PathBuf,
     pub manifest_format: ManifestFormat,
-    pub manifest_version_path: String,
+    pub manifest_version_field_path: String,
     pub select_remove_result: MenuSelection<usize>,
     pub select_edit_result: MenuSelection<usize>,
     pub select_field_result: MenuSelection<AdditionalPackageField>,
@@ -1835,8 +1835,8 @@ impl AdditionalPackageInteractionProvider for MockAdditionalPackageInteractionPr
         Ok(self.manifest_format)
     }
 
-    fn prompt_manifest_version_path(&self) -> Result<String> {
-        Ok(self.manifest_version_path.clone())
+    fn prompt_manifest_version_field_path(&self) -> Result<String> {
+        Ok(self.manifest_version_field_path.clone())
     }
 
     fn select_package_to_remove(
@@ -1885,8 +1885,8 @@ impl AdditionalPackageInteractionProvider for PanickingAdditionalPackageInteract
         panic!("prompt_manifest_format must not be called");
     }
 
-    fn prompt_manifest_version_path(&self) -> Result<String> {
-        panic!("prompt_manifest_version_path must not be called");
+    fn prompt_manifest_version_field_path(&self) -> Result<String> {
+        panic!("prompt_manifest_version_field_path must not be called");
     }
 
     fn select_package_to_remove(

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -52,6 +52,7 @@ pub struct MockProjectProvider {
     root_config: RootChangesetConfig,
     dependency_edges: Vec<(String, String)>,
     additional_packages: Vec<PackageInfo>,
+    fail_on_discover_additional: bool,
 }
 
 impl MockProjectProvider {
@@ -64,6 +65,7 @@ impl MockProjectProvider {
             root_config: RootChangesetConfig::default(),
             dependency_edges: Vec::new(),
             additional_packages: Vec::new(),
+            fail_on_discover_additional: false,
         }
     }
 
@@ -108,6 +110,12 @@ impl MockProjectProvider {
     #[must_use]
     pub fn with_additional_packages(mut self, packages: Vec<PackageInfo>) -> Self {
         self.additional_packages = packages;
+        self
+    }
+
+    #[must_use]
+    pub fn with_fail_on_discover_additional(mut self) -> Self {
+        self.fail_on_discover_additional = true;
         self
     }
 
@@ -176,6 +184,11 @@ impl ProjectProvider for MockProjectProvider {
         _project_root: &Path,
         _config: &RootChangesetConfig,
     ) -> Result<Vec<PackageInfo>> {
+        if self.fail_on_discover_additional {
+            return Err(crate::OperationError::Io(std::io::Error::other(
+                "discover_additional_packages must not be called for single-package projects",
+            )));
+        }
         Ok(self.additional_packages.clone())
     }
 }
@@ -1846,6 +1859,56 @@ impl AdditionalPackageInteractionProvider for MockAdditionalPackageInteractionPr
 
     fn confirm_removal(&self, _name: &str) -> Result<bool> {
         Ok(self.confirm_removal_result)
+    }
+}
+
+pub struct PanickingAdditionalPackageInteractionProvider;
+
+impl AdditionalPackageInteractionProvider for PanickingAdditionalPackageInteractionProvider {
+    fn prompt_package_name(&self) -> Result<String> {
+        panic!("prompt_package_name must not be called");
+    }
+
+    fn prompt_package_path(&self) -> Result<PathBuf> {
+        panic!("prompt_package_path must not be called");
+    }
+
+    fn prompt_influence_patterns(&self) -> Result<Vec<String>> {
+        panic!("prompt_influence_patterns must not be called");
+    }
+
+    fn prompt_manifest_file_path(&self) -> Result<PathBuf> {
+        panic!("prompt_manifest_file_path must not be called");
+    }
+
+    fn prompt_manifest_format(&self) -> Result<ManifestFormat> {
+        panic!("prompt_manifest_format must not be called");
+    }
+
+    fn prompt_manifest_version_path(&self) -> Result<String> {
+        panic!("prompt_manifest_version_path must not be called");
+    }
+
+    fn select_package_to_remove(
+        &self,
+        _packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>> {
+        panic!("select_package_to_remove must not be called");
+    }
+
+    fn select_package_to_edit(
+        &self,
+        _packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>> {
+        panic!("select_package_to_edit must not be called");
+    }
+
+    fn select_field_to_edit(&self) -> Result<MenuSelection<AdditionalPackageField>> {
+        panic!("select_field_to_edit must not be called");
+    }
+
+    fn confirm_removal(&self, _name: &str) -> Result<bool> {
+        panic!("confirm_removal must not be called");
     }
 }
 

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -1823,7 +1823,7 @@ impl AdditionalPackageInteractionProvider for MockAdditionalPackageInteractionPr
         Ok(self.package_path.clone())
     }
 
-    fn prompt_influence_patterns(&self) -> Result<Vec<String>> {
+    fn prompt_influence_patterns(&self, _package_path: &Path) -> Result<Vec<String>> {
         Ok(self.influence_patterns.clone())
     }
 
@@ -1873,7 +1873,7 @@ impl AdditionalPackageInteractionProvider for PanickingAdditionalPackageInteract
         panic!("prompt_package_path must not be called");
     }
 
-    fn prompt_influence_patterns(&self) -> Result<Vec<String>> {
+    fn prompt_influence_patterns(&self, _package_path: &Path) -> Result<Vec<String>> {
         panic!("prompt_influence_patterns must not be called");
     }
 

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -75,12 +76,18 @@ where
             .project_provider
             .discover_additional_packages(project.root(), &root_config)?;
 
-        let all_packages: Vec<PackageInfo> = project
-            .packages()
-            .iter()
-            .cloned()
-            .chain(additional)
-            .collect();
+        let all_packages: Cow<'_, [PackageInfo]> = if additional.is_empty() {
+            Cow::Borrowed(project.packages())
+        } else {
+            Cow::Owned(
+                project
+                    .packages()
+                    .iter()
+                    .cloned()
+                    .chain(additional)
+                    .collect(),
+            )
+        };
 
         if all_packages.is_empty() {
             return Err(OperationError::EmptyProject(project.root().to_path_buf()));

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -72,9 +72,11 @@ where
     pub fn execute(&self, start_path: &Path, input: &AddInput) -> Result<AddResult> {
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
-        let additional = self
-            .project_provider
-            .discover_additional_packages(project.root(), &root_config)?;
+        let additional = super::discover_additional_packages_if_workspace(
+            &self.project_provider,
+            &project,
+            &root_config,
+        )?;
 
         let all_packages: Cow<'_, [PackageInfo]> = if additional.is_empty() {
             Cow::Borrowed(project.packages())
@@ -830,7 +832,7 @@ mod tests {
     #[test]
     fn creates_changeset_for_additional_package() {
         let helm_chart = make_additional_package("helm-chart");
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![helm_chart]);
         let writer = MockChangesetWriter::new();
         let interaction = MockInteractionProvider::all_cancelled();
@@ -931,7 +933,7 @@ mod tests {
     #[test]
     fn workspace_with_rust_and_additional_packages_resolves_both() {
         let helm_chart = make_additional_package("helm-chart");
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![helm_chart]);
         let writer = MockChangesetWriter::new();
         let interaction = MockInteractionProvider::all_cancelled();
@@ -970,7 +972,7 @@ mod tests {
     #[test]
     fn returns_error_for_unknown_additional_package_name() {
         let helm_chart = make_additional_package("helm-chart");
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![helm_chart]);
         let writer = MockChangesetWriter::new();
         let interaction = MockInteractionProvider::all_cancelled();
@@ -1021,5 +1023,28 @@ mod tests {
             }
             _ => panic!("Expected AddResult::Created"),
         }
+    }
+
+    #[test]
+    fn single_package_never_calls_discover_additional_packages() {
+        let project_provider =
+            MockProjectProvider::single_package("solo", "1.0.0").with_fail_on_discover_additional();
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["solo".to_string()],
+            bump: Some(BumpType::Patch),
+            description: Some("Fix".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("single-package should succeed without calling discover_additional_packages");
+
+        assert!(matches!(result, AddResult::Created { .. }));
     }
 }

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -70,8 +70,19 @@ where
     /// if the changeset cannot be written.
     pub fn execute(&self, start_path: &Path, input: &AddInput) -> Result<AddResult> {
         let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+        let additional = self
+            .project_provider
+            .discover_additional_packages(project.root(), &root_config)?;
 
-        if project.packages().is_empty() {
+        let all_packages: Vec<PackageInfo> = project
+            .packages()
+            .iter()
+            .cloned()
+            .chain(additional)
+            .collect();
+
+        if all_packages.is_empty() {
             return Err(OperationError::EmptyProject(project.root().to_path_buf()));
         }
 
@@ -82,8 +93,7 @@ where
         };
 
         let display_labels: Option<Vec<String>> = graph.as_ref().map(|g| {
-            project
-                .packages()
+            all_packages
                 .iter()
                 .map(|pkg| {
                     let dependents = g.transitive_dependents(pkg.name());
@@ -104,7 +114,7 @@ where
         });
 
         let packages =
-            match self.select_packages(project.packages(), input, display_labels.as_deref())? {
+            match self.select_packages(&all_packages, input, display_labels.as_deref())? {
                 Some(packages) if packages.is_empty() => return Ok(AddResult::NoPackages),
                 Some(packages) => packages,
                 None => return Ok(AddResult::Cancelled),
@@ -139,7 +149,6 @@ where
 
         let changeset = Changeset::new(description, releases, category);
 
-        let (root_config, _) = self.project_provider.load_configs(&project)?;
         let changeset_dir = self
             .project_provider
             .ensure_changeset_dir(&project, &root_config)?;
@@ -805,6 +814,176 @@ mod tests {
             }
             _ => panic!("Expected AddResult::Created"),
         }
+    }
+
+    fn make_additional_package(name: &str) -> PackageInfo {
+        make_package(name, "1.0.0")
+    }
+
+    #[test]
+    fn creates_changeset_for_additional_package() {
+        let helm_chart = make_additional_package("helm-chart");
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![helm_chart]);
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["helm-chart".to_string()],
+            bump: Some(BumpType::Patch),
+            description: Some("Update helm chart".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("AddOperation should succeed for additional package");
+
+        match result {
+            AddResult::Created { changeset, .. } => {
+                assert_eq!(changeset.releases().len(), 1);
+                assert_eq!(changeset.releases()[0].name(), "helm-chart");
+                assert_eq!(changeset.releases()[0].bump_type(), BumpType::Patch);
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn auto_selects_single_additional_package_only_project() {
+        let helm_chart = make_additional_package("helm-chart");
+        let project_provider =
+            MockProjectProvider::workspace(vec![]).with_additional_packages(vec![helm_chart]);
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            bump: Some(BumpType::Minor),
+            description: Some("New chart version".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("AddOperation should succeed for single additional package project");
+
+        match result {
+            AddResult::Created { changeset, .. } => {
+                assert_eq!(changeset.releases().len(), 1);
+                assert_eq!(changeset.releases()[0].name(), "helm-chart");
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn additional_packages_excluded_from_dependency_graph() {
+        let helm_chart = make_additional_package("helm-chart");
+        let project_provider =
+            MockProjectProvider::workspace(vec![("core", "1.0.0"), ("app", "1.0.0")])
+                .with_dependency_edges(vec![("app", "core")])
+                .with_additional_packages(vec![helm_chart]);
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["core".to_string()],
+            bump: Some(BumpType::Patch),
+            description: Some("Fix in core".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("AddOperation should succeed");
+
+        match result {
+            AddResult::Created {
+                uncovered_dependents,
+                ..
+            } => {
+                assert!(
+                    uncovered_dependents.contains(&"app".to_string()),
+                    "app should be an uncovered dependent of core"
+                );
+                assert!(
+                    !uncovered_dependents.contains(&"helm-chart".to_string()),
+                    "helm-chart should not appear as a dependent"
+                );
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn workspace_with_rust_and_additional_packages_resolves_both() {
+        let helm_chart = make_additional_package("helm-chart");
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![helm_chart]);
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let mut package_bumps = HashMap::new();
+        package_bumps.insert("core".to_string(), BumpType::Patch);
+        package_bumps.insert("helm-chart".to_string(), BumpType::Patch);
+
+        let input = AddInput {
+            package_bumps,
+            description: Some("Update both".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("AddOperation should succeed for mixed Rust and additional packages");
+
+        match result {
+            AddResult::Created { changeset, .. } => {
+                assert_eq!(changeset.releases().len(), 2);
+                let names: Vec<_> = changeset
+                    .releases()
+                    .iter()
+                    .map(|r| r.name().as_str())
+                    .collect();
+                assert!(names.contains(&"core"));
+                assert!(names.contains(&"helm-chart"));
+            }
+            _ => panic!("Expected AddResult::Created"),
+        }
+    }
+
+    #[test]
+    fn returns_error_for_unknown_additional_package_name() {
+        let helm_chart = make_additional_package("helm-chart");
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![helm_chart]);
+        let writer = MockChangesetWriter::new();
+        let interaction = MockInteractionProvider::all_cancelled();
+
+        let operation = AddOperation::new(project_provider, writer, interaction);
+
+        let input = AddInput {
+            packages: vec!["nonexistent-chart".to_string()],
+            bump: Some(BumpType::Patch),
+            description: Some("Test".to_string()),
+            ..Default::default()
+        };
+
+        let result = operation.execute(Path::new("/any"), &input);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.expect_err("should error"),
+            crate::OperationError::UnknownPackage { .. }
+        ));
     }
 
     #[test]

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -76,7 +76,10 @@ where
         start_path: &Path,
         input: AdditionalPackageAddInput,
     ) -> Result<Vec<AdditionalPackageEvent>> {
-        execute_add(&self.project_provider, &self.writer, start_path, input)
+        let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+        write_additional_package(&self.writer, &project, &root_config, input)
     }
 }
 
@@ -104,6 +107,7 @@ where
     /// or the manifest cannot be written.
     pub fn execute(&self, start_path: &Path, name: &str) -> Result<Vec<AdditionalPackageEvent>> {
         let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
         if !root_config
@@ -156,6 +160,7 @@ where
         input: AdditionalPackageEditInput,
     ) -> Result<Vec<AdditionalPackageEvent>> {
         let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
         if !root_config
@@ -215,6 +220,7 @@ where
     /// Returns an error if the project cannot be discovered or configs cannot be loaded.
     pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
         let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
         let packages = root_config.additional_packages();
@@ -260,10 +266,13 @@ where
 
     /// # Errors
     ///
-    /// Returns an error if any user prompt fails, the project cannot be discovered,
+    /// Returns an error if the project is not a workspace, any user prompt fails,
     /// glob patterns are invalid, the manifest file does not exist, or the manifest
     /// cannot be written.
     pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
+
         let name = self.interaction.prompt_package_name()?;
         let path = self.interaction.prompt_package_path()?;
         let influence = self.interaction.prompt_influence_patterns()?;
@@ -271,10 +280,11 @@ where
         let manifest_format = self.interaction.prompt_manifest_format()?;
         let manifest_version_path = self.interaction.prompt_manifest_version_path()?;
 
-        execute_add(
-            &self.project_provider,
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+        write_additional_package(
             &self.writer,
-            start_path,
+            &project,
+            &root_config,
             AdditionalPackageAddInput {
                 name,
                 path,
@@ -314,6 +324,7 @@ where
     /// the selection prompt fails, or the manifest cannot be written.
     pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
         let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
         let packages: Vec<&AdditionalPackageDeclaration> =
@@ -370,6 +381,7 @@ where
     /// be written.
     pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
         let project = self.project_provider.discover_project(start_path)?;
+        require_workspace(&project)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
         let packages: Vec<&AdditionalPackageDeclaration> =
@@ -441,19 +453,15 @@ where
     }
 }
 
-fn execute_add<P, W>(
-    project_provider: &P,
+fn write_additional_package<W>(
     writer: &W,
-    start_path: &Path,
+    project: &changeset_project::CargoProject,
+    root_config: &changeset_project::RootChangesetConfig,
     input: AdditionalPackageAddInput,
 ) -> Result<Vec<AdditionalPackageEvent>>
 where
-    P: ProjectProvider,
     W: AdditionalPackageConfigWriter,
 {
-    let project = project_provider.discover_project(start_path)?;
-    let (root_config, _) = project_provider.load_configs(&project)?;
-
     let existing = root_config.additional_packages();
     if existing.iter().any(|p| p.name() == &input.name) {
         return Err(OperationError::AdditionalPackageAlreadyExists { name: input.name });
@@ -483,11 +491,18 @@ where
         ),
     );
 
-    let (manifest_path, section) = resolve_manifest_and_section(&project);
+    let (manifest_path, section) = resolve_manifest_and_section(project);
 
     writer.add_additional_package(&manifest_path, section, &declaration)?;
 
     Ok(vec![AdditionalPackageEvent::Added { name: input.name }])
+}
+
+fn require_workspace(project: &changeset_project::CargoProject) -> Result<()> {
+    if *project.kind() == ProjectKind::SinglePackage {
+        return Err(OperationError::AdditionalPackagesRequireWorkspace);
+    }
+    Ok(())
 }
 
 fn resolve_manifest_and_section(
@@ -498,7 +513,9 @@ fn resolve_manifest_and_section(
         ProjectKind::VirtualWorkspace | ProjectKind::WorkspaceWithRoot => {
             MetadataSection::Workspace
         }
-        ProjectKind::SinglePackage => MetadataSection::Package,
+        ProjectKind::SinglePackage => {
+            unreachable!("require_workspace() must be called before this function")
+        }
     };
     (manifest_path, section)
 }
@@ -824,5 +841,118 @@ mod tests {
             .expect("load configs");
 
         assert_eq!(root_config.additional_packages().len(), 0);
+    }
+
+    #[test]
+    fn add_rejects_single_package_project() {
+        let (_dir, manifest_file) = make_temp_manifest_file();
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec![],
+            manifest_file_path: manifest_file,
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn remove_rejects_single_package_project() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectRemoveOperation::new(provider, writer);
+        let result = op.execute(Path::new("/any"), "my-chart");
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn edit_rejects_single_package_project() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectEditOperation::new(provider, writer);
+        let input = AdditionalPackageEditInput {
+            name: "my-chart".to_string(),
+            updates: AdditionalPackageUpdate {
+                path: Some(PathBuf::from("new/path")),
+                influence: None,
+                manifest_file_path: None,
+                manifest_format: None,
+                manifest_version_path: None,
+            },
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn list_rejects_single_package_project() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let op = AdditionalPackageListOperation::new(provider);
+        let result = op.execute(Path::new("/any"));
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn interactive_add_rejects_single_package_without_prompts() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+        let interaction = crate::mocks::PanickingAdditionalPackageInteractionProvider;
+
+        let op = AdditionalPackageInteractiveAddOperation::new(provider, writer, interaction);
+        let result = op.execute(Path::new("/any"));
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn interactive_remove_rejects_single_package_without_prompts() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+        let interaction = crate::mocks::PanickingAdditionalPackageInteractionProvider;
+
+        let op = AdditionalPackageInteractiveRemoveOperation::new(provider, writer, interaction);
+        let result = op.execute(Path::new("/any"));
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
+    }
+
+    #[test]
+    fn interactive_edit_rejects_single_package_without_prompts() {
+        let provider = MockProjectProvider::single_package("my-crate", "1.0.0");
+        let writer = MockAdditionalPackageConfigWriter::new();
+        let interaction = crate::mocks::PanickingAdditionalPackageInteractionProvider;
+
+        let op = AdditionalPackageInteractiveEditOperation::new(provider, writer, interaction);
+        let result = op.execute(Path::new("/any"));
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackagesRequireWorkspace)
+        ));
     }
 }

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -275,7 +275,7 @@ where
 
         let name = self.interaction.prompt_package_name()?;
         let path = self.interaction.prompt_package_path()?;
-        let influence = self.interaction.prompt_influence_patterns()?;
+        let influence = self.interaction.prompt_influence_patterns(&path)?;
         let manifest_file_path = self.interaction.prompt_manifest_file_path()?;
         let manifest_format = self.interaction.prompt_manifest_format()?;
         let manifest_version_path = self.interaction.prompt_manifest_version_path()?;
@@ -418,7 +418,12 @@ where
                     changed_fields.push("path".to_string());
                 }
                 AdditionalPackageField::Influence => {
-                    updates.influence = Some(self.interaction.prompt_influence_patterns()?);
+                    let current_path = updates
+                        .path
+                        .as_deref()
+                        .unwrap_or_else(|| packages[index].path());
+                    updates.influence =
+                        Some(self.interaction.prompt_influence_patterns(current_path)?);
                     changed_fields.push("influence".to_string());
                 }
                 AdditionalPackageField::ManifestFilePath => {

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -494,6 +494,7 @@ where
             input.manifest_format,
             input.manifest_version_field_path,
         ),
+        Vec::new(),
     );
 
     let (manifest_path, section) = resolve_manifest_and_section(project);
@@ -583,6 +584,7 @@ mod tests {
                 ManifestFormat::Yaml,
                 "version".to_string(),
             ),
+            Vec::new(),
         )
     }
 

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -175,13 +175,13 @@ where
             validate_influence_patterns(&input.name, influence)?;
         }
 
-        if let Some(ref manifest_path) = input.updates.manifest_file_path {
-            if !manifest_path.exists() {
-                return Err(OperationError::AdditionalPackageManifestNotFound {
-                    name: input.name,
-                    path: manifest_path.clone(),
-                });
-            }
+        if let Some(ref manifest_path) = input.updates.manifest_file_path
+            && !manifest_path.exists()
+        {
+            return Err(OperationError::AdditionalPackageManifestNotFound {
+                name: input.name,
+                path: manifest_path.clone(),
+            });
         }
 
         let (manifest_path, section) = resolve_manifest_and_section(&project);

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -1,0 +1,828 @@
+use std::path::{Path, PathBuf};
+
+use changeset_core::{
+    AdditionalPackageDeclaration, AdditionalPackageManifest, CARGO_MANIFEST_FILENAME,
+    ManifestFormat,
+};
+use changeset_manifest::{AdditionalPackageUpdate, MetadataSection};
+use changeset_project::ProjectKind;
+use globset::GlobBuilder;
+
+use crate::Result;
+use crate::error::OperationError;
+use crate::traits::{
+    AdditionalPackageConfigWriter, AdditionalPackageField, AdditionalPackageInteractionProvider,
+    MenuSelection, ProjectProvider,
+};
+
+pub struct AdditionalPackageAddInput {
+    pub name: String,
+    pub path: PathBuf,
+    pub influence: Vec<String>,
+    pub manifest_file_path: PathBuf,
+    pub manifest_format: ManifestFormat,
+    pub manifest_version_path: String,
+}
+
+pub struct AdditionalPackageEditInput {
+    pub name: String,
+    pub updates: AdditionalPackageUpdate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdditionalPackageEvent {
+    Added { name: String },
+    Removed { name: String },
+    Updated { name: String, field: String },
+    Listed(Vec<AdditionalPackageSummaryData>),
+    NotFound { name: String },
+    AlreadyExists { name: String },
+    NoAdditionalPackages,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdditionalPackageSummaryData {
+    pub name: String,
+    pub path: PathBuf,
+    pub manifest_file_path: PathBuf,
+    pub manifest_format: ManifestFormat,
+}
+
+pub struct AdditionalPackageDirectAddOperation<P, W> {
+    project_provider: P,
+    writer: W,
+}
+
+impl<P, W> AdditionalPackageDirectAddOperation<P, W>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W) -> Self {
+        Self {
+            project_provider,
+            writer,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// glob patterns are invalid, the manifest file does not exist, or the manifest
+    /// cannot be written.
+    pub fn execute(
+        &self,
+        start_path: &Path,
+        input: AdditionalPackageAddInput,
+    ) -> Result<Vec<AdditionalPackageEvent>> {
+        execute_add(&self.project_provider, &self.writer, start_path, input)
+    }
+}
+
+pub struct AdditionalPackageDirectRemoveOperation<P, W> {
+    project_provider: P,
+    writer: W,
+}
+
+impl<P, W> AdditionalPackageDirectRemoveOperation<P, W>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W) -> Self {
+        Self {
+            project_provider,
+            writer,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// or the manifest cannot be written.
+    pub fn execute(&self, start_path: &Path, name: &str) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        if !root_config
+            .additional_packages()
+            .iter()
+            .any(|p| p.name() == name)
+        {
+            return Err(OperationError::AdditionalPackageNotFound {
+                name: name.to_string(),
+            });
+        }
+
+        let (manifest_path, section) = resolve_manifest_and_section(&project);
+
+        self.writer
+            .remove_additional_package(&manifest_path, section, name)?;
+
+        Ok(vec![AdditionalPackageEvent::Removed {
+            name: name.to_string(),
+        }])
+    }
+}
+
+pub struct AdditionalPackageDirectEditOperation<P, W> {
+    project_provider: P,
+    writer: W,
+}
+
+impl<P, W> AdditionalPackageDirectEditOperation<P, W>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W) -> Self {
+        Self {
+            project_provider,
+            writer,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// glob patterns are invalid, the new manifest file path does not exist, or the
+    /// manifest cannot be written.
+    pub fn execute(
+        &self,
+        start_path: &Path,
+        input: AdditionalPackageEditInput,
+    ) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        if !root_config
+            .additional_packages()
+            .iter()
+            .any(|p| p.name() == &input.name)
+        {
+            return Err(OperationError::AdditionalPackageNotFound { name: input.name });
+        }
+
+        if let Some(ref influence) = input.updates.influence {
+            validate_influence_patterns(&input.name, influence)?;
+        }
+
+        if let Some(ref manifest_path) = input.updates.manifest_file_path {
+            if !manifest_path.exists() {
+                return Err(OperationError::AdditionalPackageManifestNotFound {
+                    name: input.name,
+                    path: manifest_path.clone(),
+                });
+            }
+        }
+
+        let (manifest_path, section) = resolve_manifest_and_section(&project);
+
+        let changed_fields = describe_updated_fields(&input.updates);
+
+        self.writer.update_additional_package(
+            &manifest_path,
+            section,
+            &input.name,
+            &input.updates,
+        )?;
+
+        Ok(vec![AdditionalPackageEvent::Updated {
+            name: input.name,
+            field: changed_fields,
+        }])
+    }
+}
+
+pub struct AdditionalPackageListOperation<P> {
+    project_provider: P,
+}
+
+impl<P> AdditionalPackageListOperation<P>
+where
+    P: ProjectProvider,
+{
+    #[must_use]
+    pub fn new(project_provider: P) -> Self {
+        Self { project_provider }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered or configs cannot be loaded.
+    pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let packages = root_config.additional_packages();
+
+        if packages.is_empty() {
+            return Ok(vec![AdditionalPackageEvent::NoAdditionalPackages]);
+        }
+
+        let summaries = packages
+            .iter()
+            .map(|p| AdditionalPackageSummaryData {
+                name: p.name().clone(),
+                path: p.path().clone(),
+                manifest_file_path: p.manifest().file_path().clone(),
+                manifest_format: p.manifest().format(),
+            })
+            .collect();
+
+        Ok(vec![AdditionalPackageEvent::Listed(summaries)])
+    }
+}
+
+pub struct AdditionalPackageInteractiveAddOperation<P, W, I> {
+    project_provider: P,
+    writer: W,
+    interaction: I,
+}
+
+impl<P, W, I> AdditionalPackageInteractiveAddOperation<P, W, I>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+    I: AdditionalPackageInteractionProvider,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W, interaction: I) -> Self {
+        Self {
+            project_provider,
+            writer,
+            interaction,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if any user prompt fails, the project cannot be discovered,
+    /// glob patterns are invalid, the manifest file does not exist, or the manifest
+    /// cannot be written.
+    pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
+        let name = self.interaction.prompt_package_name()?;
+        let path = self.interaction.prompt_package_path()?;
+        let influence = self.interaction.prompt_influence_patterns()?;
+        let manifest_file_path = self.interaction.prompt_manifest_file_path()?;
+        let manifest_format = self.interaction.prompt_manifest_format()?;
+        let manifest_version_path = self.interaction.prompt_manifest_version_path()?;
+
+        execute_add(
+            &self.project_provider,
+            &self.writer,
+            start_path,
+            AdditionalPackageAddInput {
+                name,
+                path,
+                influence,
+                manifest_file_path,
+                manifest_format,
+                manifest_version_path,
+            },
+        )
+    }
+}
+
+pub struct AdditionalPackageInteractiveRemoveOperation<P, W, I> {
+    project_provider: P,
+    writer: W,
+    interaction: I,
+}
+
+impl<P, W, I> AdditionalPackageInteractiveRemoveOperation<P, W, I>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+    I: AdditionalPackageInteractionProvider,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W, interaction: I) -> Self {
+        Self {
+            project_provider,
+            writer,
+            interaction,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// the selection prompt fails, or the manifest cannot be written.
+    pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let packages: Vec<&AdditionalPackageDeclaration> =
+            root_config.additional_packages().iter().collect();
+
+        if packages.is_empty() {
+            return Ok(vec![AdditionalPackageEvent::NoAdditionalPackages]);
+        }
+
+        let selection = self.interaction.select_package_to_remove(&packages)?;
+        let MenuSelection::Selected(index) = selection else {
+            return Ok(vec![]);
+        };
+
+        let name = packages[index].name().clone();
+
+        if !self.interaction.confirm_removal(&name)? {
+            return Ok(vec![]);
+        }
+
+        let (manifest_path, section) = resolve_manifest_and_section(&project);
+        self.writer
+            .remove_additional_package(&manifest_path, section, &name)?;
+
+        Ok(vec![AdditionalPackageEvent::Removed { name }])
+    }
+}
+
+pub struct AdditionalPackageInteractiveEditOperation<P, W, I> {
+    project_provider: P,
+    writer: W,
+    interaction: I,
+}
+
+impl<P, W, I> AdditionalPackageInteractiveEditOperation<P, W, I>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+    I: AdditionalPackageInteractionProvider,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W, interaction: I) -> Self {
+        Self {
+            project_provider,
+            writer,
+            interaction,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// any interactive prompt fails, glob patterns are invalid, or the manifest cannot
+    /// be written.
+    pub fn execute(&self, start_path: &Path) -> Result<Vec<AdditionalPackageEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let packages: Vec<&AdditionalPackageDeclaration> =
+            root_config.additional_packages().iter().collect();
+
+        if packages.is_empty() {
+            return Ok(vec![AdditionalPackageEvent::NoAdditionalPackages]);
+        }
+
+        let selection = self.interaction.select_package_to_edit(&packages)?;
+        let MenuSelection::Selected(index) = selection else {
+            return Ok(vec![]);
+        };
+
+        let name = packages[index].name().clone();
+        let mut updates = AdditionalPackageUpdate {
+            path: None,
+            influence: None,
+            manifest_file_path: None,
+            manifest_format: None,
+            manifest_version_path: None,
+        };
+        let mut changed_fields: Vec<String> = Vec::new();
+
+        loop {
+            let field_selection = self.interaction.select_field_to_edit()?;
+            let MenuSelection::Selected(field) = field_selection else {
+                break;
+            };
+
+            match field {
+                AdditionalPackageField::Path => {
+                    updates.path = Some(self.interaction.prompt_package_path()?);
+                    changed_fields.push("path".to_string());
+                }
+                AdditionalPackageField::Influence => {
+                    updates.influence = Some(self.interaction.prompt_influence_patterns()?);
+                    changed_fields.push("influence".to_string());
+                }
+                AdditionalPackageField::ManifestFilePath => {
+                    updates.manifest_file_path =
+                        Some(self.interaction.prompt_manifest_file_path()?);
+                    changed_fields.push("manifest.file-path".to_string());
+                }
+                AdditionalPackageField::ManifestFormat => {
+                    updates.manifest_format = Some(self.interaction.prompt_manifest_format()?);
+                    changed_fields.push("manifest.format".to_string());
+                }
+                AdditionalPackageField::ManifestVersionPath => {
+                    updates.manifest_version_path =
+                        Some(self.interaction.prompt_manifest_version_path()?);
+                    changed_fields.push("manifest.version-path".to_string());
+                }
+            }
+        }
+
+        if changed_fields.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let (manifest_path, section) = resolve_manifest_and_section(&project);
+        self.writer
+            .update_additional_package(&manifest_path, section, &name, &updates)?;
+
+        Ok(vec![AdditionalPackageEvent::Updated {
+            name,
+            field: changed_fields.join(", "),
+        }])
+    }
+}
+
+fn execute_add<P, W>(
+    project_provider: &P,
+    writer: &W,
+    start_path: &Path,
+    input: AdditionalPackageAddInput,
+) -> Result<Vec<AdditionalPackageEvent>>
+where
+    P: ProjectProvider,
+    W: AdditionalPackageConfigWriter,
+{
+    let project = project_provider.discover_project(start_path)?;
+    let (root_config, _) = project_provider.load_configs(&project)?;
+
+    let existing = root_config.additional_packages();
+    if existing.iter().any(|p| p.name() == &input.name) {
+        return Err(OperationError::AdditionalPackageAlreadyExists { name: input.name });
+    }
+
+    if project.packages().iter().any(|p| p.name() == &input.name) {
+        return Err(OperationError::AdditionalPackageAlreadyExists { name: input.name });
+    }
+
+    if !input.manifest_file_path.exists() {
+        return Err(OperationError::AdditionalPackageManifestNotFound {
+            name: input.name,
+            path: input.manifest_file_path,
+        });
+    }
+
+    validate_influence_patterns(&input.name, &input.influence)?;
+
+    let declaration = AdditionalPackageDeclaration::new(
+        input.name.clone(),
+        input.path,
+        input.influence,
+        AdditionalPackageManifest::new(
+            input.manifest_file_path,
+            input.manifest_format,
+            input.manifest_version_path,
+        ),
+    );
+
+    let (manifest_path, section) = resolve_manifest_and_section(&project);
+
+    writer.add_additional_package(&manifest_path, section, &declaration)?;
+
+    Ok(vec![AdditionalPackageEvent::Added { name: input.name }])
+}
+
+fn resolve_manifest_and_section(
+    project: &changeset_project::CargoProject,
+) -> (PathBuf, MetadataSection) {
+    let manifest_path = project.root().join(CARGO_MANIFEST_FILENAME);
+    let section = match project.kind() {
+        ProjectKind::VirtualWorkspace | ProjectKind::WorkspaceWithRoot => {
+            MetadataSection::Workspace
+        }
+        ProjectKind::SinglePackage => MetadataSection::Package,
+    };
+    (manifest_path, section)
+}
+
+fn validate_influence_patterns(name: &str, patterns: &[String]) -> Result<()> {
+    for pattern in patterns {
+        GlobBuilder::new(pattern).build().map_err(|source| {
+            OperationError::AdditionalPackageInvalidGlob {
+                name: name.to_string(),
+                pattern: pattern.clone(),
+                source,
+            }
+        })?;
+    }
+    Ok(())
+}
+
+fn describe_updated_fields(updates: &AdditionalPackageUpdate) -> String {
+    let mut fields = Vec::new();
+    if updates.path.is_some() {
+        fields.push("path");
+    }
+    if updates.influence.is_some() {
+        fields.push("influence");
+    }
+    if updates.manifest_file_path.is_some() {
+        fields.push("manifest.file-path");
+    }
+    if updates.manifest_format.is_some() {
+        fields.push("manifest.format");
+    }
+    if updates.manifest_version_path.is_some() {
+        fields.push("manifest.version-path");
+    }
+    if fields.is_empty() {
+        "none".to_string()
+    } else {
+        fields.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use changeset_core::{AdditionalPackageManifest, ManifestFormat, PackageInfo};
+    use changeset_project::RootChangesetConfig;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::mocks::{MockAdditionalPackageConfigWriter, MockProjectProvider};
+
+    fn make_decl(name: &str) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(format!("charts/{name}")),
+            vec![format!("charts/{name}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("charts/{name}/Chart.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+        )
+    }
+
+    fn make_project_with_packages(
+        additional: Vec<AdditionalPackageDeclaration>,
+    ) -> MockProjectProvider {
+        let config = RootChangesetConfig::default().with_additional_packages(additional);
+        MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]).with_root_config(config)
+    }
+
+    fn make_temp_manifest_file() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("Chart.yaml");
+        std::fs::write(&path, "version: \"1.0.0\"\n").expect("write manifest");
+        (dir, path)
+    }
+
+    #[test]
+    fn direct_add_succeeds_with_valid_input() {
+        let (_dir, manifest_file) = make_temp_manifest_file();
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec!["charts/my-chart/**".to_string()],
+            manifest_file_path: manifest_file,
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let events = op
+            .execute(Path::new("/any"), input)
+            .expect("should succeed");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AdditionalPackageEvent::Added { name } if name == "my-chart"))
+        );
+    }
+
+    #[test]
+    fn direct_add_rejects_duplicate_name() {
+        let (_dir, manifest_file) = make_temp_manifest_file();
+        let provider = make_project_with_packages(vec![make_decl("my-chart")]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec![],
+            manifest_file_path: manifest_file,
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageAlreadyExists { name }) if name == "my-chart"
+        ));
+    }
+
+    #[test]
+    fn direct_add_rejects_name_collision_with_rust_crate() {
+        let (_dir, manifest_file) = make_temp_manifest_file();
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "crate-a".to_string(),
+            path: PathBuf::from("crate-a"),
+            influence: vec![],
+            manifest_file_path: manifest_file,
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageAlreadyExists { .. })
+        ));
+    }
+
+    #[test]
+    fn direct_add_validates_manifest_file_exists() {
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec![],
+            manifest_file_path: PathBuf::from("/nonexistent/Chart.yaml"),
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageManifestNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn direct_add_validates_glob_patterns() {
+        let (_dir, manifest_file) = make_temp_manifest_file();
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectAddOperation::new(provider, writer);
+        let input = AdditionalPackageAddInput {
+            name: "my-chart".to_string(),
+            path: PathBuf::from("charts/my-chart"),
+            influence: vec!["[invalid".to_string()],
+            manifest_file_path: manifest_file,
+            manifest_format: ManifestFormat::Yaml,
+            manifest_version_path: "version".to_string(),
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageInvalidGlob { .. })
+        ));
+    }
+
+    #[test]
+    fn direct_remove_succeeds() {
+        let provider = make_project_with_packages(vec![make_decl("my-chart")]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectRemoveOperation::new(provider, writer);
+        let events = op
+            .execute(Path::new("/any"), "my-chart")
+            .expect("should succeed");
+
+        assert!(
+            events.iter().any(
+                |e| matches!(e, AdditionalPackageEvent::Removed { name } if name == "my-chart")
+            )
+        );
+    }
+
+    #[test]
+    fn direct_remove_nonexistent() {
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectRemoveOperation::new(provider, writer);
+        let result = op.execute(Path::new("/any"), "nonexistent");
+
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn direct_edit_updates_fields() {
+        let provider = make_project_with_packages(vec![make_decl("my-chart")]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectEditOperation::new(provider, writer);
+        let input = AdditionalPackageEditInput {
+            name: "my-chart".to_string(),
+            updates: AdditionalPackageUpdate {
+                path: Some(PathBuf::from("new/path")),
+                influence: None,
+                manifest_file_path: None,
+                manifest_format: None,
+                manifest_version_path: None,
+            },
+        };
+
+        let events = op
+            .execute(Path::new("/any"), input)
+            .expect("should succeed");
+        assert!(events.iter().any(
+            |e| matches!(e, AdditionalPackageEvent::Updated { name, .. } if name == "my-chart")
+        ));
+    }
+
+    #[test]
+    fn direct_edit_nonexistent() {
+        let provider = make_project_with_packages(vec![]);
+        let writer = MockAdditionalPackageConfigWriter::new();
+
+        let op = AdditionalPackageDirectEditOperation::new(provider, writer);
+        let input = AdditionalPackageEditInput {
+            name: "nonexistent".to_string(),
+            updates: AdditionalPackageUpdate {
+                path: Some(PathBuf::from("new/path")),
+                influence: None,
+                manifest_file_path: None,
+                manifest_format: None,
+                manifest_version_path: None,
+            },
+        };
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::AdditionalPackageNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn list_returns_all_packages() {
+        let provider = make_project_with_packages(vec![make_decl("chart-a"), make_decl("chart-b")]);
+
+        let op = AdditionalPackageListOperation::new(provider);
+        let events = op.execute(Path::new("/any")).expect("should succeed");
+
+        let listed = events.iter().find_map(|e| {
+            if let AdditionalPackageEvent::Listed(s) = e {
+                Some(s)
+            } else {
+                None
+            }
+        });
+        let summaries = listed.expect("should have Listed event");
+        assert_eq!(summaries.len(), 2);
+    }
+
+    #[test]
+    fn list_empty_returns_no_additional_packages() {
+        let provider = make_project_with_packages(vec![]);
+        let op = AdditionalPackageListOperation::new(provider);
+        let events = op.execute(Path::new("/any")).expect("should succeed");
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AdditionalPackageEvent::NoAdditionalPackages))
+        );
+    }
+
+    #[test]
+    fn additional_packages_from_mock_provider() {
+        let info = PackageInfo::new(
+            "my-helm-chart".to_string(),
+            "1.2.3".parse().expect("valid version"),
+            PathBuf::from("/mock/charts/my-helm-chart"),
+        );
+        let provider = MockProjectProvider::workspace(vec![]).with_additional_packages(vec![info]);
+
+        let project_provider: &dyn crate::traits::ProjectProvider = &provider;
+        let project = project_provider
+            .discover_project(Path::new("/any"))
+            .expect("discover");
+        let (root_config, _) = project_provider
+            .load_configs(&project)
+            .expect("load configs");
+
+        assert_eq!(root_config.additional_packages().len(), 0);
+    }
+}

--- a/crates/changeset-operations/src/operations/additional_packages.rs
+++ b/crates/changeset-operations/src/operations/additional_packages.rs
@@ -21,7 +21,7 @@ pub struct AdditionalPackageAddInput {
     pub influence: Vec<String>,
     pub manifest_file_path: PathBuf,
     pub manifest_format: ManifestFormat,
-    pub manifest_version_path: String,
+    pub manifest_version_field_path: String,
 }
 
 pub struct AdditionalPackageEditInput {
@@ -278,7 +278,7 @@ where
         let influence = self.interaction.prompt_influence_patterns(&path)?;
         let manifest_file_path = self.interaction.prompt_manifest_file_path()?;
         let manifest_format = self.interaction.prompt_manifest_format()?;
-        let manifest_version_path = self.interaction.prompt_manifest_version_path()?;
+        let manifest_version_field_path = self.interaction.prompt_manifest_version_field_path()?;
 
         let (root_config, _) = self.project_provider.load_configs(&project)?;
         write_additional_package(
@@ -291,7 +291,7 @@ where
                 influence,
                 manifest_file_path,
                 manifest_format,
-                manifest_version_path,
+                manifest_version_field_path,
             },
         )
     }
@@ -402,7 +402,7 @@ where
             influence: None,
             manifest_file_path: None,
             manifest_format: None,
-            manifest_version_path: None,
+            manifest_version_field_path: None,
         };
         let mut changed_fields: Vec<String> = Vec::new();
 
@@ -435,10 +435,10 @@ where
                     updates.manifest_format = Some(self.interaction.prompt_manifest_format()?);
                     changed_fields.push("manifest.format".to_string());
                 }
-                AdditionalPackageField::ManifestVersionPath => {
-                    updates.manifest_version_path =
-                        Some(self.interaction.prompt_manifest_version_path()?);
-                    changed_fields.push("manifest.version-path".to_string());
+                AdditionalPackageField::ManifestVersionFieldPath => {
+                    updates.manifest_version_field_path =
+                        Some(self.interaction.prompt_manifest_version_field_path()?);
+                    changed_fields.push("manifest.version-field-path".to_string());
                 }
             }
         }
@@ -492,7 +492,7 @@ where
         AdditionalPackageManifest::new(
             input.manifest_file_path,
             input.manifest_format,
-            input.manifest_version_path,
+            input.manifest_version_field_path,
         ),
     );
 
@@ -552,8 +552,8 @@ fn describe_updated_fields(updates: &AdditionalPackageUpdate) -> String {
     if updates.manifest_format.is_some() {
         fields.push("manifest.format");
     }
-    if updates.manifest_version_path.is_some() {
-        fields.push("manifest.version-path");
+    if updates.manifest_version_field_path.is_some() {
+        fields.push("manifest.version-field-path");
     }
     if fields.is_empty() {
         "none".to_string()
@@ -613,7 +613,7 @@ mod tests {
             influence: vec!["charts/my-chart/**".to_string()],
             manifest_file_path: manifest_file,
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let events = op
@@ -639,7 +639,7 @@ mod tests {
             influence: vec![],
             manifest_file_path: manifest_file,
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let result = op.execute(Path::new("/any"), input);
@@ -662,7 +662,7 @@ mod tests {
             influence: vec![],
             manifest_file_path: manifest_file,
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let result = op.execute(Path::new("/any"), input);
@@ -684,7 +684,7 @@ mod tests {
             influence: vec![],
             manifest_file_path: PathBuf::from("/nonexistent/Chart.yaml"),
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let result = op.execute(Path::new("/any"), input);
@@ -707,7 +707,7 @@ mod tests {
             influence: vec!["[invalid".to_string()],
             manifest_file_path: manifest_file,
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let result = op.execute(Path::new("/any"), input);
@@ -761,7 +761,7 @@ mod tests {
                 influence: None,
                 manifest_file_path: None,
                 manifest_format: None,
-                manifest_version_path: None,
+                manifest_version_field_path: None,
             },
         };
 
@@ -786,7 +786,7 @@ mod tests {
                 influence: None,
                 manifest_file_path: None,
                 manifest_format: None,
-                manifest_version_path: None,
+                manifest_version_field_path: None,
             },
         };
 
@@ -861,7 +861,7 @@ mod tests {
             influence: vec![],
             manifest_file_path: manifest_file,
             manifest_format: ManifestFormat::Yaml,
-            manifest_version_path: "version".to_string(),
+            manifest_version_field_path: "version".to_string(),
         };
 
         let result = op.execute(Path::new("/any"), input);
@@ -897,7 +897,7 @@ mod tests {
                 influence: None,
                 manifest_file_path: None,
                 manifest_format: None,
-                manifest_version_path: None,
+                manifest_version_field_path: None,
             },
         };
 

--- a/crates/changeset-operations/src/operations/init.rs
+++ b/crates/changeset-operations/src/operations/init.rs
@@ -262,17 +262,17 @@ where
     fn build_config(&self, input: &InitInput, context: ProjectContext) -> Result<InitConfig> {
         let mut config = build_config_from_input(input, context);
 
-        if config.is_empty() {
-            if let Some(ref provider) = self.interaction_provider {
-                let interactive_input = InitInputBuilder::default()
-                    .git_config(provider.configure_git_settings(context)?)
-                    .changelog_config(provider.configure_changelog_settings(context)?)
-                    .version_config(provider.configure_version_settings()?)
-                    .filtering_config(provider.configure_filtering_settings()?)
-                    .build()
-                    .expect("all fields have defaults");
-                apply_settings_to_config(&mut config, &interactive_input);
-            }
+        if config.is_empty()
+            && let Some(ref provider) = self.interaction_provider
+        {
+            let interactive_input = InitInputBuilder::default()
+                .git_config(provider.configure_git_settings(context)?)
+                .changelog_config(provider.configure_changelog_settings(context)?)
+                .version_config(provider.configure_version_settings()?)
+                .filtering_config(provider.configure_filtering_settings()?)
+                .build()
+                .expect("all fields have defaults");
+            apply_settings_to_config(&mut config, &interactive_input);
         }
 
         Ok(config)
@@ -380,10 +380,10 @@ fn apply_settings_to_config(config: &mut InitConfig, input: &InitInput) {
             .clone_from(&version.none_bump_promote_message_template);
     }
 
-    if let Some(filtering) = input.filtering_config() {
-        if !filtering.ignored_files.is_empty() {
-            config.ignored_files = Some(filtering.ignored_files.clone());
-        }
+    if let Some(filtering) = input.filtering_config()
+        && !filtering.ignored_files.is_empty()
+    {
+        config.ignored_files = Some(filtering.ignored_files.clone());
     }
 }
 

--- a/crates/changeset-operations/src/operations/init.rs
+++ b/crates/changeset-operations/src/operations/init.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use changeset_core::CARGO_MANIFEST_FILENAME;
 use changeset_git::DEFAULT_BASE_BRANCH;
 use changeset_manifest::{InitConfig, MetadataSection};
 use changeset_project::{CargoProject, ProjectKind, RootChangesetConfig};
@@ -228,7 +229,7 @@ where
             if plan.config().is_empty() {
                 false
             } else {
-                let manifest_path = project.root().join("Cargo.toml");
+                let manifest_path = project.root().join(CARGO_MANIFEST_FILENAME);
                 writer.write_metadata(&manifest_path, plan.metadata_section(), plan.config())?;
                 true
             }

--- a/crates/changeset-operations/src/operations/mod.rs
+++ b/crates/changeset-operations/src/operations/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod additional_packages;
 mod changelog_aggregation;
 mod init;
 mod manage;
@@ -8,6 +9,13 @@ mod verify;
 
 pub use crate::planner::{ReleasePlan, VersionPlanner};
 pub use add::{AddInput, AddOperation, AddResult};
+pub use additional_packages::{
+    AdditionalPackageAddInput, AdditionalPackageDirectAddOperation,
+    AdditionalPackageDirectEditOperation, AdditionalPackageDirectRemoveOperation,
+    AdditionalPackageEditInput, AdditionalPackageEvent, AdditionalPackageInteractiveAddOperation,
+    AdditionalPackageInteractiveEditOperation, AdditionalPackageInteractiveRemoveOperation,
+    AdditionalPackageListOperation, AdditionalPackageSummaryData,
+};
 pub use init::{
     InitInput, InitInputBuilder, InitOperation, InitOutput, InitPlan, build_config_from_input,
 };

--- a/crates/changeset-operations/src/operations/mod.rs
+++ b/crates/changeset-operations/src/operations/mod.rs
@@ -7,6 +7,12 @@ pub mod release;
 mod status;
 mod verify;
 
+use changeset_core::PackageInfo;
+use changeset_project::ProjectKind;
+
+use crate::Result;
+use crate::traits::ProjectProvider;
+
 pub use crate::planner::{ReleasePlan, VersionPlanner};
 pub use add::{AddInput, AddOperation, AddResult};
 pub use additional_packages::{
@@ -33,3 +39,14 @@ pub use release::{
 };
 pub use status::{StatusOperation, StatusOutput, StatusOutputBuilder};
 pub use verify::{VerifyInput, VerifyInputBuilder, VerifyOperation, VerifyOutcome, VerifyResult};
+
+pub(crate) fn discover_additional_packages_if_workspace<P: ProjectProvider>(
+    provider: &P,
+    project: &changeset_project::CargoProject,
+    root_config: &changeset_project::RootChangesetConfig,
+) -> Result<Vec<PackageInfo>> {
+    if *project.kind() == ProjectKind::SinglePackage {
+        return Ok(Vec::new());
+    }
+    provider.discover_additional_packages(project.root(), root_config)
+}

--- a/crates/changeset-operations/src/operations/mod.rs
+++ b/crates/changeset-operations/src/operations/mod.rs
@@ -6,6 +6,7 @@ mod manage;
 pub mod release;
 mod status;
 mod verify;
+mod version_tracking_deps;
 
 use changeset_core::PackageInfo;
 use changeset_project::ProjectKind;
@@ -39,6 +40,12 @@ pub use release::{
 };
 pub use status::{StatusOperation, StatusOutput, StatusOutputBuilder};
 pub use verify::{VerifyInput, VerifyInputBuilder, VerifyOperation, VerifyOutcome, VerifyResult};
+pub use version_tracking_deps::{
+    VersionTrackingDependencyAddInput, VersionTrackingDependencyAddOperation,
+    VersionTrackingDependencyEvent, VersionTrackingDependencyListOperation,
+    VersionTrackingDependencyRemoveInput, VersionTrackingDependencyRemoveOperation,
+    VersionTrackingDependencySummary,
+};
 
 pub(crate) fn discover_additional_packages_if_workspace<P: ProjectProvider>(
     provider: &P,

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -9,12 +9,14 @@ use indexmap::IndexMap;
 
 use super::classifiers::{self, EarlyReturnDecision};
 use super::context::ReleaseSagaContext;
-use super::saga_data::{AdditionalManifestInfo, ReleaseSagaData, SagaReleaseOptions};
+use super::saga_data::{
+    AdditionalManifestInfo, ReleaseSagaData, SagaReleaseOptions, VersionTrackingWrite,
+};
 use super::saga_steps::{
     ClearChangesetsConsumedStep, CreateCommitStep, CreateTagsStep, DeleteChangesetFilesStep,
     MarkChangesetsConsumedStep, RemoveWorkspaceVersionStep, RestoreChangelogsStep, StageFilesStep,
     UpdateDependencyVersionsStep, UpdateLockfileStep, UpdateReleaseStateStep,
-    WriteManifestVersionsStep,
+    WriteManifestVersionsStep, WriteVersionTrackingStep,
 };
 use super::types::{
     ChangelogUpdate, GitOptions, PrepareResult, ReleaseClassification, ReleaseContext,
@@ -28,8 +30,8 @@ use crate::operations::changelog_aggregation::ChangesetAggregator;
 use crate::planner::VersionPlanner;
 use crate::traits::{
     ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider,
-    ExternalManifestVersionWriter, FullGitProvider, FullManifestWriter, ProjectProvider,
-    ReleaseStateIO,
+    ExternalManifestVersionReader, ExternalManifestVersionWriter, FullGitProvider,
+    FullManifestWriter, ProjectProvider, ReleaseStateIO,
 };
 use crate::types::PackageVersion;
 
@@ -46,7 +48,12 @@ impl<P, RW, M, C, G, S> ReleaseOperation<P, RW, M, C, G, S>
 where
     P: ProjectProvider + DependencyGraphProvider,
     RW: ChangesetReader + ChangesetWriter + Send + Sync + 'static,
-    M: FullManifestWriter + ExternalManifestVersionWriter + Send + Sync + 'static,
+    M: FullManifestWriter
+        + ExternalManifestVersionWriter
+        + ExternalManifestVersionReader
+        + Send
+        + Sync
+        + 'static,
     C: ChangelogWriter + Send + Sync + 'static,
     G: FullGitProvider + Send + Sync + 'static,
     S: ReleaseStateIO + Send + Sync + 'static,
@@ -168,7 +175,7 @@ where
         input: &ReleaseInput,
     ) -> Result<PrepareResult> {
         let project = self.project_provider.discover_project(start_path)?;
-        let (root_config, _) = self.project_provider.load_configs(&project)?;
+        let (root_config, package_configs) = self.project_provider.load_configs(&project)?;
 
         let additional_packages = crate::operations::discover_additional_packages_if_workspace(
             &self.project_provider,
@@ -255,9 +262,11 @@ where
             inherited_packages,
             additional_packages,
             all_packages,
+            package_configs,
         })))
     }
 
+    #[allow(clippy::too_many_lines)]
     fn plan_release(&self, context: &ReleaseContext, dry_run: bool) -> Result<ReleasePlan> {
         let (changesets, mut aggregator) = super::loading::load_changesets(
             self.changeset_io.as_ref(),
@@ -300,13 +309,24 @@ where
             .releases()
             .clone();
 
-            let graph = self
+            let mut graph = self
                 .project_provider
                 .build_dependency_graph(&context.project)?;
+
+            let additional_names = context.additional_packages.iter().map(|p| p.name().clone());
+            graph.add_members(additional_names);
+
+            let tracking_info = changeset_project::collect_version_tracking_info(
+                &context.root_config,
+                &context.package_configs,
+            );
+            let edges = changeset_project::tracking_edges(&tracking_info);
+            graph.extend_with_edges(&edges);
+
             let expanded = super::dependency_expansion::expand_with_reverse_dependencies(
                 base_releases,
                 &graph,
-                context.project.packages(),
+                &context.all_packages,
                 context.root_config.zero_version_behavior(),
             )?;
 
@@ -401,6 +421,28 @@ where
             })
             .collect();
 
+        let tracking_info = changeset_project::collect_version_tracking_info(
+            &context.root_config,
+            &context.package_configs,
+        );
+
+        let project_root = context.project.root();
+        let version_tracking_writes: Vec<VersionTrackingWrite> = tracking_info
+            .iter()
+            .filter_map(|entry| {
+                plan.output
+                    .planned_releases()
+                    .iter()
+                    .find(|r| r.name() == entry.dependency_name())
+                    .map(|release| VersionTrackingWrite {
+                        manifest_path: project_root.join(entry.manifest().file_path()),
+                        format: entry.manifest().format(),
+                        version_field_path: entry.manifest().version_field_path().clone(),
+                        new_dependency_version: release.new_version().clone(),
+                    })
+            })
+            .collect();
+
         let saga_data = ReleaseSagaData::new(
             context.changeset_dir.clone(),
             context.project.root().join(CARGO_MANIFEST_FILENAME),
@@ -417,7 +459,8 @@ where
         .with_prerelease_state(context.prerelease_state.as_ref())
         .with_graduation_state(context.graduation_state.as_ref())
         .with_additional_packages(additional_package_manifests)
-        .with_changelog_backups(plan.changelog_backups);
+        .with_changelog_backups(plan.changelog_backups)
+        .with_version_tracking_writes(version_tracking_writes);
 
         let result = self.execute_release_saga(context, saga_data)?;
 
@@ -433,6 +476,7 @@ where
     ) -> Result<ReleaseSagaData> {
         type RestoreChangelogs<G, M, RW, S, CW> = RestoreChangelogsStep<G, M, RW, S, CW>;
         type WriteManifests<G, M, RW, S, CW> = WriteManifestVersionsStep<G, M, RW, S, CW>;
+        type WriteVersionTracking<G, M, RW, S, CW> = WriteVersionTrackingStep<G, M, RW, S, CW>;
         type UpdateDeps<G, M, RW, S, CW> = UpdateDependencyVersionsStep<G, M, RW, S, CW>;
         type RemoveWorkspace<G, M, RW, S, CW> = RemoveWorkspaceVersionStep<G, M, RW, S, CW>;
         type UpdateLockfile<G, M, RW, S, CW> = UpdateLockfileStep<G, M, RW, S, CW>;
@@ -453,6 +497,7 @@ where
         let saga = SagaBuilder::new()
             .first_step(RestoreChangelogs::<G, M, RW, S, C>::new())
             .then(WriteManifests::<G, M, RW, S, C>::new())
+            .then(WriteVersionTracking::<G, M, RW, S, C>::new())
             .then(UpdateDeps::<G, M, RW, S, C>::new())
             .then(RemoveWorkspace::<G, M, RW, S, C>::new())
             .then(UpdateLockfile::<G, M, RW, S, C>::new())
@@ -545,7 +590,12 @@ mod tests {
     where
         P: ProjectProvider + DependencyGraphProvider,
         RW: ChangesetReader + ChangesetWriter + Send + Sync + 'static,
-        M: FullManifestWriter + ExternalManifestVersionWriter + Send + Sync + 'static,
+        M: FullManifestWriter
+            + ExternalManifestVersionWriter
+            + ExternalManifestVersionReader
+            + Send
+            + Sync
+            + 'static,
     {
         ReleaseOperation::new(
             project_provider,

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -395,7 +395,7 @@ where
                     AdditionalManifestInfo {
                         manifest_path: context.project.root().join(decl.manifest().file_path()),
                         format: decl.manifest().format(),
-                        version_path: decl.manifest().version_path().clone(),
+                        version_field_path: decl.manifest().version_field_path().clone(),
                     },
                 )
             })

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use changeset_core::PackageInfo;
+use changeset_core::{CARGO_MANIFEST_FILENAME, PackageInfo};
 use changeset_project::{ProjectKind, TagFormat, WorkspaceDependencyGraph};
 use changeset_saga::SagaBuilder;
 use chrono::Local;
@@ -363,7 +363,7 @@ where
 
         let saga_data = ReleaseSagaData::new(
             context.changeset_dir.clone(),
-            context.project.root().join("Cargo.toml"),
+            context.project.root().join(CARGO_MANIFEST_FILENAME),
             plan.output.planned_releases().clone(),
             package_paths,
             plan.output.changelog_updates().clone(),

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -200,6 +200,14 @@ where
             .chain(additional_packages.iter().cloned())
             .collect();
 
+        let all_package_names: std::collections::HashSet<String> =
+            all_packages.iter().map(|p| p.name().clone()).collect();
+        changeset_project::validate_version_tracking_dependencies(
+            &root_config,
+            &package_configs,
+            &all_package_names,
+        )?;
+
         let cli_input = ReleaseCliInput::from(input);
         let validated_config = ReleaseValidator::validate(
             &cli_input,

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -252,17 +252,8 @@ where
             git_options,
             inherited_packages,
             additional_packages,
+            all_packages,
         })))
-    }
-
-    fn all_packages(context: &ReleaseContext) -> Vec<PackageInfo> {
-        context
-            .project
-            .packages()
-            .iter()
-            .cloned()
-            .chain(context.additional_packages.iter().cloned())
-            .collect()
     }
 
     fn plan_release(&self, context: &ReleaseContext, dry_run: bool) -> Result<ReleasePlan> {
@@ -272,10 +263,10 @@ where
             &context.changeset_files,
         )?;
 
-        let all_packages = Self::all_packages(context);
+        let all_packages = &context.all_packages;
 
         let planned_releases = if context.classification.is_prerelease_graduation {
-            VersionPlanner::plan_graduation(&all_packages)?
+            VersionPlanner::plan_graduation(all_packages)?
                 .releases()
                 .clone()
         } else {
@@ -300,7 +291,7 @@ where
 
             let base_releases = VersionPlanner::plan_releases_per_package(
                 &changesets,
-                &all_packages,
+                all_packages,
                 &context.per_package_config,
                 context.root_config.zero_version_behavior(),
             )?
@@ -338,7 +329,7 @@ where
         }
 
         let unchanged_packages =
-            classifiers::collect_unchanged_packages(&all_packages, &planned_releases);
+            classifiers::collect_unchanged_packages(all_packages, &planned_releases);
 
         let (changelog_updates, changelog_backups) = if dry_run {
             (Vec::new(), Vec::new())

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -170,9 +170,11 @@ where
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
-        let additional_packages = self
-            .project_provider
-            .discover_additional_packages(project.root(), &root_config)?;
+        let additional_packages = crate::operations::discover_additional_packages_if_workspace(
+            &self.project_provider,
+            &project,
+            &root_config,
+        )?;
 
         let changeset_dir = project.root().join(root_config.changeset_dir());
         let changeset_files = self.changeset_io.list_changesets(&changeset_dir)?;
@@ -2423,5 +2425,31 @@ mod tests {
             .find(|r| r.name() == "crate-b")
             .expect("crate-b should be in planned releases");
         assert_eq!(release_b.bump_type(), BumpType::Patch);
+    }
+
+    #[test]
+    fn single_package_never_calls_discover_additional_packages() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0")
+            .with_fail_on_discover_additional();
+
+        let changeset = make_changeset("my-crate", BumpType::Patch, "Fix bug");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/fix.md"), changeset);
+
+        let operation = ReleaseOperation::new(
+            project_provider,
+            changeset_reader,
+            MockManifestWriter::new(),
+            MockChangelogWriter::new(),
+            MockGitProvider::new(),
+            MockReleaseStateIO::new(),
+        );
+
+        let input = default_input();
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("single-package should succeed without calling discover_additional_packages");
+
+        assert!(matches!(result, ReleaseOutcome::DryRun(_)));
     }
 }

--- a/crates/changeset-operations/src/operations/release/operation.rs
+++ b/crates/changeset-operations/src/operations/release/operation.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 
 use super::classifiers::{self, EarlyReturnDecision};
 use super::context::ReleaseSagaContext;
-use super::saga_data::{ReleaseSagaData, SagaReleaseOptions};
+use super::saga_data::{AdditionalManifestInfo, ReleaseSagaData, SagaReleaseOptions};
 use super::saga_steps::{
     ClearChangesetsConsumedStep, CreateCommitStep, CreateTagsStep, DeleteChangesetFilesStep,
     MarkChangesetsConsumedStep, RemoveWorkspaceVersionStep, RestoreChangelogsStep, StageFilesStep,
@@ -27,8 +27,9 @@ use crate::none_bump;
 use crate::operations::changelog_aggregation::ChangesetAggregator;
 use crate::planner::VersionPlanner;
 use crate::traits::{
-    ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider, FullGitProvider,
-    FullManifestWriter, ProjectProvider, ReleaseStateIO,
+    ChangelogWriter, ChangesetReader, ChangesetWriter, DependencyGraphProvider,
+    ExternalManifestVersionWriter, FullGitProvider, FullManifestWriter, ProjectProvider,
+    ReleaseStateIO,
 };
 use crate::types::PackageVersion;
 
@@ -45,7 +46,7 @@ impl<P, RW, M, C, G, S> ReleaseOperation<P, RW, M, C, G, S>
 where
     P: ProjectProvider + DependencyGraphProvider,
     RW: ChangesetReader + ChangesetWriter + Send + Sync + 'static,
-    M: FullManifestWriter + Send + Sync + 'static,
+    M: FullManifestWriter + ExternalManifestVersionWriter + Send + Sync + 'static,
     C: ChangelogWriter + Send + Sync + 'static,
     G: FullGitProvider + Send + Sync + 'static,
     S: ReleaseStateIO + Send + Sync + 'static,
@@ -169,6 +170,10 @@ where
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
 
+        let additional_packages = self
+            .project_provider
+            .discover_additional_packages(project.root(), &root_config)?;
+
         let changeset_dir = project.root().join(root_config.changeset_dir());
         let changeset_files = self.changeset_io.list_changesets(&changeset_dir)?;
 
@@ -179,12 +184,19 @@ where
             .release_state_io
             .load_graduation_state(&changeset_dir)?;
 
+        let all_packages: Vec<PackageInfo> = project
+            .packages()
+            .iter()
+            .cloned()
+            .chain(additional_packages.iter().cloned())
+            .collect();
+
         let cli_input = ReleaseCliInput::from(input);
         let validated_config = ReleaseValidator::validate(
             &cli_input,
             prerelease_state.as_ref(),
             graduation_state.as_ref(),
-            project.packages(),
+            &all_packages,
             project.kind(),
         )?;
 
@@ -239,7 +251,18 @@ where
             },
             git_options,
             inherited_packages,
+            additional_packages,
         })))
+    }
+
+    fn all_packages(context: &ReleaseContext) -> Vec<PackageInfo> {
+        context
+            .project
+            .packages()
+            .iter()
+            .cloned()
+            .chain(context.additional_packages.iter().cloned())
+            .collect()
     }
 
     fn plan_release(&self, context: &ReleaseContext, dry_run: bool) -> Result<ReleasePlan> {
@@ -249,8 +272,10 @@ where
             &context.changeset_files,
         )?;
 
+        let all_packages = Self::all_packages(context);
+
         let planned_releases = if context.classification.is_prerelease_graduation {
-            VersionPlanner::plan_graduation(context.project.packages())?
+            VersionPlanner::plan_graduation(&all_packages)?
                 .releases()
                 .clone()
         } else {
@@ -275,7 +300,7 @@ where
 
             let base_releases = VersionPlanner::plan_releases_per_package(
                 &changesets,
-                context.project.packages(),
+                &all_packages,
                 &context.per_package_config,
                 context.root_config.zero_version_behavior(),
             )?
@@ -302,15 +327,18 @@ where
             expanded
         };
 
-        let package_lookup: IndexMap<_, _> = context
+        let mut package_lookup: IndexMap<_, _> = context
             .project
             .packages()
             .iter()
             .map(|p| (p.name().clone(), p.clone()))
             .collect();
+        for pkg in &context.additional_packages {
+            package_lookup.insert(pkg.name().clone(), pkg.clone());
+        }
 
         let unchanged_packages =
-            classifiers::collect_unchanged_packages(context.project.packages(), &planned_releases);
+            classifiers::collect_unchanged_packages(&all_packages, &planned_releases);
 
         let (changelog_updates, changelog_backups) = if dry_run {
             (Vec::new(), Vec::new())
@@ -355,10 +383,29 @@ where
         context: &ReleaseContext,
         plan: ReleasePlan,
     ) -> Result<ReleaseOutcome> {
-        let package_paths: IndexMap<String, PathBuf> = plan
+        let mut package_paths: IndexMap<String, PathBuf> = plan
             .package_lookup
             .iter()
             .map(|(name, info)| (name.clone(), info.path().clone()))
+            .collect();
+        for pkg in &context.additional_packages {
+            package_paths.insert(pkg.name().clone(), pkg.path().clone());
+        }
+
+        let additional_package_manifests: IndexMap<String, AdditionalManifestInfo> = context
+            .root_config
+            .additional_packages()
+            .iter()
+            .map(|decl| {
+                (
+                    decl.name().clone(),
+                    AdditionalManifestInfo {
+                        manifest_path: context.project.root().join(decl.manifest().file_path()),
+                        format: decl.manifest().format(),
+                        version_path: decl.manifest().version_path().clone(),
+                    },
+                )
+            })
             .collect();
 
         let saga_data = ReleaseSagaData::new(
@@ -376,6 +423,7 @@ where
         .with_inherited_packages(context.inherited_packages.clone())
         .with_prerelease_state(context.prerelease_state.as_ref())
         .with_graduation_state(context.graduation_state.as_ref())
+        .with_additional_packages(additional_package_manifests)
         .with_changelog_backups(plan.changelog_backups);
 
         let result = self.execute_release_saga(context, saga_data)?;
@@ -504,7 +552,7 @@ mod tests {
     where
         P: ProjectProvider + DependencyGraphProvider,
         RW: ChangesetReader + ChangesetWriter + Send + Sync + 'static,
-        M: FullManifestWriter + Send + Sync + 'static,
+        M: FullManifestWriter + ExternalManifestVersionWriter + Send + Sync + 'static,
     {
         ReleaseOperation::new(
             project_provider,

--- a/crates/changeset-operations/src/operations/release/saga_data.rs
+++ b/crates/changeset-operations/src/operations/release/saga_data.rs
@@ -23,7 +23,7 @@ pub(super) enum ManifestKind {
     #[allow(dead_code)]
     Additional {
         format: ManifestFormat,
-        version_path: String,
+        version_field_path: String,
     },
 }
 
@@ -31,7 +31,7 @@ pub(super) enum ManifestKind {
 pub(super) struct AdditionalManifestInfo {
     pub(super) manifest_path: PathBuf,
     pub(super) format: ManifestFormat,
-    pub(super) version_path: String,
+    pub(super) version_field_path: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/changeset-operations/src/operations/release/saga_data.rs
+++ b/crates/changeset-operations/src/operations/release/saga_data.rs
@@ -91,6 +91,9 @@ pub struct ReleaseSagaData {
     #[getset(get, vis = "pub(super)")]
     changelog_backups: Vec<ChangelogFileState>,
     changelogs_written: bool,
+
+    pub(super) version_tracking_writes: Vec<VersionTrackingWrite>,
+    pub(super) version_tracking_records: Vec<VersionTrackingWriteRecord>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,6 +112,24 @@ pub(super) struct DependencyUpdate {
     pub(super) dependency_name: String,
     pub(super) old_version: Version,
     pub(super) new_version: Version,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct VersionTrackingWrite {
+    pub(super) manifest_path: PathBuf,
+    pub(super) format: ManifestFormat,
+    pub(super) version_field_path: String,
+    pub(super) new_dependency_version: Version,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct VersionTrackingWriteRecord {
+    pub(super) manifest_path: PathBuf,
+    pub(super) format: ManifestFormat,
+    pub(super) version_field_path: String,
+    pub(super) old_value: String,
+    pub(super) new_version: Version,
+    pub(super) written: bool,
 }
 
 impl ReleaseSagaData {
@@ -196,6 +217,11 @@ impl ReleaseSagaData {
     pub fn with_changelog_backups(mut self, backups: Vec<ChangelogFileState>) -> Self {
         self.changelogs_written = !backups.is_empty();
         self.changelog_backups = backups;
+        self
+    }
+
+    pub fn with_version_tracking_writes(mut self, writes: Vec<VersionTrackingWrite>) -> Self {
+        self.version_tracking_writes = writes;
         self
     }
 

--- a/crates/changeset-operations/src/operations/release/saga_data.rs
+++ b/crates/changeset-operations/src/operations/release/saga_data.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
+use changeset_core::ManifestFormat;
 use changeset_project::{GraduationState, PrereleaseState};
+use gset::Getset;
 use indexmap::IndexMap;
 use semver::Version;
 
@@ -15,6 +17,23 @@ pub struct SagaReleaseOptions {
     pub git_options: GitOptions,
 }
 
+#[derive(Debug, Clone)]
+pub(super) enum ManifestKind {
+    Cargo,
+    #[allow(dead_code)]
+    Additional {
+        format: ManifestFormat,
+        version_path: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AdditionalManifestInfo {
+    pub(super) manifest_path: PathBuf,
+    pub(super) format: ManifestFormat,
+    pub(super) version_path: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) enum ChangesetConsumedState {
     #[default]
@@ -23,45 +42,55 @@ pub(super) enum ChangesetConsumedState {
     Cleared,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Getset)]
 pub struct ReleaseSagaData {
-    pub changeset_dir: PathBuf,
-    pub root_manifest_path: PathBuf,
-    pub inherited_packages: Vec<String>,
+    #[getset(get, vis = "pub(super)")]
+    changeset_dir: PathBuf,
+    #[getset(get, vis = "pub(super)")]
+    root_manifest_path: PathBuf,
+    pub(super) inherited_packages: Vec<String>,
 
-    pub planned_releases: Vec<PackageVersion>,
-    pub package_paths: IndexMap<String, PathBuf>,
-    pub changelog_updates: Vec<ChangelogUpdate>,
+    #[getset(get, vis = "pub(super)")]
+    planned_releases: Vec<PackageVersion>,
+    #[getset(get, vis = "pub(super)")]
+    package_paths: IndexMap<String, PathBuf>,
+    #[getset(get, vis = "pub(super)")]
+    additional_package_manifests: IndexMap<String, AdditionalManifestInfo>,
+    #[getset(get, vis = "pub(super)")]
+    changelog_updates: Vec<ChangelogUpdate>,
 
-    pub classification: ReleaseClassification,
-    pub git_options: GitOptions,
+    pub(super) classification: ReleaseClassification,
+    pub(super) git_options: GitOptions,
 
-    pub prerelease_state_update: Option<PrereleaseStateUpdate>,
-    pub graduation_state_update: Option<GraduationStateUpdate>,
+    #[getset(get, vis = "pub(super)")]
+    prerelease_state_update: Option<PrereleaseStateUpdate>,
+    #[getset(get, vis = "pub(super)")]
+    graduation_state_update: Option<GraduationStateUpdate>,
 
-    pub changeset_files: Vec<ChangesetFileState>,
+    pub(super) changeset_files: Vec<ChangesetFileState>,
 
-    pub manifest_updates: Vec<ManifestUpdate>,
-    pub dependency_updates: Vec<DependencyUpdate>,
-    pub workspace_version_removed: bool,
-    pub original_workspace_version: Option<Version>,
+    pub(super) manifest_updates: Vec<ManifestUpdate>,
+    pub(super) dependency_updates: Vec<DependencyUpdate>,
+    pub(super) workspace_version_removed: bool,
+    pub(super) original_workspace_version: Option<Version>,
 
-    pub lockfile_backup: Option<Vec<u8>>,
-    pub lockfile_path: Option<PathBuf>,
+    pub(super) lockfile_backup: Option<Vec<u8>>,
+    pub(super) lockfile_path: Option<PathBuf>,
 
-    pub staged_files: Vec<PathBuf>,
-    pub files_were_staged: bool,
+    pub(super) staged_files: Vec<PathBuf>,
+    pub(super) files_were_staged: bool,
 
-    pub commit_result: Option<CommitResult>,
+    pub(super) commit_result: Option<CommitResult>,
 
-    pub tags_created: Vec<TagResult>,
+    pub(super) tags_created: Vec<TagResult>,
 
-    pub changesets_deleted: Vec<PathBuf>,
-    pub consumed_state: ChangesetConsumedState,
-    pub consumed_files_cleared: Vec<ChangesetFileState>,
+    pub(super) changesets_deleted: Vec<PathBuf>,
+    pub(super) consumed_state: ChangesetConsumedState,
+    pub(super) consumed_files_cleared: Vec<ChangesetFileState>,
 
-    pub changelog_backups: Vec<ChangelogFileState>,
-    pub changelogs_written: bool,
+    #[getset(get, vis = "pub(super)")]
+    changelog_backups: Vec<ChangelogFileState>,
+    changelogs_written: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -70,6 +99,8 @@ pub(super) struct ManifestUpdate {
     pub(super) old_version: Version,
     pub(super) new_version: Version,
     pub(super) written: bool,
+    #[allow(dead_code)]
+    pub(super) kind: ManifestKind,
 }
 
 #[derive(Debug, Clone)]
@@ -151,6 +182,14 @@ impl ReleaseSagaData {
                 new_state,
             });
         }
+        self
+    }
+
+    pub fn with_additional_packages(
+        mut self,
+        additional: IndexMap<String, AdditionalManifestInfo>,
+    ) -> Self {
+        self.additional_package_manifests = additional;
         self
     }
 

--- a/crates/changeset-operations/src/operations/release/saga_data.rs
+++ b/crates/changeset-operations/src/operations/release/saga_data.rs
@@ -18,16 +18,6 @@ pub struct SagaReleaseOptions {
 }
 
 #[derive(Debug, Clone)]
-pub(super) enum ManifestKind {
-    Cargo,
-    #[allow(dead_code)]
-    Additional {
-        format: ManifestFormat,
-        version_field_path: String,
-    },
-}
-
-#[derive(Debug, Clone)]
 pub(super) struct AdditionalManifestInfo {
     pub(super) manifest_path: PathBuf,
     pub(super) format: ManifestFormat,
@@ -102,8 +92,6 @@ pub(super) struct ManifestUpdate {
     pub(super) old_version: Version,
     pub(super) new_version: Version,
     pub(super) written: bool,
-    #[allow(dead_code)]
-    pub(super) kind: ManifestKind,
 }
 
 #[derive(Debug, Clone)]
@@ -128,7 +116,6 @@ pub(super) struct VersionTrackingWriteRecord {
     pub(super) format: ManifestFormat,
     pub(super) version_field_path: String,
     pub(super) old_value: String,
-    pub(super) new_version: Version,
     pub(super) written: bool,
 }
 

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -8,13 +8,16 @@ use semver::Version;
 use tracing::debug;
 
 use super::context::ReleaseSagaContext;
-use super::saga_data::{DependencyUpdate, ManifestKind, ManifestUpdate, ReleaseSagaData};
+use super::saga_data::{
+    DependencyUpdate, ManifestKind, ManifestUpdate, ReleaseSagaData, VersionTrackingWriteRecord,
+};
 use super::{CommitResult, TagResult};
 use crate::OperationError;
 use crate::traits::{
-    ChangelogWriter, ChangesetReader, ChangesetWriter, ExternalManifestVersionWriter,
-    GitCommitProvider, GitStagingProvider, GitTagProvider, LockfileUpdater,
-    ManifestDependencyWriter, ManifestVersionWriter, ReleaseStateIO, WorkspaceVersionManager,
+    ChangelogWriter, ChangesetReader, ChangesetWriter, ExternalManifestVersionReader,
+    ExternalManifestVersionWriter, GitCommitProvider, GitStagingProvider, GitTagProvider,
+    LockfileUpdater, ManifestDependencyWriter, ManifestVersionWriter, ReleaseStateIO,
+    WorkspaceVersionManager,
 };
 
 macro_rules! saga_step_struct {
@@ -273,6 +276,81 @@ where
 
     fn compensation_description(&self) -> String {
         "restore original dependency versions in Cargo.toml files".to_string()
+    }
+}
+
+saga_step_struct!(WriteVersionTrackingStep);
+
+impl<G, M, RW, S, C> SagaStep for WriteVersionTrackingStep<G, M, RW, S, C>
+where
+    G: Send + Sync,
+    M: ExternalManifestVersionWriter + ExternalManifestVersionReader,
+    RW: Send + Sync,
+    S: Send + Sync,
+    C: Send + Sync,
+{
+    type Input = ReleaseSagaData;
+    type Output = ReleaseSagaData;
+    type Context = ReleaseSagaContext<G, M, RW, S, C>;
+    type Error = OperationError;
+
+    fn name(&self) -> &'static str {
+        "write_version_tracking"
+    }
+
+    fn execute(
+        &self,
+        ctx: &Self::Context,
+        mut input: Self::Input,
+    ) -> Result<Self::Output, Self::Error> {
+        let mut records = Vec::new();
+        for write in &input.version_tracking_writes {
+            let old_value = ctx.manifest_writer().read_external_version(
+                &write.manifest_path,
+                write.format,
+                &write.version_field_path,
+            )?;
+            ctx.manifest_writer().write_external_version(
+                &write.manifest_path,
+                write.format,
+                &write.version_field_path,
+                &write.new_dependency_version,
+            )?;
+            ctx.manifest_writer().verify_external_version(
+                &write.manifest_path,
+                write.format,
+                &write.version_field_path,
+                &write.new_dependency_version,
+            )?;
+            records.push(VersionTrackingWriteRecord {
+                manifest_path: write.manifest_path.clone(),
+                format: write.format,
+                version_field_path: write.version_field_path.clone(),
+                old_value,
+                new_version: write.new_dependency_version.clone(),
+                written: true,
+            });
+        }
+        input.version_tracking_records = records;
+        Ok(input)
+    }
+
+    fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
+        for record in &input.version_tracking_records {
+            if record.written {
+                ctx.manifest_writer().restore_external_version(
+                    &record.manifest_path,
+                    record.format,
+                    &record.version_field_path,
+                    &record.old_value,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn compensation_description(&self) -> String {
+        "restore original version-tracking dependency versions".to_string()
     }
 }
 
@@ -625,6 +703,10 @@ where
 
         for update in &input.dependency_updates {
             files.push(update.manifest_path.clone());
+        }
+
+        for record in &input.version_tracking_records {
+            files.push(record.manifest_path.clone());
         }
 
         if !input.changesets_deleted.is_empty() {
@@ -2110,6 +2192,129 @@ mod tests {
                 .staged_files
                 .contains(&PathBuf::from("/mock/project/charts/my-chart/Chart.yaml")),
             "additional package manifest should be staged"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_writes_dependency_version() -> anyhow::Result<()> {
+        let tracking_manifest_path = PathBuf::from("/mock/project/charts/my-chart/Chart.yaml");
+        let manifest_writer = Arc::new(MockManifestWriter::new().with_external_version_to_read(
+            tracking_manifest_path.clone(),
+            changeset_core::ManifestFormat::Yaml,
+            "appVersion".to_string(),
+            "0.0.0".to_string(),
+        ));
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_writes = vec![super::super::saga_data::VersionTrackingWrite {
+            manifest_path: tracking_manifest_path,
+            format: changeset_core::ManifestFormat::Yaml,
+            version_field_path: "appVersion".to_string(),
+            new_dependency_version: "1.0.1".parse()?,
+        }];
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert_eq!(result.version_tracking_records.len(), 1);
+        assert_eq!(result.version_tracking_records[0].old_value, "0.0.0");
+        assert!(result.version_tracking_records[0].written);
+        assert_eq!(manifest_writer.external_written_versions().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_compensate_restores_old_version() -> anyhow::Result<()> {
+        let tracking_manifest_path = PathBuf::from("/mock/project/charts/my-chart/Chart.yaml");
+        let manifest_writer = Arc::new(MockManifestWriter::new().with_external_version_to_read(
+            tracking_manifest_path.clone(),
+            changeset_core::ManifestFormat::Yaml,
+            "appVersion".to_string(),
+            "0.5.0".to_string(),
+        ));
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_writes = vec![super::super::saga_data::VersionTrackingWrite {
+            manifest_path: tracking_manifest_path.clone(),
+            format: changeset_core::ManifestFormat::Yaml,
+            version_field_path: "appVersion".to_string(),
+            new_dependency_version: "1.0.1".parse()?,
+        }];
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+        assert_eq!(manifest_writer.external_written_versions().len(), 1);
+
+        SagaStep::compensate(&step, &ctx, result)?;
+
+        assert_eq!(manifest_writer.external_written_versions().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stage_files_includes_version_tracking_paths() -> anyhow::Result<()> {
+        let git_provider = Arc::new(MockGitProvider::new());
+        let ctx = make_test_context(
+            Arc::clone(&git_provider),
+            Arc::new(MockManifestWriter::new()),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: StageFilesStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = StageFilesStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_records =
+            vec![super::super::saga_data::VersionTrackingWriteRecord {
+                manifest_path: PathBuf::from("/mock/project/charts/dep/values.yaml"),
+                format: changeset_core::ManifestFormat::Yaml,
+                version_field_path: "appVersion".to_string(),
+                old_value: "0.0.0".to_string(),
+                new_version: "1.0.1".parse()?,
+                written: true,
+            }];
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert!(result.files_were_staged);
+        assert!(
+            result
+                .staged_files
+                .contains(&PathBuf::from("/mock/project/charts/dep/values.yaml")),
+            "version tracking manifest should be staged"
         );
 
         Ok(())

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::path::Path;
 
+use changeset_core::CARGO_MANIFEST_FILENAME;
 use changeset_project::TagFormat;
 use changeset_saga::SagaStep;
 use semver::Version;
@@ -67,7 +68,7 @@ where
 
         for release in &input.planned_releases {
             if let Some(pkg_path) = input.package_paths.get(release.name()) {
-                let manifest_path = pkg_path.join("Cargo.toml");
+                let manifest_path = pkg_path.join(CARGO_MANIFEST_FILENAME);
                 ctx.manifest_writer()
                     .write_version(&manifest_path, release.new_version())?;
                 ctx.manifest_writer()
@@ -101,7 +102,7 @@ where
         );
         for release in &input.planned_releases {
             if let Some(pkg_path) = input.package_paths.get(release.name()) {
-                let manifest_path = pkg_path.join("Cargo.toml");
+                let manifest_path = pkg_path.join(CARGO_MANIFEST_FILENAME);
                 ctx.manifest_writer()
                     .write_version(&manifest_path, release.current_version())?;
             }
@@ -143,7 +144,7 @@ where
         let mut manifest_paths: Vec<_> = input
             .package_paths
             .values()
-            .map(|p| p.join("Cargo.toml"))
+            .map(|p| p.join(CARGO_MANIFEST_FILENAME))
             .collect();
         manifest_paths.push(input.root_manifest_path.clone());
 
@@ -186,7 +187,7 @@ where
         let mut manifest_paths: Vec<_> = input
             .package_paths
             .values()
-            .map(|p| p.join("Cargo.toml"))
+            .map(|p| p.join(CARGO_MANIFEST_FILENAME))
             .collect();
         manifest_paths.push(input.root_manifest_path.clone());
 

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -405,20 +405,21 @@ where
         ctx: &Self::Context,
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if input.classification.is_prerelease_release && !input.changeset_files.is_empty() {
-            if let Some(first_release) = input.planned_releases().first() {
-                let paths_refs: Vec<&Path> = input
-                    .changeset_files
-                    .iter()
-                    .map(|f| f.path.as_path())
-                    .collect();
-                ctx.changeset_rw().mark_consumed_for_prerelease(
-                    input.changeset_dir(),
-                    &paths_refs,
-                    first_release.new_version(),
-                )?;
-                input.consumed_state = super::saga_data::ChangesetConsumedState::Consumed;
-            }
+        if input.classification.is_prerelease_release
+            && !input.changeset_files.is_empty()
+            && let Some(first_release) = input.planned_releases().first()
+        {
+            let paths_refs: Vec<&Path> = input
+                .changeset_files
+                .iter()
+                .map(|f| f.path.as_path())
+                .collect();
+            ctx.changeset_rw().mark_consumed_for_prerelease(
+                input.changeset_dir(),
+                &paths_refs,
+                first_release.new_version(),
+            )?;
+            input.consumed_state = super::saga_data::ChangesetConsumedState::Consumed;
         }
         Ok(input)
     }
@@ -906,18 +907,18 @@ where
     }
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
-        if let Some(update) = input.prerelease_state_update() {
-            if let Some(original) = &update.original {
-                ctx.release_state_io()
-                    .save_prerelease_state(input.changeset_dir(), original)?;
-            }
+        if let Some(update) = input.prerelease_state_update()
+            && let Some(original) = &update.original
+        {
+            ctx.release_state_io()
+                .save_prerelease_state(input.changeset_dir(), original)?;
         }
 
-        if let Some(update) = input.graduation_state_update() {
-            if let Some(original) = &update.original {
-                ctx.release_state_io()
-                    .save_graduation_state(input.changeset_dir(), original)?;
-            }
+        if let Some(update) = input.graduation_state_update()
+            && let Some(original) = &update.original
+        {
+            ctx.release_state_io()
+                .save_graduation_state(input.changeset_dir(), original)?;
         }
 
         Ok(())

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -71,18 +71,18 @@ where
             {
                 let manifest_path = &additional_info.manifest_path;
                 let format = additional_info.format;
-                let version_path = &additional_info.version_path;
+                let version_field_path = &additional_info.version_field_path;
 
                 ctx.manifest_writer().write_external_version(
                     manifest_path,
                     format,
-                    version_path,
+                    version_field_path,
                     release.new_version(),
                 )?;
                 ctx.manifest_writer().verify_external_version(
                     manifest_path,
                     format,
-                    version_path,
+                    version_field_path,
                     release.new_version(),
                 )?;
 
@@ -93,7 +93,7 @@ where
                     written: true,
                     kind: ManifestKind::Additional {
                         format,
-                        version_path: version_path.clone(),
+                        version_field_path: version_field_path.clone(),
                     },
                 };
                 debug!(
@@ -144,7 +144,7 @@ where
                 ctx.manifest_writer().write_external_version(
                     &additional_info.manifest_path,
                     additional_info.format,
-                    &additional_info.version_path,
+                    &additional_info.version_field_path,
                     release.current_version(),
                 )?;
             } else if let Some(pkg_path) = input.package_paths().get(release.name()) {
@@ -1777,12 +1777,12 @@ mod tests {
     fn make_additional_manifest_info(
         manifest_path: &str,
         format: changeset_core::ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
     ) -> AdditionalManifestInfo {
         AdditionalManifestInfo {
             manifest_path: PathBuf::from(manifest_path),
             format,
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         }
     }
 
@@ -2098,7 +2098,7 @@ mod tests {
             written: true,
             kind: ManifestKind::Additional {
                 format: changeset_core::ManifestFormat::Yaml,
-                version_path: "version".to_string(),
+                version_field_path: "version".to_string(),
             },
         });
 

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use super::context::ReleaseSagaContext;
 use super::saga_data::{
-    DependencyUpdate, ManifestKind, ManifestUpdate, ReleaseSagaData, VersionTrackingWriteRecord,
+    DependencyUpdate, ManifestUpdate, ReleaseSagaData, VersionTrackingWriteRecord,
 };
 use super::{CommitResult, TagResult};
 use crate::OperationError;
@@ -94,10 +94,6 @@ where
                     old_version: release.current_version().clone(),
                     new_version: release.new_version().clone(),
                     written: true,
-                    kind: ManifestKind::Additional {
-                        format,
-                        version_field_path: version_field_path.clone(),
-                    },
                 };
                 debug!(
                     manifest = %update.manifest_path.display(),
@@ -119,7 +115,6 @@ where
                     old_version: release.current_version().clone(),
                     new_version: release.new_version().clone(),
                     written: true,
-                    kind: ManifestKind::Cargo,
                 };
                 debug!(
                     manifest = %update.manifest_path.display(),
@@ -144,11 +139,11 @@ where
         for release in input.planned_releases() {
             if let Some(additional_info) = input.additional_package_manifests().get(release.name())
             {
-                ctx.manifest_writer().write_external_version(
+                ctx.manifest_writer().restore_external_version(
                     &additional_info.manifest_path,
                     additional_info.format,
                     &additional_info.version_field_path,
-                    release.current_version(),
+                    &release.current_version().to_string(),
                 )?;
             } else if let Some(pkg_path) = input.package_paths().get(release.name()) {
                 let manifest_path = pkg_path.join(CARGO_MANIFEST_FILENAME);
@@ -327,7 +322,6 @@ where
                 format: write.format,
                 version_field_path: write.version_field_path.clone(),
                 old_value,
-                new_version: write.new_dependency_version.clone(),
                 written: true,
             });
         }
@@ -1071,9 +1065,7 @@ mod tests {
         MockChangelogWriter, MockChangesetReader, MockGitProvider, MockManifestWriter,
         MockReleaseStateIO,
     };
-    use crate::operations::release::saga_data::{
-        AdditionalManifestInfo, ManifestKind, SagaReleaseOptions,
-    };
+    use crate::operations::release::saga_data::{AdditionalManifestInfo, SagaReleaseOptions};
     use crate::operations::release::types::{GitOptions, ReleaseClassification};
     use crate::types::PackageVersion;
 
@@ -1191,7 +1183,6 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
-            kind: ManifestKind::Cargo,
         });
 
         SagaStep::compensate(&step, &ctx, input)?;
@@ -1341,7 +1332,6 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
-            kind: ManifestKind::Cargo,
         });
         input.dependency_updates.push(DependencyUpdate {
             manifest_path: shared_path.clone(),
@@ -1385,7 +1375,6 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
-            kind: ManifestKind::Cargo,
         });
 
         let result = SagaStep::execute(&step, &ctx, input)?;
@@ -1981,12 +1970,11 @@ mod tests {
             manifest_writer.written_versions().is_empty(),
             "Cargo write_version should not be called during compensate for additional packages"
         );
-        let external = manifest_writer.external_written_versions();
-        assert_eq!(external.len(), 1);
+        let restores = manifest_writer.restore_calls();
+        assert_eq!(restores.len(), 1);
         assert_eq!(
-            external[0].version.to_string(),
-            "1.0.0",
-            "compensate should restore old version via external writer"
+            restores[0].version_str, "1.0.0",
+            "compensate should restore old version via restore_external_version"
         );
 
         Ok(())
@@ -2132,22 +2120,20 @@ mod tests {
 
         assert_eq!(result.manifest_updates.len(), 2);
 
-        let cargo_update = result
-            .manifest_updates
-            .iter()
-            .find(|u| u.manifest_path.ends_with("Cargo.toml"))
-            .expect("should have a Cargo manifest update");
-        assert!(matches!(cargo_update.kind, ManifestKind::Cargo));
-
-        let external_update = result
-            .manifest_updates
-            .iter()
-            .find(|u| u.manifest_path.ends_with("Chart.yaml"))
-            .expect("should have an external manifest update");
-        assert!(matches!(
-            external_update.kind,
-            ManifestKind::Additional { .. }
-        ));
+        assert!(
+            result
+                .manifest_updates
+                .iter()
+                .any(|u| u.manifest_path.ends_with("Cargo.toml")),
+            "should have a Cargo manifest update"
+        );
+        assert!(
+            result
+                .manifest_updates
+                .iter()
+                .any(|u| u.manifest_path.ends_with("Chart.yaml")),
+            "should have an external manifest update"
+        );
 
         assert_eq!(manifest_writer.written_versions().len(), 1);
         assert_eq!(manifest_writer.external_written_versions().len(), 1);
@@ -2178,10 +2164,6 @@ mod tests {
             old_version: "2.0.0".parse()?,
             new_version: "2.0.1".parse()?,
             written: true,
-            kind: ManifestKind::Additional {
-                format: changeset_core::ManifestFormat::Yaml,
-                version_field_path: "version".to_string(),
-            },
         });
 
         let result = SagaStep::execute(&step, &ctx, input)?;
@@ -2303,7 +2285,6 @@ mod tests {
                 format: changeset_core::ManifestFormat::Yaml,
                 version_field_path: "appVersion".to_string(),
                 old_value: "0.0.0".to_string(),
-                new_version: "1.0.1".parse()?,
                 written: true,
             }];
 
@@ -2315,6 +2296,190 @@ mod tests {
                 .staged_files
                 .contains(&PathBuf::from("/mock/project/charts/dep/values.yaml")),
             "version tracking manifest should be staged"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_step_writes_dependency_version() -> anyhow::Result<()> {
+        let tracking_path = PathBuf::from("/mock/project/charts/dep/Chart.yaml");
+        let manifest_writer = Arc::new(MockManifestWriter::new().with_external_version_to_read(
+            tracking_path.clone(),
+            changeset_core::ManifestFormat::Yaml,
+            "appVersion".to_string(),
+            "0.9.0".to_string(),
+        ));
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_writes = vec![super::super::saga_data::VersionTrackingWrite {
+            manifest_path: tracking_path,
+            format: changeset_core::ManifestFormat::Yaml,
+            version_field_path: "appVersion".to_string(),
+            new_dependency_version: "1.0.1".parse()?,
+        }];
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert_eq!(result.version_tracking_records.len(), 1);
+        assert!(result.version_tracking_records[0].written);
+        assert_eq!(result.version_tracking_records[0].old_value, "0.9.0");
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_step_skips_empty_writes() -> anyhow::Result<()> {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let input = make_test_data();
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert!(result.version_tracking_records.is_empty());
+        assert!(manifest_writer.external_written_versions().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_step_compensate_restores_written_records() -> anyhow::Result<()> {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_records =
+            vec![super::super::saga_data::VersionTrackingWriteRecord {
+                manifest_path: PathBuf::from("/mock/project/charts/dep/Chart.yaml"),
+                format: changeset_core::ManifestFormat::Yaml,
+                version_field_path: "appVersion".to_string(),
+                old_value: "0.9.0".to_string(),
+                written: true,
+            }];
+
+        SagaStep::compensate(&step, &ctx, input)?;
+
+        let restores = manifest_writer.restore_calls();
+        assert_eq!(restores.len(), 1);
+        assert_eq!(restores[0].version_str, "0.9.0");
+        assert_eq!(
+            restores[0].manifest_path,
+            PathBuf::from("/mock/project/charts/dep/Chart.yaml")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_version_tracking_step_compensate_skips_unwritten_records() -> anyhow::Result<()> {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteVersionTrackingStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteVersionTrackingStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_records =
+            vec![super::super::saga_data::VersionTrackingWriteRecord {
+                manifest_path: PathBuf::from("/mock/project/charts/dep/Chart.yaml"),
+                format: changeset_core::ManifestFormat::Yaml,
+                version_field_path: "appVersion".to_string(),
+                old_value: "0.9.0".to_string(),
+                written: false,
+            }];
+
+        SagaStep::compensate(&step, &ctx, input)?;
+
+        assert!(
+            manifest_writer.restore_calls().is_empty(),
+            "restore_external_version should not be called for unwritten records"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn stage_files_step_includes_version_tracking_manifest_paths() -> anyhow::Result<()> {
+        let git_provider = Arc::new(MockGitProvider::new());
+        let ctx = make_test_context(
+            Arc::clone(&git_provider),
+            Arc::new(MockManifestWriter::new()),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: StageFilesStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = StageFilesStep::new();
+        let mut input = make_test_data();
+        input.version_tracking_records =
+            vec![super::super::saga_data::VersionTrackingWriteRecord {
+                manifest_path: PathBuf::from("/mock/project/charts/tracked/values.yaml"),
+                format: changeset_core::ManifestFormat::Yaml,
+                version_field_path: "appVersion".to_string(),
+                old_value: "0.0.0".to_string(),
+                written: true,
+            }];
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert!(result.files_were_staged);
+        assert!(
+            result
+                .staged_files
+                .contains(&PathBuf::from("/mock/project/charts/tracked/values.yaml")),
+            "version-tracking manifest path should be staged"
         );
 
         Ok(())

--- a/crates/changeset-operations/src/operations/release/saga_steps.rs
+++ b/crates/changeset-operations/src/operations/release/saga_steps.rs
@@ -8,13 +8,13 @@ use semver::Version;
 use tracing::debug;
 
 use super::context::ReleaseSagaContext;
-use super::saga_data::{DependencyUpdate, ManifestUpdate, ReleaseSagaData};
+use super::saga_data::{DependencyUpdate, ManifestKind, ManifestUpdate, ReleaseSagaData};
 use super::{CommitResult, TagResult};
 use crate::OperationError;
 use crate::traits::{
-    ChangelogWriter, ChangesetReader, ChangesetWriter, GitCommitProvider, GitStagingProvider,
-    GitTagProvider, LockfileUpdater, ManifestDependencyWriter, ManifestVersionWriter,
-    ReleaseStateIO, WorkspaceVersionManager,
+    ChangelogWriter, ChangesetReader, ChangesetWriter, ExternalManifestVersionWriter,
+    GitCommitProvider, GitStagingProvider, GitTagProvider, LockfileUpdater,
+    ManifestDependencyWriter, ManifestVersionWriter, ReleaseStateIO, WorkspaceVersionManager,
 };
 
 macro_rules! saga_step_struct {
@@ -45,7 +45,7 @@ saga_step_struct!(WriteManifestVersionsStep);
 impl<G, M, RW, S, C> SagaStep for WriteManifestVersionsStep<G, M, RW, S, C>
 where
     G: Send + Sync,
-    M: ManifestVersionWriter,
+    M: ManifestVersionWriter + ExternalManifestVersionWriter,
     RW: Send + Sync,
     S: Send + Sync,
     C: Send + Sync,
@@ -66,8 +66,45 @@ where
     ) -> Result<Self::Output, Self::Error> {
         let mut manifest_updates = Vec::new();
 
-        for release in &input.planned_releases {
-            if let Some(pkg_path) = input.package_paths.get(release.name()) {
+        for release in input.planned_releases() {
+            if let Some(additional_info) = input.additional_package_manifests().get(release.name())
+            {
+                let manifest_path = &additional_info.manifest_path;
+                let format = additional_info.format;
+                let version_path = &additional_info.version_path;
+
+                ctx.manifest_writer().write_external_version(
+                    manifest_path,
+                    format,
+                    version_path,
+                    release.new_version(),
+                )?;
+                ctx.manifest_writer().verify_external_version(
+                    manifest_path,
+                    format,
+                    version_path,
+                    release.new_version(),
+                )?;
+
+                let update = ManifestUpdate {
+                    manifest_path: manifest_path.clone(),
+                    old_version: release.current_version().clone(),
+                    new_version: release.new_version().clone(),
+                    written: true,
+                    kind: ManifestKind::Additional {
+                        format,
+                        version_path: version_path.clone(),
+                    },
+                };
+                debug!(
+                    manifest = %update.manifest_path.display(),
+                    old = %update.old_version,
+                    new = %update.new_version,
+                    written = update.written,
+                    "updated external manifest version"
+                );
+                manifest_updates.push(update);
+            } else if let Some(pkg_path) = input.package_paths().get(release.name()) {
                 let manifest_path = pkg_path.join(CARGO_MANIFEST_FILENAME);
                 ctx.manifest_writer()
                     .write_version(&manifest_path, release.new_version())?;
@@ -79,6 +116,7 @@ where
                     old_version: release.current_version().clone(),
                     new_version: release.new_version().clone(),
                     written: true,
+                    kind: ManifestKind::Cargo,
                 };
                 debug!(
                     manifest = %update.manifest_path.display(),
@@ -100,8 +138,16 @@ where
             count = input.manifest_updates.len(),
             "rolling back manifest version updates"
         );
-        for release in &input.planned_releases {
-            if let Some(pkg_path) = input.package_paths.get(release.name()) {
+        for release in input.planned_releases() {
+            if let Some(additional_info) = input.additional_package_manifests().get(release.name())
+            {
+                ctx.manifest_writer().write_external_version(
+                    &additional_info.manifest_path,
+                    additional_info.format,
+                    &additional_info.version_path,
+                    release.current_version(),
+                )?;
+            } else if let Some(pkg_path) = input.package_paths().get(release.name()) {
                 let manifest_path = pkg_path.join(CARGO_MANIFEST_FILENAME);
                 ctx.manifest_writer()
                     .write_version(&manifest_path, release.current_version())?;
@@ -111,7 +157,7 @@ where
     }
 
     fn compensation_description(&self) -> String {
-        "restore original package versions in Cargo.toml files".to_string()
+        "restore original package versions in manifest files".to_string()
     }
 }
 
@@ -142,13 +188,24 @@ where
         let mut dependency_updates = Vec::new();
 
         let mut manifest_paths: Vec<_> = input
-            .package_paths
-            .values()
-            .map(|p| p.join(CARGO_MANIFEST_FILENAME))
+            .package_paths()
+            .iter()
+            .filter(|(name, _)| {
+                !input
+                    .additional_package_manifests()
+                    .contains_key(name.as_str())
+            })
+            .map(|(_, p)| p.join(CARGO_MANIFEST_FILENAME))
             .collect();
-        manifest_paths.push(input.root_manifest_path.clone());
+        manifest_paths.push(input.root_manifest_path().clone());
 
-        for release in &input.planned_releases {
+        let cargo_releases: Vec<_> = input
+            .planned_releases()
+            .iter()
+            .filter(|r| !input.additional_package_manifests().contains_key(r.name()))
+            .collect();
+
+        for release in &cargo_releases {
             for manifest_path in &manifest_paths {
                 let updated = ctx.manifest_writer().update_dependency_version(
                     manifest_path,
@@ -185,13 +242,24 @@ where
             "rolling back dependency version updates"
         );
         let mut manifest_paths: Vec<_> = input
-            .package_paths
-            .values()
-            .map(|p| p.join(CARGO_MANIFEST_FILENAME))
+            .package_paths()
+            .iter()
+            .filter(|(name, _)| {
+                !input
+                    .additional_package_manifests()
+                    .contains_key(name.as_str())
+            })
+            .map(|(_, p)| p.join(CARGO_MANIFEST_FILENAME))
             .collect();
-        manifest_paths.push(input.root_manifest_path.clone());
+        manifest_paths.push(input.root_manifest_path().clone());
 
-        for release in &input.planned_releases {
+        let cargo_releases: Vec<_> = input
+            .planned_releases()
+            .iter()
+            .filter(|r| !input.additional_package_manifests().contains_key(r.name()))
+            .collect();
+
+        for release in &cargo_releases {
             for manifest_path in &manifest_paths {
                 ctx.manifest_writer().update_dependency_version(
                     manifest_path,
@@ -235,9 +303,9 @@ where
         if !input.inherited_packages.is_empty() {
             input.original_workspace_version = ctx
                 .manifest_writer()
-                .read_workspace_version(&input.root_manifest_path)?;
+                .read_workspace_version(input.root_manifest_path())?;
             ctx.manifest_writer()
-                .remove_workspace_version(&input.root_manifest_path)?;
+                .remove_workspace_version(input.root_manifest_path())?;
             input.workspace_version_removed = true;
         }
         Ok(input)
@@ -247,10 +315,10 @@ where
         if !input.inherited_packages.is_empty() {
             if let Some(version) = &input.original_workspace_version {
                 ctx.manifest_writer()
-                    .write_workspace_version(&input.root_manifest_path, version)?;
-            } else if let Some(release) = input.planned_releases.first() {
+                    .write_workspace_version(input.root_manifest_path(), version)?;
+            } else if let Some(release) = input.planned_releases().first() {
                 ctx.manifest_writer().write_workspace_version(
-                    &input.root_manifest_path,
+                    input.root_manifest_path(),
                     release.current_version(),
                 )?;
             }
@@ -338,14 +406,14 @@ where
         mut input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
         if input.classification.is_prerelease_release && !input.changeset_files.is_empty() {
-            if let Some(first_release) = input.planned_releases.first() {
+            if let Some(first_release) = input.planned_releases().first() {
                 let paths_refs: Vec<&Path> = input
                     .changeset_files
                     .iter()
                     .map(|f| f.path.as_path())
                     .collect();
                 ctx.changeset_rw().mark_consumed_for_prerelease(
-                    &input.changeset_dir,
+                    input.changeset_dir(),
                     &paths_refs,
                     first_release.new_version(),
                 )?;
@@ -369,7 +437,7 @@ where
 
             if !files_to_clear.is_empty() {
                 ctx.changeset_rw()
-                    .clear_consumed_for_prerelease(&input.changeset_dir, &files_to_clear)?;
+                    .clear_consumed_for_prerelease(input.changeset_dir(), &files_to_clear)?;
             }
         }
         Ok(())
@@ -407,7 +475,7 @@ where
         if input.classification.is_graduating {
             let consumed_paths = ctx
                 .changeset_rw()
-                .list_consumed_changesets(&input.changeset_dir)?;
+                .list_consumed_changesets(input.changeset_dir())?;
 
             if !consumed_paths.is_empty() {
                 let mut consumed_files = Vec::new();
@@ -422,7 +490,7 @@ where
 
                 let paths_refs: Vec<&Path> = consumed_paths.iter().map(AsRef::as_ref).collect();
                 ctx.changeset_rw()
-                    .clear_consumed_for_prerelease(&input.changeset_dir, &paths_refs)?;
+                    .clear_consumed_for_prerelease(input.changeset_dir(), &paths_refs)?;
                 input.consumed_state = super::saga_data::ChangesetConsumedState::Cleared;
                 input.consumed_files_cleared = consumed_files;
             }
@@ -433,18 +501,10 @@ where
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
         for file_state in &input.consumed_files_cleared {
             if let Some(original_version) = &file_state.original_consumed_status {
-                let version: Version =
-                    original_version
-                        .parse()
-                        .map_err(|source| OperationError::VersionParse {
-                            version: original_version.clone(),
-                            context: "compensation restore consumed status".to_string(),
-                            source,
-                        })?;
-                ctx.changeset_rw().mark_consumed_for_prerelease(
-                    &input.changeset_dir,
+                ctx.changeset_rw().restore_consumed_for_prerelease(
+                    input.changeset_dir(),
                     &[file_state.path.as_path()],
-                    &version,
+                    original_version,
                 )?;
             }
         }
@@ -555,10 +615,10 @@ where
         }
 
         if input.workspace_version_removed {
-            files.push(input.root_manifest_path.clone());
+            files.push(input.root_manifest_path().clone());
         }
 
-        for update in &input.changelog_updates {
+        for update in input.changelog_updates() {
             files.push(update.path().clone());
         }
 
@@ -670,7 +730,7 @@ where
             return Ok(input);
         }
 
-        let message = self.build_commit_message(&input.planned_releases);
+        let message = self.build_commit_message(input.planned_releases());
         let commit_info = ctx.git_provider().commit(ctx.project_root(), &message)?;
 
         input.commit_result = Some(CommitResult::new(
@@ -748,7 +808,7 @@ where
         let mut tags = Vec::new();
         let mut created_tag_names: Vec<String> = Vec::new();
 
-        for release in &input.planned_releases {
+        for release in input.planned_releases() {
             let tag_name = self.format_tag_name(release.name(), release.new_version());
 
             let tag_message = format!("Release {} v{}", release.name(), release.new_version());
@@ -785,7 +845,7 @@ where
         }
 
         let mut failed_tags = Vec::new();
-        for release in &input.planned_releases {
+        for release in input.planned_releases() {
             let tag_name = self.format_tag_name(release.name(), release.new_version());
             if ctx
                 .git_provider()
@@ -832,31 +892,31 @@ where
         ctx: &Self::Context,
         input: Self::Input,
     ) -> Result<Self::Output, Self::Error> {
-        if let Some(update) = &input.prerelease_state_update {
+        if let Some(update) = input.prerelease_state_update() {
             ctx.release_state_io()
-                .save_prerelease_state(&input.changeset_dir, &update.new_state)?;
+                .save_prerelease_state(input.changeset_dir(), &update.new_state)?;
         }
 
-        if let Some(update) = &input.graduation_state_update {
+        if let Some(update) = input.graduation_state_update() {
             ctx.release_state_io()
-                .save_graduation_state(&input.changeset_dir, &update.new_state)?;
+                .save_graduation_state(input.changeset_dir(), &update.new_state)?;
         }
 
         Ok(input)
     }
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
-        if let Some(update) = &input.prerelease_state_update {
+        if let Some(update) = input.prerelease_state_update() {
             if let Some(original) = &update.original {
                 ctx.release_state_io()
-                    .save_prerelease_state(&input.changeset_dir, original)?;
+                    .save_prerelease_state(input.changeset_dir(), original)?;
             }
         }
 
-        if let Some(update) = &input.graduation_state_update {
+        if let Some(update) = input.graduation_state_update() {
             if let Some(original) = &update.original {
                 ctx.release_state_io()
-                    .save_graduation_state(&input.changeset_dir, original)?;
+                    .save_graduation_state(input.changeset_dir(), original)?;
             }
         }
 
@@ -896,7 +956,7 @@ where
     }
 
     fn compensate(&self, ctx: &Self::Context, input: Self::Input) -> Result<(), Self::Error> {
-        for backup in &input.changelog_backups {
+        for backup in input.changelog_backups() {
             if backup.file_existed {
                 if let Some(content) = &backup.original_content {
                     ctx.changelog_writer()
@@ -928,7 +988,9 @@ mod tests {
         MockChangelogWriter, MockChangesetReader, MockGitProvider, MockManifestWriter,
         MockReleaseStateIO,
     };
-    use crate::operations::release::saga_data::SagaReleaseOptions;
+    use crate::operations::release::saga_data::{
+        AdditionalManifestInfo, ManifestKind, SagaReleaseOptions,
+    };
     use crate::operations::release::types::{GitOptions, ReleaseClassification};
     use crate::types::PackageVersion;
 
@@ -1046,6 +1108,7 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
+            kind: ManifestKind::Cargo,
         });
 
         SagaStep::compensate(&step, &ctx, input)?;
@@ -1195,6 +1258,7 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
+            kind: ManifestKind::Cargo,
         });
         input.dependency_updates.push(DependencyUpdate {
             manifest_path: shared_path.clone(),
@@ -1238,6 +1302,7 @@ mod tests {
             old_version: "1.0.0".parse()?,
             new_version: "1.0.1".parse()?,
             written: true,
+            kind: ManifestKind::Cargo,
         });
 
         let result = SagaStep::execute(&step, &ctx, input)?;
@@ -1708,6 +1773,347 @@ mod tests {
         );
     }
 
+    fn make_additional_manifest_info(
+        manifest_path: &str,
+        format: changeset_core::ManifestFormat,
+        version_path: &str,
+    ) -> AdditionalManifestInfo {
+        AdditionalManifestInfo {
+            manifest_path: PathBuf::from(manifest_path),
+            format,
+            version_path: version_path.to_string(),
+        }
+    }
+
+    #[test]
+    fn write_manifest_versions_uses_external_writer_for_additional_packages() -> anyhow::Result<()>
+    {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteManifestVersionsStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteManifestVersionsStep::new();
+
+        let mut additional = IndexMap::new();
+        additional.insert(
+            "my-chart".to_string(),
+            make_additional_manifest_info(
+                "/mock/project/charts/my-chart/Chart.yaml",
+                changeset_core::ManifestFormat::Yaml,
+                "version",
+            ),
+        );
+
+        let mut package_paths = IndexMap::new();
+        package_paths.insert(
+            "my-chart".to_string(),
+            PathBuf::from("/mock/project/charts/my-chart"),
+        );
+
+        let input = ReleaseSagaData::new(
+            PathBuf::from("/mock/project/.changeset"),
+            PathBuf::from("/mock/project/Cargo.toml"),
+            vec![make_test_release("my-chart", "1.0.0", "1.0.1")],
+            package_paths,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_additional_packages(additional);
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert_eq!(result.manifest_updates.len(), 1);
+        assert!(result.manifest_updates[0].written);
+        assert!(
+            manifest_writer.written_versions().is_empty(),
+            "Cargo write_version should not be called for additional packages"
+        );
+        assert_eq!(
+            manifest_writer.external_written_versions().len(),
+            1,
+            "external writer should be called for additional packages"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_manifest_versions_compensate_uses_external_writer_for_additional() -> anyhow::Result<()>
+    {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteManifestVersionsStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteManifestVersionsStep::new();
+
+        let mut additional = IndexMap::new();
+        additional.insert(
+            "my-chart".to_string(),
+            make_additional_manifest_info(
+                "/mock/project/charts/my-chart/Chart.yaml",
+                changeset_core::ManifestFormat::Yaml,
+                "version",
+            ),
+        );
+
+        let mut package_paths = IndexMap::new();
+        package_paths.insert(
+            "my-chart".to_string(),
+            PathBuf::from("/mock/project/charts/my-chart"),
+        );
+
+        let input = ReleaseSagaData::new(
+            PathBuf::from("/mock/project/.changeset"),
+            PathBuf::from("/mock/project/Cargo.toml"),
+            vec![make_test_release("my-chart", "1.0.0", "1.0.1")],
+            package_paths,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_additional_packages(additional);
+
+        SagaStep::compensate(&step, &ctx, input)?;
+
+        assert!(
+            manifest_writer.written_versions().is_empty(),
+            "Cargo write_version should not be called during compensate for additional packages"
+        );
+        let external = manifest_writer.external_written_versions();
+        assert_eq!(external.len(), 1);
+        assert_eq!(
+            external[0].version.to_string(),
+            "1.0.0",
+            "compensate should restore old version via external writer"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_dependency_versions_skips_additional_packages() -> anyhow::Result<()> {
+        let manifest_writer =
+            Arc::new(MockManifestWriter::new().with_dependency_updates_returning_true());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: UpdateDependencyVersionsStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = UpdateDependencyVersionsStep::new();
+
+        let mut additional = IndexMap::new();
+        additional.insert(
+            "my-chart".to_string(),
+            make_additional_manifest_info(
+                "/mock/project/charts/my-chart/Chart.yaml",
+                changeset_core::ManifestFormat::Yaml,
+                "version",
+            ),
+        );
+
+        let mut package_paths = IndexMap::new();
+        package_paths.insert(
+            "pkg-a".to_string(),
+            PathBuf::from("/mock/project/crates/pkg-a"),
+        );
+        package_paths.insert(
+            "my-chart".to_string(),
+            PathBuf::from("/mock/project/charts/my-chart"),
+        );
+
+        let input = ReleaseSagaData::new(
+            PathBuf::from("/mock/project/.changeset"),
+            PathBuf::from("/mock/project/Cargo.toml"),
+            vec![
+                make_test_release("pkg-a", "1.0.0", "1.0.1"),
+                make_test_release("my-chart", "2.0.0", "2.0.1"),
+            ],
+            package_paths,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_additional_packages(additional);
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        let dep_names: Vec<_> = result
+            .dependency_updates
+            .iter()
+            .map(|d| d.dependency_name.as_str())
+            .collect();
+        assert!(
+            !dep_names.contains(&"my-chart"),
+            "additional packages should not appear in dependency updates"
+        );
+
+        let update_calls = manifest_writer.dependency_version_updates();
+        let chart_calls: Vec<_> = update_calls
+            .iter()
+            .filter(|(_, name, _)| name == "my-chart")
+            .collect();
+        assert!(
+            chart_calls.is_empty(),
+            "update_dependency_version should not be called for additional packages"
+        );
+
+        let manifest_paths: Vec<_> = update_calls.iter().map(|(p, _, _)| p.clone()).collect();
+        let chart_manifest =
+            PathBuf::from("/mock/project/charts/my-chart").join(CARGO_MANIFEST_FILENAME);
+        assert!(
+            !manifest_paths.contains(&chart_manifest),
+            "additional package manifest path should not be in scanned manifests"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn mixed_cargo_and_additional_packages_write_correct_manifests() -> anyhow::Result<()> {
+        let manifest_writer = Arc::new(MockManifestWriter::new());
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::clone(&manifest_writer),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: WriteManifestVersionsStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = WriteManifestVersionsStep::new();
+
+        let mut additional = IndexMap::new();
+        additional.insert(
+            "my-chart".to_string(),
+            make_additional_manifest_info(
+                "/mock/project/charts/my-chart/Chart.yaml",
+                changeset_core::ManifestFormat::Yaml,
+                "version",
+            ),
+        );
+
+        let mut package_paths = IndexMap::new();
+        package_paths.insert(
+            "pkg-a".to_string(),
+            PathBuf::from("/mock/project/crates/pkg-a"),
+        );
+        package_paths.insert(
+            "my-chart".to_string(),
+            PathBuf::from("/mock/project/charts/my-chart"),
+        );
+
+        let input = ReleaseSagaData::new(
+            PathBuf::from("/mock/project/.changeset"),
+            PathBuf::from("/mock/project/Cargo.toml"),
+            vec![
+                make_test_release("pkg-a", "1.0.0", "1.0.1"),
+                make_test_release("my-chart", "2.0.0", "2.0.1"),
+            ],
+            package_paths,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_additional_packages(additional);
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert_eq!(result.manifest_updates.len(), 2);
+
+        let cargo_update = result
+            .manifest_updates
+            .iter()
+            .find(|u| u.manifest_path.ends_with("Cargo.toml"))
+            .expect("should have a Cargo manifest update");
+        assert!(matches!(cargo_update.kind, ManifestKind::Cargo));
+
+        let external_update = result
+            .manifest_updates
+            .iter()
+            .find(|u| u.manifest_path.ends_with("Chart.yaml"))
+            .expect("should have an external manifest update");
+        assert!(matches!(
+            external_update.kind,
+            ManifestKind::Additional { .. }
+        ));
+
+        assert_eq!(manifest_writer.written_versions().len(), 1);
+        assert_eq!(manifest_writer.external_written_versions().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stage_files_includes_additional_package_manifests() -> anyhow::Result<()> {
+        let git_provider = Arc::new(MockGitProvider::new());
+        let ctx = make_test_context(
+            Arc::clone(&git_provider),
+            Arc::new(MockManifestWriter::new()),
+            Arc::new(MockChangesetReader::new()),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: StageFilesStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = StageFilesStep::new();
+        let mut input = make_test_data();
+        input.manifest_updates.push(ManifestUpdate {
+            manifest_path: PathBuf::from("/mock/project/charts/my-chart/Chart.yaml"),
+            old_version: "2.0.0".parse()?,
+            new_version: "2.0.1".parse()?,
+            written: true,
+            kind: ManifestKind::Additional {
+                format: changeset_core::ManifestFormat::Yaml,
+                version_path: "version".to_string(),
+            },
+        });
+
+        let result = SagaStep::execute(&step, &ctx, input)?;
+
+        assert!(result.files_were_staged);
+        assert!(
+            result
+                .staged_files
+                .contains(&PathBuf::from("/mock/project/charts/my-chart/Chart.yaml")),
+            "additional package manifest should be staged"
+        );
+
+        Ok(())
+    }
+
     #[allow(clippy::items_after_statements)]
     mod rollback_integration {
         use changeset_core::{ChangeCategory, Changeset, PackageRelease};
@@ -2132,5 +2538,95 @@ mod tests {
                 "consumed status should be cleared after rollback (was not consumed before)"
             );
         }
+    }
+
+    #[test]
+    fn clear_changesets_consumed_compensate_restores_consumed_status() -> anyhow::Result<()> {
+        let changeset_path = PathBuf::from(".changeset/some-changeset.md");
+        let changeset = changeset_core::Changeset::new(
+            "test change".to_string(),
+            vec![],
+            changeset_core::ChangeCategory::Fixed,
+        );
+        let changeset_rw = Arc::new(MockChangesetReader::new().with_consumed_changeset(
+            changeset_path.clone(),
+            changeset,
+            "1.0.0-alpha.1".to_string(),
+        ));
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::new(MockManifestWriter::new()),
+            Arc::clone(&changeset_rw),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: ClearChangesetsConsumedStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = ClearChangesetsConsumedStep::new();
+        let mut input = make_test_data();
+        input.consumed_files_cleared =
+            vec![crate::operations::release::types::ChangesetFileState {
+                path: changeset_path.clone(),
+                original_consumed_status: Some("1.0.0-alpha.1".to_string()),
+                backup: None,
+            }];
+
+        SagaStep::compensate(&step, &ctx, input)?;
+
+        assert_eq!(
+            changeset_rw.get_consumed_status(&changeset_path),
+            Some("1.0.0-alpha.1".to_string()),
+            "consumed status should be restored to the original version string"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_changesets_consumed_compensate_skips_files_without_original_status()
+    -> anyhow::Result<()> {
+        let changeset_path = PathBuf::from(".changeset/some-changeset.md");
+        let changeset = changeset_core::Changeset::new(
+            "test change".to_string(),
+            vec![],
+            changeset_core::ChangeCategory::Fixed,
+        );
+        let changeset_rw =
+            Arc::new(MockChangesetReader::new().with_changeset(changeset_path.clone(), changeset));
+        let ctx = make_test_context(
+            Arc::new(MockGitProvider::new()),
+            Arc::new(MockManifestWriter::new()),
+            Arc::clone(&changeset_rw),
+            Arc::new(MockReleaseStateIO::new()),
+        );
+
+        let step: ClearChangesetsConsumedStep<
+            MockGitProvider,
+            MockManifestWriter,
+            MockChangesetReader,
+            MockReleaseStateIO,
+            MockChangelogWriter,
+        > = ClearChangesetsConsumedStep::new();
+        let mut input = make_test_data();
+        input.consumed_files_cleared =
+            vec![crate::operations::release::types::ChangesetFileState {
+                path: changeset_path.clone(),
+                original_consumed_status: None,
+                backup: None,
+            }];
+
+        SagaStep::compensate(&step, &ctx, input)?;
+
+        assert_eq!(
+            changeset_rw.get_consumed_status(&changeset_path),
+            None,
+            "consumed status should remain absent when original was absent"
+        );
+
+        Ok(())
     }
 }

--- a/crates/changeset-operations/src/operations/release/types.rs
+++ b/crates/changeset-operations/src/operations/release/types.rs
@@ -320,6 +320,7 @@ pub(super) struct ReleaseContext {
     pub(super) git_options: GitOptions,
     pub(super) inherited_packages: Vec<String>,
     pub(super) additional_packages: Vec<PackageInfo>,
+    pub(super) all_packages: Vec<PackageInfo>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/changeset-operations/src/operations/release/types.rs
+++ b/crates/changeset-operations/src/operations/release/types.rs
@@ -319,6 +319,7 @@ pub(super) struct ReleaseContext {
     pub(super) classification: ReleaseClassification,
     pub(super) git_options: GitOptions,
     pub(super) inherited_packages: Vec<String>,
+    pub(super) additional_packages: Vec<PackageInfo>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/changeset-operations/src/operations/release/types.rs
+++ b/crates/changeset-operations/src/operations/release/types.rs
@@ -321,6 +321,7 @@ pub(super) struct ReleaseContext {
     pub(super) inherited_packages: Vec<String>,
     pub(super) additional_packages: Vec<PackageInfo>,
     pub(super) all_packages: Vec<PackageInfo>,
+    pub(super) package_configs: HashMap<String, changeset_project::PackageChangesetConfig>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/changeset-operations/src/operations/release/validator.rs
+++ b/crates/changeset-operations/src/operations/release/validator.rs
@@ -374,25 +374,25 @@ impl ReleaseValidator {
         collector: &mut ValidationErrorCollector,
     ) {
         for pkg_name in &cli_input.cli_graduate {
-            if let Some(pkg) = package_lookup.get(pkg_name.as_str()) {
-                if is_prerelease(pkg.version()) {
-                    collector.push(ValidationError::CannotGraduateFromPrerelease {
-                        package: pkg_name.clone(),
-                        current_version: pkg.version().clone(),
-                    });
-                }
+            if let Some(pkg) = package_lookup.get(pkg_name.as_str())
+                && is_prerelease(pkg.version())
+            {
+                collector.push(ValidationError::CannotGraduateFromPrerelease {
+                    package: pkg_name.clone(),
+                    current_version: pkg.version().clone(),
+                });
             }
         }
 
         if let Some(state) = graduation_state {
             for pkg_name in state.iter() {
-                if let Some(pkg) = package_lookup.get(pkg_name) {
-                    if is_prerelease(pkg.version()) {
-                        collector.push(ValidationError::CannotGraduateFromPrerelease {
-                            package: pkg_name.to_string(),
-                            current_version: pkg.version().clone(),
-                        });
-                    }
+                if let Some(pkg) = package_lookup.get(pkg_name)
+                    && is_prerelease(pkg.version())
+                {
+                    collector.push(ValidationError::CannotGraduateFromPrerelease {
+                        package: pkg_name.to_string(),
+                        current_version: pkg.version().clone(),
+                    });
                 }
             }
         }
@@ -405,25 +405,27 @@ impl ReleaseValidator {
         collector: &mut ValidationErrorCollector,
     ) {
         for pkg_name in &cli_input.cli_graduate {
-            if let Some(pkg) = package_lookup.get(pkg_name.as_str()) {
-                if !is_zero_version(pkg.version()) && !is_prerelease(pkg.version()) {
-                    collector.push(ValidationError::CannotGraduateStableVersion {
-                        package: pkg_name.clone(),
-                        version: pkg.version().clone(),
-                    });
-                }
+            if let Some(pkg) = package_lookup.get(pkg_name.as_str())
+                && !is_zero_version(pkg.version())
+                && !is_prerelease(pkg.version())
+            {
+                collector.push(ValidationError::CannotGraduateStableVersion {
+                    package: pkg_name.clone(),
+                    version: pkg.version().clone(),
+                });
             }
         }
 
         if let Some(state) = graduation_state {
             for pkg_name in state.iter() {
-                if let Some(pkg) = package_lookup.get(pkg_name) {
-                    if !is_zero_version(pkg.version()) && !is_prerelease(pkg.version()) {
-                        collector.push(ValidationError::CannotGraduateStableVersion {
-                            package: pkg_name.to_string(),
-                            version: pkg.version().clone(),
-                        });
-                    }
+                if let Some(pkg) = package_lookup.get(pkg_name)
+                    && !is_zero_version(pkg.version())
+                    && !is_prerelease(pkg.version())
+                {
+                    collector.push(ValidationError::CannotGraduateStableVersion {
+                        package: pkg_name.to_string(),
+                        version: pkg.version().clone(),
+                    });
                 }
             }
         }

--- a/crates/changeset-operations/src/operations/status.rs
+++ b/crates/changeset-operations/src/operations/status.rs
@@ -68,9 +68,11 @@ where
     pub fn execute(&self, start_path: &Path) -> Result<StatusOutput> {
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
-        let additional = self
-            .project_provider
-            .discover_additional_packages(project.root(), &root_config)?;
+        let additional = super::discover_additional_packages_if_workspace(
+            &self.project_provider,
+            &project,
+            &root_config,
+        )?;
 
         let all_packages: Cow<'_, [PackageInfo]> = if additional.is_empty() {
             Cow::Borrowed(project.packages())
@@ -878,7 +880,7 @@ mod tests {
 
     #[test]
     fn status_includes_additional_package_in_projected_releases() {
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
 
         let changeset = make_changeset("helm-chart", BumpType::Patch, "Fix chart template");
@@ -911,7 +913,7 @@ mod tests {
 
     #[test]
     fn status_lists_additional_package_in_unchanged_when_no_changeset() {
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
         let changeset_reader = MockChangesetReader::new();
 
@@ -1006,7 +1008,7 @@ mod tests {
 
     #[test]
     fn mixed_rust_and_additional_packages_with_changesets() {
-        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
             .with_additional_packages(vec![make_package("helm-chart", "2.0.0")]);
 
         let changeset1 = make_changeset("core", BumpType::Patch, "Fix core");
@@ -1042,5 +1044,20 @@ mod tests {
         assert_eq!(*helm_release.new_version(), Version::new(2, 1, 0));
 
         assert!(result.unchanged_packages().is_empty());
+    }
+
+    #[test]
+    fn single_package_never_calls_discover_additional_packages() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0")
+            .with_fail_on_discover_additional();
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("single-package should succeed without calling discover_additional_packages");
+
+        assert!(result.changesets().is_empty());
     }
 }

--- a/crates/changeset-operations/src/operations/status.rs
+++ b/crates/changeset-operations/src/operations/status.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -67,6 +68,22 @@ where
     pub fn execute(&self, start_path: &Path) -> Result<StatusOutput> {
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, _) = self.project_provider.load_configs(&project)?;
+        let additional = self
+            .project_provider
+            .discover_additional_packages(project.root(), &root_config)?;
+
+        let all_packages: Cow<'_, [PackageInfo]> = if additional.is_empty() {
+            Cow::Borrowed(project.packages())
+        } else {
+            Cow::Owned(
+                project
+                    .packages()
+                    .iter()
+                    .cloned()
+                    .chain(additional)
+                    .collect(),
+            )
+        };
 
         let changeset_dir = project.root().join(root_config.changeset_dir());
         let changeset_files = self.changeset_reader.list_changesets(&changeset_dir)?;
@@ -93,7 +110,7 @@ where
 
         let plan = VersionPlanner::plan_releases_with_behavior(
             &changesets,
-            project.packages(),
+            &all_packages,
             None,
             root_config.zero_version_behavior(),
         )?;
@@ -103,12 +120,12 @@ where
         let projected_releases = super::release::expand_with_reverse_dependencies(
             plan.releases().clone(),
             &graph,
-            project.packages(),
+            &all_packages,
             root_config.zero_version_behavior(),
         )?;
 
         let (_, unchanged_packages) =
-            VersionPlanner::partition_packages(&changesets, project.packages());
+            VersionPlanner::partition_packages(&changesets, &all_packages);
 
         let packages_with_inherited_versions = self
             .inherited_checker
@@ -194,7 +211,7 @@ mod tests {
     use super::*;
     use crate::mocks::{
         FailingInheritedVersionChecker, MockChangesetReader, MockInheritedVersionChecker,
-        MockProjectProvider, make_changeset,
+        MockProjectProvider, make_changeset, make_package,
     };
     use crate::traits::DependencyGraphProvider;
     use changeset_core::BumpType;
@@ -857,5 +874,173 @@ mod tests {
             result.projected_releases().is_empty(),
             "None bump with Allow should not produce projected releases"
         );
+    }
+
+    #[test]
+    fn status_includes_additional_package_in_projected_releases() {
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
+
+        let changeset = make_changeset("helm-chart", BumpType::Patch, "Fix chart template");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/fix.md"), changeset);
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("StatusOperation failed");
+
+        let release = result
+            .projected_releases()
+            .iter()
+            .find(|r| r.name() == "helm-chart")
+            .expect("helm-chart should be in projected releases");
+        assert_eq!(*release.current_version(), Version::new(1, 0, 0));
+        assert_eq!(*release.new_version(), Version::new(1, 0, 1));
+        assert_eq!(release.bump_type(), BumpType::Patch);
+
+        assert!(
+            result
+                .unchanged_packages()
+                .iter()
+                .any(|p| p.name() == "core"),
+            "core should be in unchanged packages"
+        );
+    }
+
+    #[test]
+    fn status_lists_additional_package_in_unchanged_when_no_changeset() {
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("StatusOperation failed");
+
+        assert_eq!(result.unchanged_packages().len(), 2);
+        let names: Vec<&str> = result
+            .unchanged_packages()
+            .iter()
+            .map(|p| p.name().as_str())
+            .collect();
+        assert!(names.contains(&"core"));
+        assert!(names.contains(&"helm-chart"));
+    }
+
+    #[test]
+    fn additional_packages_not_expanded_as_transitive_dependents() {
+        let project_provider =
+            MockProjectProvider::workspace(vec![("core", "1.0.0"), ("app", "1.0.0")])
+                .with_dependency_edges(vec![("app", "core")])
+                .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
+
+        let changeset = make_changeset("core", BumpType::Patch, "Fix core");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/fix.md"), changeset);
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("StatusOperation failed");
+
+        assert!(
+            result
+                .projected_releases()
+                .iter()
+                .any(|r| r.name() == "app" && r.auto_bumped()),
+            "app should be auto-bumped via dependency graph"
+        );
+        assert!(
+            !result
+                .projected_releases()
+                .iter()
+                .any(|r| r.name() == "helm-chart"),
+            "helm-chart should not appear in projected releases"
+        );
+        assert!(
+            result
+                .unchanged_packages()
+                .iter()
+                .any(|p| p.name() == "helm-chart"),
+            "helm-chart should be in unchanged packages"
+        );
+    }
+
+    #[test]
+    fn additional_packages_with_changesets_dont_affect_rust_dependency_expansion() {
+        let project_provider =
+            MockProjectProvider::workspace(vec![("core", "1.0.0"), ("app", "1.0.0")])
+                .with_dependency_edges(vec![("app", "core")])
+                .with_additional_packages(vec![make_package("helm-chart", "1.0.0")]);
+
+        let changeset = make_changeset("helm-chart", BumpType::Minor, "Add new endpoint");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/feature.md"), changeset);
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("StatusOperation failed");
+
+        assert_eq!(
+            result.projected_releases().len(),
+            1,
+            "only helm-chart should be in projected releases"
+        );
+        assert_eq!(result.projected_releases()[0].name(), "helm-chart");
+
+        let unchanged_names: Vec<&str> = result
+            .unchanged_packages()
+            .iter()
+            .map(|p| p.name().as_str())
+            .collect();
+        assert!(unchanged_names.contains(&"core"));
+        assert!(unchanged_names.contains(&"app"));
+    }
+
+    #[test]
+    fn mixed_rust_and_additional_packages_with_changesets() {
+        let project_provider = MockProjectProvider::single_package("core", "1.0.0")
+            .with_additional_packages(vec![make_package("helm-chart", "2.0.0")]);
+
+        let changeset1 = make_changeset("core", BumpType::Patch, "Fix core");
+        let changeset2 = make_changeset("helm-chart", BumpType::Minor, "Add endpoint");
+        let changeset_reader = MockChangesetReader::new().with_changesets(vec![
+            (PathBuf::from(".changeset/changesets/fix.md"), changeset1),
+            (
+                PathBuf::from(".changeset/changesets/feature.md"),
+                changeset2,
+            ),
+        ]);
+
+        let operation = make_operation(project_provider, changeset_reader);
+
+        let result = operation
+            .execute(Path::new("/any"))
+            .expect("StatusOperation failed");
+
+        assert_eq!(result.projected_releases().len(), 2);
+
+        let core_release = result
+            .projected_releases()
+            .iter()
+            .find(|r| r.name() == "core")
+            .expect("core should be in projected releases");
+        assert_eq!(*core_release.new_version(), Version::new(1, 0, 1));
+
+        let helm_release = result
+            .projected_releases()
+            .iter()
+            .find(|r| r.name() == "helm-chart")
+            .expect("helm-chart should be in projected releases");
+        assert_eq!(*helm_release.new_version(), Version::new(2, 1, 0));
+
+        assert!(result.unchanged_packages().is_empty());
     }
 }

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use changeset_core::{NoneBumpBehavior, PackageInfo};
 use changeset_git::{FileChange, FileStatus};
-use changeset_project::map_files_to_packages;
+use changeset_project::{compile_influence_patterns, map_files_to_all_packages};
 
 use derive_builder::Builder;
 use gset::Getset;
@@ -92,6 +92,15 @@ where
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, package_configs) = self.project_provider.load_configs(&project)?;
 
+        let additional_packages = self
+            .project_provider
+            .discover_additional_packages(project.root(), &root_config)?;
+        let influence_patterns = compile_influence_patterns(root_config.additional_packages())?;
+        let additional_with_patterns: Vec<_> = additional_packages
+            .into_iter()
+            .zip(influence_patterns)
+            .collect();
+
         let collected = self.collect_changes(&project, root_config.changeset_dir(), input)?;
         let is_dirty = collected.is_dirty;
         let changeset_files = collected.changeset_files;
@@ -106,7 +115,13 @@ where
         }
 
         let mapping = has_code_changes.then(|| {
-            map_files_to_packages(&project, &changed_paths, &root_config, &package_configs)
+            map_files_to_all_packages(
+                &project,
+                &changed_paths,
+                &root_config,
+                &package_configs,
+                &additional_with_patterns,
+            )
         });
 
         let (affected_packages, transitive_dependents) =
@@ -308,7 +323,7 @@ mod tests {
     use changeset_git::FileStatus;
     use changeset_project::RootChangesetConfig;
 
-    use crate::mocks::{MockChangesetReader, MockGitProvider, MockProjectProvider};
+    use crate::mocks::{MockChangesetReader, MockGitProvider, MockProjectProvider, make_package};
 
     #[test]
     fn returns_no_changes_when_no_files_changed() {
@@ -1025,6 +1040,315 @@ mod tests {
                 assert!(verification_result.covered_packages().contains("my-crate"));
             }
             other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
+        }
+    }
+
+    fn make_declaration(
+        name: &str,
+        influence: &[&str],
+    ) -> changeset_core::AdditionalPackageDeclaration {
+        let influence_json: String = influence
+            .iter()
+            .map(|s| format!("\"{s}\""))
+            .collect::<Vec<_>>()
+            .join(",");
+        let json = format!(
+            r#"{{"name":"{name}","path":"{name}","influence":[{influence_json}],"manifest":{{"file-path":"/{name}/manifest.yaml","format":"yaml","version-path":"version"}}}}"#
+        );
+        serde_json::from_str(&json).expect("valid declaration JSON")
+    }
+
+    #[test]
+    fn detects_additional_package_changes_via_influence_globs() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![decl.clone()]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider = MockProjectProvider::workspace(vec![("my-crate", "1.0.0")])
+            .with_root_config(root_config)
+            .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![FileChange::new(
+            PathBuf::from("charts/values.yaml"),
+            FileStatus::Modified,
+        )]);
+
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        match result.outcome() {
+            VerifyOutcome::Failed(verification_result) => {
+                assert!(
+                    verification_result
+                        .uncovered_packages()
+                        .iter()
+                        .any(|p| p.name() == "helm-chart"),
+                    "helm-chart should be uncovered"
+                );
+            }
+            other => panic!("Expected VerifyOutcome::Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn succeeds_when_additional_package_covered_by_changeset() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider = MockProjectProvider::workspace(vec![("my-crate", "1.0.0")])
+            .with_root_config(root_config)
+            .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![
+            FileChange::new(
+                PathBuf::from(".changeset/changesets/chart.md"),
+                FileStatus::Added,
+            ),
+            FileChange::new(PathBuf::from("charts/values.yaml"), FileStatus::Modified),
+        ]);
+
+        let changeset = crate::mocks::make_changeset("helm-chart", BumpType::Patch, "Update chart");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/chart.md"), changeset);
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        match result.outcome() {
+            VerifyOutcome::Success(verification_result) => {
+                assert!(
+                    verification_result
+                        .covered_packages()
+                        .contains("helm-chart")
+                );
+                assert!(verification_result.uncovered_packages().is_empty());
+            }
+            other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn files_outside_influence_globs_not_matched_to_additional_packages() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider = MockProjectProvider::workspace(vec![("my-crate", "1.0.0")])
+            .with_root_config(root_config)
+            .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![FileChange::new(
+            PathBuf::from("docs/README.md"),
+            FileStatus::Modified,
+        )]);
+
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        assert!(matches!(
+            result.outcome(),
+            VerifyOutcome::NoPackagesAffected { .. }
+        ));
+    }
+
+    #[test]
+    fn mixed_rust_and_additional_packages_both_detected_and_covered() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
+            .with_root_config(root_config)
+            .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![
+            FileChange::new(
+                PathBuf::from(".changeset/changesets/both.md"),
+                FileStatus::Added,
+            ),
+            FileChange::new(
+                PathBuf::from("crates/core/src/lib.rs"),
+                FileStatus::Modified,
+            ),
+            FileChange::new(PathBuf::from("charts/values.yaml"), FileStatus::Modified),
+        ]);
+
+        let changeset = changeset_core::Changeset::new(
+            "Update both".to_string(),
+            vec![
+                changeset_core::PackageRelease::new("core".to_string(), BumpType::Patch),
+                changeset_core::PackageRelease::new("helm-chart".to_string(), BumpType::Patch),
+            ],
+            changeset_core::ChangeCategory::Changed,
+        );
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/both.md"), changeset);
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        match result.outcome() {
+            VerifyOutcome::Success(verification_result) => {
+                assert!(verification_result.covered_packages().contains("core"));
+                assert!(
+                    verification_result
+                        .covered_packages()
+                        .contains("helm-chart")
+                );
+                assert!(verification_result.uncovered_packages().is_empty());
+            }
+            other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn additional_packages_not_expanded_as_transitive_dependents() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider =
+            MockProjectProvider::workspace(vec![("core", "1.0.0"), ("app", "1.0.0")])
+                .with_dependency_edges(vec![("app", "core")])
+                .with_root_config(root_config)
+                .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![
+            FileChange::new(
+                PathBuf::from(".changeset/changesets/fix.md"),
+                FileStatus::Added,
+            ),
+            FileChange::new(
+                PathBuf::from("crates/core/src/lib.rs"),
+                FileStatus::Modified,
+            ),
+        ]);
+
+        let changeset = changeset_core::Changeset::new(
+            "Fix core and app".to_string(),
+            vec![
+                changeset_core::PackageRelease::new("core".to_string(), BumpType::Patch),
+                changeset_core::PackageRelease::new("app".to_string(), BumpType::Patch),
+            ],
+            changeset_core::ChangeCategory::Changed,
+        );
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/fix.md"), changeset);
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        match result.outcome() {
+            VerifyOutcome::Success(verification_result) => {
+                assert!(verification_result.covered_packages().contains("core"));
+                assert!(verification_result.covered_packages().contains("app"));
+                assert!(
+                    !verification_result
+                        .uncovered_packages()
+                        .iter()
+                        .any(|p| p.name() == "helm-chart"),
+                    "helm-chart should not appear as uncovered — it had no changes"
+                );
+            }
+            other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn additional_package_uncovered_while_rust_packages_covered() {
+        let decl = make_declaration("helm-chart", &["charts/**"]);
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let helm_chart = make_package("helm-chart", "1.0.0");
+        let project_provider = MockProjectProvider::workspace(vec![("core", "1.0.0")])
+            .with_root_config(root_config)
+            .with_additional_packages(vec![helm_chart]);
+
+        let git_provider = MockGitProvider::new().with_changed_files(vec![
+            FileChange::new(
+                PathBuf::from(".changeset/changesets/fix.md"),
+                FileStatus::Added,
+            ),
+            FileChange::new(
+                PathBuf::from("crates/core/src/lib.rs"),
+                FileStatus::Modified,
+            ),
+            FileChange::new(PathBuf::from("charts/values.yaml"), FileStatus::Modified),
+        ]);
+
+        let changeset = crate::mocks::make_changeset("core", BumpType::Patch, "Fix core");
+        let changeset_reader = MockChangesetReader::new()
+            .with_changeset(PathBuf::from(".changeset/changesets/fix.md"), changeset);
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("operation should not error");
+
+        match result.outcome() {
+            VerifyOutcome::Failed(verification_result) => {
+                assert!(
+                    verification_result
+                        .uncovered_packages()
+                        .iter()
+                        .any(|p| p.name() == "helm-chart"),
+                    "helm-chart should be uncovered"
+                );
+                assert!(
+                    !verification_result
+                        .uncovered_packages()
+                        .iter()
+                        .any(|p| p.name() == "core"),
+                    "core should be covered"
+                );
+            }
+            other => panic!("Expected VerifyOutcome::Failed, got {other:?}"),
         }
     }
 

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -97,6 +97,19 @@ where
             &project,
             &root_config,
         )?;
+
+        let all_package_names: HashSet<String> = project
+            .packages()
+            .iter()
+            .map(|p| p.name().clone())
+            .chain(additional_packages.iter().map(|p| p.name().clone()))
+            .collect();
+        changeset_project::validate_version_tracking_dependencies(
+            &root_config,
+            &package_configs,
+            &all_package_names,
+        )?;
+
         let additional_with_patterns: Vec<_> = if additional_packages.is_empty() {
             Vec::new()
         } else {

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -92,14 +92,20 @@ where
         let project = self.project_provider.discover_project(start_path)?;
         let (root_config, package_configs) = self.project_provider.load_configs(&project)?;
 
-        let additional_packages = self
-            .project_provider
-            .discover_additional_packages(project.root(), &root_config)?;
-        let influence_patterns = compile_influence_patterns(root_config.additional_packages())?;
-        let additional_with_patterns: Vec<_> = additional_packages
-            .into_iter()
-            .zip(influence_patterns)
-            .collect();
+        let additional_packages = super::discover_additional_packages_if_workspace(
+            &self.project_provider,
+            &project,
+            &root_config,
+        )?;
+        let additional_with_patterns: Vec<_> = if additional_packages.is_empty() {
+            Vec::new()
+        } else {
+            let influence_patterns = compile_influence_patterns(root_config.additional_packages())?;
+            additional_packages
+                .into_iter()
+                .zip(influence_patterns)
+                .collect()
+        };
 
         let collected = self.collect_changes(&project, root_config.changeset_dir(), input)?;
         let is_dirty = collected.is_dirty;
@@ -1392,5 +1398,27 @@ mod tests {
             }
             other => panic!("Expected VerifyOutcome::Success, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn single_package_never_calls_discover_additional_packages() {
+        let project_provider = MockProjectProvider::single_package("my-crate", "1.0.0")
+            .with_fail_on_discover_additional();
+
+        let git_provider = MockGitProvider::new();
+        let changeset_reader = MockChangesetReader::new();
+
+        let operation = VerifyOperation::new(project_provider, git_provider, changeset_reader);
+
+        let input = VerifyInputBuilder::default()
+            .base("main".to_string())
+            .build()
+            .expect("all fields have defaults");
+
+        let result = operation
+            .execute(Path::new("/any"), &input)
+            .expect("single-package should succeed without calling discover_additional_packages");
+
+        assert!(matches!(result.outcome(), VerifyOutcome::NoChanges));
     }
 }

--- a/crates/changeset-operations/src/operations/verify.rs
+++ b/crates/changeset-operations/src/operations/verify.rs
@@ -1059,7 +1059,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join(",");
         let json = format!(
-            r#"{{"name":"{name}","path":"{name}","influence":[{influence_json}],"manifest":{{"file-path":"/{name}/manifest.yaml","format":"yaml","version-path":"version"}}}}"#
+            r#"{{"name":"{name}","path":"{name}","influence":[{influence_json}],"manifest":{{"file-path":"/{name}/manifest.yaml","format":"yaml","version-field-path":"version"}}}}"#
         );
         serde_json::from_str(&json).expect("valid declaration JSON")
     }

--- a/crates/changeset-operations/src/operations/version_tracking_deps.rs
+++ b/crates/changeset-operations/src/operations/version_tracking_deps.rs
@@ -1,0 +1,547 @@
+use std::path::{Path, PathBuf};
+
+use changeset_core::{
+    CARGO_MANIFEST_FILENAME, ManifestFormat, VersionTrackingDependency, VersionTrackingManifest,
+};
+use changeset_manifest::MetadataSection;
+use changeset_project::ProjectKind;
+use gset::Getset;
+
+use crate::Result;
+use crate::error::OperationError;
+use crate::traits::{ProjectProvider, VersionTrackingDependencyWriter};
+
+pub struct VersionTrackingDependencyAddInput {
+    package_name: String,
+    dependency_name: String,
+    manifest_file_path: PathBuf,
+    manifest_format: ManifestFormat,
+    version_field_path: String,
+}
+
+impl VersionTrackingDependencyAddInput {
+    #[must_use]
+    pub fn new(
+        package_name: String,
+        dependency_name: String,
+        manifest_file_path: PathBuf,
+        manifest_format: ManifestFormat,
+        version_field_path: String,
+    ) -> Self {
+        Self {
+            package_name,
+            dependency_name,
+            manifest_file_path,
+            manifest_format,
+            version_field_path,
+        }
+    }
+}
+
+pub struct VersionTrackingDependencyRemoveInput {
+    package_name: String,
+    dependency_name: String,
+}
+
+impl VersionTrackingDependencyRemoveInput {
+    #[must_use]
+    pub fn new(package_name: String, dependency_name: String) -> Self {
+        Self {
+            package_name,
+            dependency_name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionTrackingDependencyEvent {
+    Added {
+        package_name: String,
+        dependency_name: String,
+    },
+    Removed {
+        package_name: String,
+        dependency_name: String,
+    },
+    Listed(Vec<VersionTrackingDependencySummary>),
+    NoDependencies {
+        package_name: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Getset)]
+pub struct VersionTrackingDependencySummary {
+    #[getset(get, vis = "pub")]
+    dependency_name: String,
+    #[getset(get, vis = "pub")]
+    manifest_file_path: PathBuf,
+    #[getset(get_copy, vis = "pub")]
+    manifest_format: ManifestFormat,
+    #[getset(get, vis = "pub")]
+    version_field_path: String,
+}
+
+pub struct VersionTrackingDependencyAddOperation<P, W> {
+    project_provider: P,
+    writer: W,
+}
+
+impl<P, W> VersionTrackingDependencyAddOperation<P, W>
+where
+    P: ProjectProvider,
+    W: VersionTrackingDependencyWriter,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W) -> Self {
+        Self {
+            project_provider,
+            writer,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// or the manifest cannot be written.
+    pub fn execute(
+        &self,
+        start_path: &Path,
+        input: VersionTrackingDependencyAddInput,
+    ) -> Result<Vec<VersionTrackingDependencyEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let dependency = VersionTrackingDependency::new(
+            input.dependency_name.clone(),
+            VersionTrackingManifest::new(
+                input.manifest_file_path,
+                input.manifest_format,
+                input.version_field_path,
+            ),
+        );
+
+        let is_additional = root_config
+            .additional_packages()
+            .iter()
+            .any(|p| p.name() == &input.package_name);
+
+        let is_crate = project
+            .packages()
+            .iter()
+            .any(|p| p.name() == &input.package_name);
+
+        if is_additional {
+            let (manifest_path, section) = resolve_workspace_manifest(&project);
+            self.writer.add_dependency_to_additional_package(
+                &manifest_path,
+                section,
+                &input.package_name,
+                &dependency,
+            )?;
+        } else if is_crate {
+            let crate_manifest = find_crate_manifest(&project, &input.package_name)?;
+            self.writer
+                .add_dependency_to_crate(&crate_manifest, &dependency)?;
+        } else {
+            return Err(OperationError::PackageNotFound {
+                name: input.package_name,
+            });
+        }
+
+        Ok(vec![VersionTrackingDependencyEvent::Added {
+            package_name: input.package_name,
+            dependency_name: input.dependency_name,
+        }])
+    }
+}
+
+pub struct VersionTrackingDependencyRemoveOperation<P, W> {
+    project_provider: P,
+    writer: W,
+}
+
+impl<P, W> VersionTrackingDependencyRemoveOperation<P, W>
+where
+    P: ProjectProvider,
+    W: VersionTrackingDependencyWriter,
+{
+    #[must_use]
+    pub fn new(project_provider: P, writer: W) -> Self {
+        Self {
+            project_provider,
+            writer,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered, configs cannot be loaded,
+    /// or the manifest cannot be written.
+    pub fn execute(
+        &self,
+        start_path: &Path,
+        input: VersionTrackingDependencyRemoveInput,
+    ) -> Result<Vec<VersionTrackingDependencyEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, _) = self.project_provider.load_configs(&project)?;
+
+        let is_additional = root_config
+            .additional_packages()
+            .iter()
+            .any(|p| p.name() == &input.package_name);
+
+        let is_crate = project
+            .packages()
+            .iter()
+            .any(|p| p.name() == &input.package_name);
+
+        if is_additional {
+            let (manifest_path, section) = resolve_workspace_manifest(&project);
+            self.writer.remove_dependency_from_additional_package(
+                &manifest_path,
+                section,
+                &input.package_name,
+                &input.dependency_name,
+            )?;
+        } else if is_crate {
+            let crate_manifest = find_crate_manifest(&project, &input.package_name)?;
+            self.writer
+                .remove_dependency_from_crate(&crate_manifest, &input.dependency_name)?;
+        } else {
+            return Err(OperationError::PackageNotFound {
+                name: input.package_name,
+            });
+        }
+
+        Ok(vec![VersionTrackingDependencyEvent::Removed {
+            package_name: input.package_name,
+            dependency_name: input.dependency_name,
+        }])
+    }
+}
+
+pub struct VersionTrackingDependencyListOperation<P> {
+    project_provider: P,
+}
+
+impl<P> VersionTrackingDependencyListOperation<P>
+where
+    P: ProjectProvider,
+{
+    #[must_use]
+    pub fn new(project_provider: P) -> Self {
+        Self { project_provider }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the project cannot be discovered or configs cannot be loaded.
+    pub fn execute(
+        &self,
+        start_path: &Path,
+        package_name: &str,
+    ) -> Result<Vec<VersionTrackingDependencyEvent>> {
+        let project = self.project_provider.discover_project(start_path)?;
+        let (root_config, package_configs) = self.project_provider.load_configs(&project)?;
+
+        let additional_pkg = root_config
+            .additional_packages()
+            .iter()
+            .find(|p| p.name() == package_name);
+
+        if let Some(pkg) = additional_pkg {
+            let deps = pkg.dependencies();
+            if deps.is_empty() {
+                return Ok(vec![VersionTrackingDependencyEvent::NoDependencies {
+                    package_name: package_name.to_string(),
+                }]);
+            }
+            let summaries = deps
+                .iter()
+                .map(|d| VersionTrackingDependencySummary {
+                    dependency_name: d.dependency_name().clone(),
+                    manifest_file_path: d.version_tracking_manifest().file_path().clone(),
+                    manifest_format: d.version_tracking_manifest().format(),
+                    version_field_path: d.version_tracking_manifest().version_field_path().clone(),
+                })
+                .collect();
+            return Ok(vec![VersionTrackingDependencyEvent::Listed(summaries)]);
+        }
+
+        let is_crate = project.packages().iter().any(|p| p.name() == package_name);
+
+        if is_crate {
+            let deps = package_configs
+                .get(package_name)
+                .map(changeset_project::PackageChangesetConfig::additional_package_dependencies)
+                .unwrap_or_default();
+
+            if deps.is_empty() {
+                return Ok(vec![VersionTrackingDependencyEvent::NoDependencies {
+                    package_name: package_name.to_string(),
+                }]);
+            }
+
+            let summaries = deps
+                .iter()
+                .map(|d| VersionTrackingDependencySummary {
+                    dependency_name: d.dependency_name().clone(),
+                    manifest_file_path: d.version_tracking_manifest().file_path().clone(),
+                    manifest_format: d.version_tracking_manifest().format(),
+                    version_field_path: d.version_tracking_manifest().version_field_path().clone(),
+                })
+                .collect();
+            return Ok(vec![VersionTrackingDependencyEvent::Listed(summaries)]);
+        }
+
+        Err(OperationError::PackageNotFound {
+            name: package_name.to_string(),
+        })
+    }
+}
+
+fn resolve_workspace_manifest(
+    project: &changeset_project::CargoProject,
+) -> (PathBuf, MetadataSection) {
+    let manifest_path = project.root().join(CARGO_MANIFEST_FILENAME);
+    let section = match project.kind() {
+        ProjectKind::VirtualWorkspace | ProjectKind::WorkspaceWithRoot => {
+            MetadataSection::Workspace
+        }
+        ProjectKind::SinglePackage => MetadataSection::Package,
+    };
+    (manifest_path, section)
+}
+
+fn find_crate_manifest(
+    project: &changeset_project::CargoProject,
+    package_name: &str,
+) -> Result<PathBuf> {
+    project
+        .packages()
+        .iter()
+        .find(|p| p.name() == package_name)
+        .map(|p| p.path().join(CARGO_MANIFEST_FILENAME))
+        .ok_or_else(|| OperationError::PackageNotFound {
+            name: package_name.to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use changeset_core::{
+        AdditionalPackageDeclaration, AdditionalPackageManifest, ManifestFormat,
+        VersionTrackingDependency, VersionTrackingManifest,
+    };
+    use changeset_project::RootChangesetConfig;
+
+    use super::*;
+    use crate::mocks::{MockManifestWriter, MockProjectProvider};
+
+    fn make_decl_with_deps(
+        name: &str,
+        deps: Vec<VersionTrackingDependency>,
+    ) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(format!("charts/{name}")),
+            vec![format!("charts/{name}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("charts/{name}/Chart.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            deps,
+        )
+    }
+
+    fn make_tracking_dep(dep_name: &str) -> VersionTrackingDependency {
+        VersionTrackingDependency::new(
+            dep_name.to_string(),
+            VersionTrackingManifest::new(
+                PathBuf::from(format!("charts/dep/{dep_name}.yaml")),
+                ManifestFormat::Yaml,
+                "appVersion".to_string(),
+            ),
+        )
+    }
+
+    #[test]
+    fn add_dependency_to_additional_package_succeeds() {
+        let config = RootChangesetConfig::default()
+            .with_additional_packages(vec![make_decl_with_deps("my-chart", vec![])]);
+        let provider =
+            MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]).with_root_config(config);
+        let writer = MockManifestWriter::new();
+
+        let op = VersionTrackingDependencyAddOperation::new(provider, writer);
+        let input = VersionTrackingDependencyAddInput::new(
+            "my-chart".to_string(),
+            "crate-a".to_string(),
+            PathBuf::from("charts/dep/crate-a.yaml"),
+            ManifestFormat::Yaml,
+            "appVersion".to_string(),
+        );
+
+        let events = op
+            .execute(Path::new("/any"), input)
+            .expect("should succeed");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            VersionTrackingDependencyEvent::Added {
+                package_name,
+                dependency_name
+            } if package_name == "my-chart" && dependency_name == "crate-a"
+        )));
+    }
+
+    #[test]
+    fn add_dependency_to_crate_succeeds() {
+        let provider = MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]);
+        let writer = MockManifestWriter::new();
+
+        let op = VersionTrackingDependencyAddOperation::new(provider, writer);
+        let input = VersionTrackingDependencyAddInput::new(
+            "crate-a".to_string(),
+            "my-chart".to_string(),
+            PathBuf::from("charts/dep/my-chart.yaml"),
+            ManifestFormat::Yaml,
+            "appVersion".to_string(),
+        );
+
+        let events = op
+            .execute(Path::new("/any"), input)
+            .expect("should succeed");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            VersionTrackingDependencyEvent::Added {
+                package_name,
+                dependency_name
+            } if package_name == "crate-a" && dependency_name == "my-chart"
+        )));
+    }
+
+    #[test]
+    fn add_dependency_to_unknown_package_fails() {
+        let provider = MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]);
+        let writer = MockManifestWriter::new();
+
+        let op = VersionTrackingDependencyAddOperation::new(provider, writer);
+        let input = VersionTrackingDependencyAddInput::new(
+            "nonexistent".to_string(),
+            "crate-a".to_string(),
+            PathBuf::from("charts/dep/crate-a.yaml"),
+            ManifestFormat::Yaml,
+            "appVersion".to_string(),
+        );
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::PackageNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn remove_dependency_from_additional_package_succeeds() {
+        let config =
+            RootChangesetConfig::default().with_additional_packages(vec![make_decl_with_deps(
+                "my-chart",
+                vec![make_tracking_dep("crate-a")],
+            )]);
+        let provider =
+            MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]).with_root_config(config);
+        let writer = MockManifestWriter::new();
+
+        let op = VersionTrackingDependencyRemoveOperation::new(provider, writer);
+        let input = VersionTrackingDependencyRemoveInput::new(
+            "my-chart".to_string(),
+            "crate-a".to_string(),
+        );
+
+        let events = op
+            .execute(Path::new("/any"), input)
+            .expect("should succeed");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            VersionTrackingDependencyEvent::Removed {
+                package_name,
+                dependency_name
+            } if package_name == "my-chart" && dependency_name == "crate-a"
+        )));
+    }
+
+    #[test]
+    fn remove_dependency_from_unknown_package_fails() {
+        let provider = MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]);
+        let writer = MockManifestWriter::new();
+
+        let op = VersionTrackingDependencyRemoveOperation::new(provider, writer);
+        let input = VersionTrackingDependencyRemoveInput::new(
+            "nonexistent".to_string(),
+            "crate-a".to_string(),
+        );
+
+        let result = op.execute(Path::new("/any"), input);
+        assert!(matches!(
+            result,
+            Err(OperationError::PackageNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn list_dependencies_for_additional_package() {
+        let dep = make_tracking_dep("crate-a");
+        let config = RootChangesetConfig::default()
+            .with_additional_packages(vec![make_decl_with_deps("my-chart", vec![dep])]);
+        let provider =
+            MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]).with_root_config(config);
+
+        let op = VersionTrackingDependencyListOperation::new(provider);
+        let events = op
+            .execute(Path::new("/any"), "my-chart")
+            .expect("should succeed");
+
+        let listed = events.iter().find_map(|e| {
+            if let VersionTrackingDependencyEvent::Listed(s) = e {
+                Some(s)
+            } else {
+                None
+            }
+        });
+        let summaries = listed.expect("should have Listed event");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].dependency_name(), "crate-a");
+    }
+
+    #[test]
+    fn list_dependencies_for_package_with_none_returns_no_dependencies() {
+        let config = RootChangesetConfig::default()
+            .with_additional_packages(vec![make_decl_with_deps("my-chart", vec![])]);
+        let provider =
+            MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]).with_root_config(config);
+
+        let op = VersionTrackingDependencyListOperation::new(provider);
+        let events = op
+            .execute(Path::new("/any"), "my-chart")
+            .expect("should succeed");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            VersionTrackingDependencyEvent::NoDependencies { package_name } if package_name == "my-chart"
+        )));
+    }
+
+    #[test]
+    fn list_dependencies_for_unknown_package_fails() {
+        let provider = MockProjectProvider::workspace(vec![("crate-a", "1.0.0")]);
+        let op = VersionTrackingDependencyListOperation::new(provider);
+
+        let result = op.execute(Path::new("/any"), "nonexistent");
+        assert!(matches!(
+            result,
+            Err(OperationError::PackageNotFound { .. })
+        ));
+    }
+}

--- a/crates/changeset-operations/src/planner.rs
+++ b/crates/changeset-operations/src/planner.rs
@@ -325,7 +325,7 @@ impl VersionPlanner {
         prerelease: Option<&PrereleaseSpec>,
         should_graduate: bool,
     ) -> bool {
-        let is_noop_or_absent = bump_type.is_none() || bump_type.is_some_and(|b| b.is_noop());
+        let is_noop_or_absent = bump_type.is_none_or(|b| b.is_noop());
         is_noop_or_absent && prerelease.is_none() && !should_graduate
     }
 

--- a/crates/changeset-operations/src/providers/changeset_io.rs
+++ b/crates/changeset-operations/src/providers/changeset_io.rs
@@ -243,7 +243,6 @@ fn generate_unique_filename(changeset_dir: &Path) -> String {
 
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_millis());
     format!("changeset-{timestamp}.md")
 }

--- a/crates/changeset-operations/src/providers/changeset_io.rs
+++ b/crates/changeset-operations/src/providers/changeset_io.rs
@@ -188,6 +188,22 @@ impl ChangesetWriter for FileSystemChangesetIO {
         }
         Ok(())
     }
+
+    fn restore_consumed_for_prerelease(
+        &self,
+        changeset_dir: &Path,
+        paths: &[&Path],
+        version: &str,
+    ) -> Result<()> {
+        let version_string = version.to_owned();
+        for path in paths {
+            let full_path = self.resolve_changeset_path(changeset_dir, path)?;
+            update_changeset_file(&full_path, |changeset| {
+                changeset.set_consumed_for_prerelease(Some(version_string.clone()));
+            })?;
+        }
+        Ok(())
+    }
 }
 
 fn update_changeset_file<F>(full_path: &Path, updater: F) -> Result<()>

--- a/crates/changeset-operations/src/providers/manifest.rs
+++ b/crates/changeset-operations/src/providers/manifest.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 use std::process::Command;
 
-use changeset_core::ManifestFormat;
-use changeset_manifest::{InitConfig, MetadataSection};
+use changeset_core::{AdditionalPackageDeclaration, ManifestFormat};
+use changeset_manifest::{AdditionalPackageUpdate, InitConfig, MetadataSection};
 use semver::Version;
 
 use crate::Result;
 use crate::error::OperationError;
 use crate::traits::{
-    ExternalManifestVersionWriter, InheritedVersionChecker, LockfileUpdater,
-    ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter,
+    AdditionalPackageConfigWriter, ExternalManifestVersionWriter, InheritedVersionChecker,
+    LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter,
     WorkspaceVersionManager,
 };
 
@@ -185,6 +185,49 @@ impl ManifestMetadataWriter for FileSystemManifestWriter {
             manifest_path,
             section,
             config,
+        )?)
+    }
+}
+
+impl AdditionalPackageConfigWriter for FileSystemManifestWriter {
+    fn add_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        declaration: &AdditionalPackageDeclaration,
+    ) -> Result<()> {
+        Ok(changeset_manifest::add_additional_package(
+            manifest_path,
+            section,
+            declaration,
+        )?)
+    }
+
+    fn remove_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        name: &str,
+    ) -> Result<bool> {
+        Ok(changeset_manifest::remove_additional_package(
+            manifest_path,
+            section,
+            name,
+        )?)
+    }
+
+    fn update_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        name: &str,
+        updates: &AdditionalPackageUpdate,
+    ) -> Result<bool> {
+        Ok(changeset_manifest::update_additional_package(
+            manifest_path,
+            section,
+            name,
+            updates,
         )?)
     }
 }

--- a/crates/changeset-operations/src/providers/manifest.rs
+++ b/crates/changeset-operations/src/providers/manifest.rs
@@ -147,13 +147,13 @@ impl ExternalManifestVersionWriter for FileSystemManifestWriter {
         &self,
         manifest_path: &Path,
         format: ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
         new_version: &Version,
     ) -> Result<()> {
         Ok(changeset_manifest::write_external_version(
             manifest_path,
             format,
-            version_path,
+            version_field_path,
             new_version,
         )?)
     }
@@ -162,13 +162,13 @@ impl ExternalManifestVersionWriter for FileSystemManifestWriter {
         &self,
         manifest_path: &Path,
         format: ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
         expected: &Version,
     ) -> Result<()> {
         Ok(changeset_manifest::verify_external_version(
             manifest_path,
             format,
-            version_path,
+            version_field_path,
             expected,
         )?)
     }

--- a/crates/changeset-operations/src/providers/manifest.rs
+++ b/crates/changeset-operations/src/providers/manifest.rs
@@ -1,14 +1,16 @@
 use std::path::Path;
 use std::process::Command;
 
+use changeset_core::ManifestFormat;
 use changeset_manifest::{InitConfig, MetadataSection};
 use semver::Version;
 
 use crate::Result;
 use crate::error::OperationError;
 use crate::traits::{
-    InheritedVersionChecker, LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter,
-    ManifestVersionWriter, WorkspaceVersionManager,
+    ExternalManifestVersionWriter, InheritedVersionChecker, LockfileUpdater,
+    ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter,
+    WorkspaceVersionManager,
 };
 
 pub struct FileSystemManifestWriter;
@@ -140,6 +142,38 @@ impl LockfileUpdater for FileSystemManifestWriter {
     }
 }
 
+impl ExternalManifestVersionWriter for FileSystemManifestWriter {
+    fn write_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_path: &str,
+        new_version: &Version,
+    ) -> Result<()> {
+        Ok(changeset_manifest::write_external_version(
+            manifest_path,
+            format,
+            version_path,
+            new_version,
+        )?)
+    }
+
+    fn verify_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_path: &str,
+        expected: &Version,
+    ) -> Result<()> {
+        Ok(changeset_manifest::verify_external_version(
+            manifest_path,
+            format,
+            version_path,
+            expected,
+        )?)
+    }
+}
+
 impl ManifestMetadataWriter for FileSystemManifestWriter {
     fn write_metadata(
         &self,
@@ -152,5 +186,81 @@ impl ManifestMetadataWriter for FileSystemManifestWriter {
             section,
             config,
         )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use changeset_core::ManifestFormat;
+    use semver::Version;
+    use tempfile::NamedTempFile;
+
+    use super::FileSystemManifestWriter;
+    use crate::traits::ExternalManifestVersionWriter;
+
+    fn toml_manifest(version: &str) -> String {
+        format!("[package]\nversion = \"{version}\"\n")
+    }
+
+    #[test]
+    fn write_external_version_writes_toml_version() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), toml_manifest("1.0.0"))?;
+
+        let writer = FileSystemManifestWriter::new();
+        writer.write_external_version(
+            file.path(),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(2, 0, 0),
+        )?;
+
+        let content = std::fs::read_to_string(file.path())?;
+        assert!(content.contains("\"2.0.0\""));
+        Ok(())
+    }
+
+    #[test]
+    fn verify_external_version_succeeds_when_matching() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), toml_manifest("1.0.0"))?;
+
+        let writer = FileSystemManifestWriter::new();
+        writer.verify_external_version(
+            file.path(),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(1, 0, 0),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_external_version_fails_when_mismatched() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), toml_manifest("1.0.0"))?;
+
+        let writer = FileSystemManifestWriter::new();
+        let result = writer.verify_external_version(
+            file.path(),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(2, 0, 0),
+        );
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn write_external_version_propagates_error_for_missing_file() {
+        let writer = FileSystemManifestWriter::new();
+        let result = writer.write_external_version(
+            std::path::Path::new("/nonexistent/path/manifest.toml"),
+            ManifestFormat::Toml,
+            "package.version",
+            &Version::new(1, 0, 0),
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/changeset-operations/src/providers/manifest.rs
+++ b/crates/changeset-operations/src/providers/manifest.rs
@@ -7,10 +7,12 @@ use semver::Version;
 
 use crate::Result;
 use crate::error::OperationError;
+use changeset_core::VersionTrackingDependency;
+
 use crate::traits::{
-    AdditionalPackageConfigWriter, ExternalManifestVersionWriter, InheritedVersionChecker,
-    LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter,
-    WorkspaceVersionManager,
+    AdditionalPackageConfigWriter, ExternalManifestVersionReader, ExternalManifestVersionWriter,
+    InheritedVersionChecker, LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter,
+    ManifestVersionWriter, VersionTrackingDependencyWriter, WorkspaceVersionManager,
 };
 
 pub struct FileSystemManifestWriter;
@@ -142,6 +144,21 @@ impl LockfileUpdater for FileSystemManifestWriter {
     }
 }
 
+impl ExternalManifestVersionReader for FileSystemManifestWriter {
+    fn read_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+    ) -> Result<String> {
+        Ok(changeset_manifest::read_external_version_string(
+            manifest_path,
+            format,
+            version_field_path,
+        )?)
+    }
+}
+
 impl ExternalManifestVersionWriter for FileSystemManifestWriter {
     fn write_external_version(
         &self,
@@ -172,6 +189,21 @@ impl ExternalManifestVersionWriter for FileSystemManifestWriter {
             expected,
         )?)
     }
+
+    fn restore_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+        version_str: &str,
+    ) -> Result<()> {
+        Ok(changeset_manifest::restore_external_version(
+            manifest_path,
+            format,
+            version_field_path,
+            version_str,
+        )?)
+    }
 }
 
 impl ManifestMetadataWriter for FileSystemManifestWriter {
@@ -186,6 +218,68 @@ impl ManifestMetadataWriter for FileSystemManifestWriter {
             section,
             config,
         )?)
+    }
+}
+
+impl VersionTrackingDependencyWriter for FileSystemManifestWriter {
+    fn add_dependency_to_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        package_name: &str,
+        dependency: &VersionTrackingDependency,
+    ) -> Result<bool> {
+        Ok(
+            changeset_manifest::add_version_tracking_dependency_to_additional_package(
+                manifest_path,
+                section,
+                package_name,
+                dependency,
+            )?,
+        )
+    }
+
+    fn remove_dependency_from_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        package_name: &str,
+        dependency_name: &str,
+    ) -> Result<bool> {
+        Ok(
+            changeset_manifest::remove_version_tracking_dependency_from_additional_package(
+                manifest_path,
+                section,
+                package_name,
+                dependency_name,
+            )?,
+        )
+    }
+
+    fn add_dependency_to_crate(
+        &self,
+        manifest_path: &Path,
+        dependency: &VersionTrackingDependency,
+    ) -> Result<()> {
+        Ok(
+            changeset_manifest::add_version_tracking_dependency_to_crate(
+                manifest_path,
+                dependency,
+            )?,
+        )
+    }
+
+    fn remove_dependency_from_crate(
+        &self,
+        manifest_path: &Path,
+        dependency_name: &str,
+    ) -> Result<bool> {
+        Ok(
+            changeset_manifest::remove_version_tracking_dependency_from_crate(
+                manifest_path,
+                dependency_name,
+            )?,
+        )
     }
 }
 

--- a/crates/changeset-operations/src/providers/project.rs
+++ b/crates/changeset-operations/src/providers/project.rs
@@ -107,7 +107,7 @@ mod tests {
                 "manifest": {
                     "file-path": "charts/my-chart/Chart.yaml",
                     "format": "yaml",
-                    "version-path": "version"
+                    "version-field-path": "version"
                 }
             }"#,
         );
@@ -135,7 +135,7 @@ mod tests {
                 "manifest": {
                     "file-path": "/nonexistent/path/Chart.yaml",
                     "format": "yaml",
-                    "version-path": "version"
+                    "version-field-path": "version"
                 }
             }"#,
         );

--- a/crates/changeset-operations/src/providers/project.rs
+++ b/crates/changeset-operations/src/providers/project.rs
@@ -99,19 +99,18 @@ mod tests {
             "version: \"1.2.3\"\n",
         )?;
 
-        let decl = make_decl(&format!(
-            r#"{{
+        let decl = make_decl(
+            r#"{
                 "name": "my-helm-chart",
                 "path": "charts/my-chart",
                 "influence": ["charts/my-chart/**"],
-                "manifest": {{
-                    "file-path": "{}/charts/my-chart/Chart.yaml",
+                "manifest": {
+                    "file-path": "charts/my-chart/Chart.yaml",
                     "format": "yaml",
                     "version-path": "version"
-                }}
-            }}"#,
-            root.display()
-        ));
+                }
+            }"#,
+        );
 
         let config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
         let provider = FileSystemProjectProvider::new();

--- a/crates/changeset-operations/src/providers/project.rs
+++ b/crates/changeset-operations/src/providers/project.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use changeset_core::PackageInfo;
 use changeset_project::{
     CargoProject, PackageChangesetConfig, RootChangesetConfig, WorkspaceDependencyGraph,
-    discover_project, ensure_changeset_dir, load_changeset_configs,
+    discover_additional_packages, discover_project, ensure_changeset_dir, load_changeset_configs,
 };
 
 use crate::Result;
@@ -43,10 +44,108 @@ impl ProjectProvider for FileSystemProjectProvider {
     ) -> Result<PathBuf> {
         Ok(ensure_changeset_dir(project, config)?)
     }
+
+    fn discover_additional_packages(
+        &self,
+        project_root: &Path,
+        config: &RootChangesetConfig,
+    ) -> Result<Vec<PackageInfo>> {
+        Ok(discover_additional_packages(
+            project_root,
+            config.additional_packages(),
+        )?)
+    }
 }
 
 impl DependencyGraphProvider for FileSystemProjectProvider {
     fn build_dependency_graph(&self, project: &CargoProject) -> Result<WorkspaceDependencyGraph> {
         Ok(WorkspaceDependencyGraph::build(project)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use changeset_core::AdditionalPackageDeclaration;
+    use changeset_project::RootChangesetConfig;
+    use tempfile::TempDir;
+
+    use super::FileSystemProjectProvider;
+    use crate::traits::ProjectProvider;
+
+    fn make_decl(json: &str) -> AdditionalPackageDeclaration {
+        serde_json::from_str(json).expect("valid declaration JSON")
+    }
+
+    #[test]
+    fn discover_additional_packages_returns_empty_for_no_declarations() -> Result<()> {
+        let dir = TempDir::new()?;
+        let config = RootChangesetConfig::default();
+        let provider = FileSystemProjectProvider::new();
+
+        let packages = provider.discover_additional_packages(dir.path(), &config)?;
+        assert!(packages.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn discover_additional_packages_discovers_yaml_package() -> Result<()> {
+        let dir = TempDir::new()?;
+        let root = dir.path();
+
+        std::fs::create_dir_all(root.join("charts/my-chart"))?;
+        std::fs::write(
+            root.join("charts/my-chart/Chart.yaml"),
+            "version: \"1.2.3\"\n",
+        )?;
+
+        let decl = make_decl(&format!(
+            r#"{{
+                "name": "my-helm-chart",
+                "path": "charts/my-chart",
+                "influence": ["charts/my-chart/**"],
+                "manifest": {{
+                    "file-path": "{}/charts/my-chart/Chart.yaml",
+                    "format": "yaml",
+                    "version-path": "version"
+                }}
+            }}"#,
+            root.display()
+        ));
+
+        let config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let provider = FileSystemProjectProvider::new();
+
+        let packages = provider.discover_additional_packages(root, &config)?;
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name(), "my-helm-chart");
+        assert_eq!(packages[0].version(), &semver::Version::new(1, 2, 3));
+        Ok(())
+    }
+
+    #[test]
+    fn discover_additional_packages_propagates_error_for_missing_manifest() -> Result<()> {
+        let dir = TempDir::new()?;
+        let root = dir.path();
+
+        let decl = make_decl(
+            r#"{
+                "name": "missing-pkg",
+                "path": "nonexistent",
+                "influence": [],
+                "manifest": {
+                    "file-path": "/nonexistent/path/Chart.yaml",
+                    "format": "yaml",
+                    "version-path": "version"
+                }
+            }"#,
+        );
+
+        let config = RootChangesetConfig::default().with_additional_packages(vec![decl]);
+        let provider = FileSystemProjectProvider::new();
+
+        let result = provider.discover_additional_packages(root, &config);
+        assert!(result.is_err());
+        Ok(())
     }
 }

--- a/crates/changeset-operations/src/traits/additional_package_interaction.rs
+++ b/crates/changeset-operations/src/traits/additional_package_interaction.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use changeset_core::{AdditionalPackageDeclaration, ManifestFormat};
+
+use crate::Result;
+use crate::traits::MenuSelection;
+
+#[derive(Debug, Clone)]
+pub enum AdditionalPackageField {
+    Path,
+    Influence,
+    ManifestFilePath,
+    ManifestFormat,
+    ManifestVersionPath,
+}
+
+pub trait AdditionalPackageInteractionProvider: Send + Sync {
+    /// # Errors
+    /// Returns an error if the terminal interaction fails (e.g. I/O error or cancelled).
+    fn prompt_package_name(&self) -> Result<String>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn prompt_package_path(&self) -> Result<PathBuf>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn prompt_influence_patterns(&self) -> Result<Vec<String>>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn prompt_manifest_file_path(&self) -> Result<PathBuf>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails or the user cancels.
+    fn prompt_manifest_format(&self) -> Result<ManifestFormat>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn prompt_manifest_version_path(&self) -> Result<String>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn select_package_to_remove(
+        &self,
+        packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn select_package_to_edit(
+        &self,
+        packages: &[&AdditionalPackageDeclaration],
+    ) -> Result<MenuSelection<usize>>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn select_field_to_edit(&self) -> Result<MenuSelection<AdditionalPackageField>>;
+
+    /// # Errors
+    /// Returns an error if the terminal interaction fails.
+    fn confirm_removal(&self, name: &str) -> Result<bool>;
+}

--- a/crates/changeset-operations/src/traits/additional_package_interaction.rs
+++ b/crates/changeset-operations/src/traits/additional_package_interaction.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use changeset_core::{AdditionalPackageDeclaration, ManifestFormat};
 
@@ -25,7 +25,7 @@ pub trait AdditionalPackageInteractionProvider: Send + Sync {
 
     /// # Errors
     /// Returns an error if the terminal interaction fails.
-    fn prompt_influence_patterns(&self) -> Result<Vec<String>>;
+    fn prompt_influence_patterns(&self, package_path: &Path) -> Result<Vec<String>>;
 
     /// # Errors
     /// Returns an error if the terminal interaction fails.

--- a/crates/changeset-operations/src/traits/additional_package_interaction.rs
+++ b/crates/changeset-operations/src/traits/additional_package_interaction.rs
@@ -11,7 +11,7 @@ pub enum AdditionalPackageField {
     Influence,
     ManifestFilePath,
     ManifestFormat,
-    ManifestVersionPath,
+    ManifestVersionFieldPath,
 }
 
 pub trait AdditionalPackageInteractionProvider: Send + Sync {
@@ -37,7 +37,7 @@ pub trait AdditionalPackageInteractionProvider: Send + Sync {
 
     /// # Errors
     /// Returns an error if the terminal interaction fails.
-    fn prompt_manifest_version_path(&self) -> Result<String>;
+    fn prompt_manifest_version_field_path(&self) -> Result<String>;
 
     /// # Errors
     /// Returns an error if the terminal interaction fails.

--- a/crates/changeset-operations/src/traits/additional_package_writer.rs
+++ b/crates/changeset-operations/src/traits/additional_package_writer.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+
+use changeset_core::AdditionalPackageDeclaration;
+use changeset_manifest::{AdditionalPackageUpdate, MetadataSection};
+
+use crate::Result;
+
+pub trait AdditionalPackageConfigWriter: Send + Sync {
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn add_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        declaration: &AdditionalPackageDeclaration,
+    ) -> Result<()>;
+
+    /// Returns `true` if the entry was found and removed, `false` if no entry matched `name`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn remove_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        name: &str,
+    ) -> Result<bool>;
+
+    /// Returns `true` if the entry was found and updated, `false` if no entry matched `name`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn update_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        name: &str,
+        updates: &AdditionalPackageUpdate,
+    ) -> Result<bool>;
+}

--- a/crates/changeset-operations/src/traits/changeset_io.rs
+++ b/crates/changeset-operations/src/traits/changeset_io.rs
@@ -85,4 +85,17 @@ pub trait ChangesetWriter: Send + Sync {
     ///
     /// Returns an error if changesets cannot be read, parsed, or written.
     fn clear_consumed_for_prerelease(&self, changeset_dir: &Path, paths: &[&Path]) -> Result<()>;
+
+    /// Writes back a previously stored consumed-for-prerelease version string verbatim,
+    /// without parsing it. Used during saga compensation to restore the original state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if changesets cannot be read, parsed, or written.
+    fn restore_consumed_for_prerelease(
+        &self,
+        changeset_dir: &Path,
+        paths: &[&Path],
+        version: &str,
+    ) -> Result<()>;
 }

--- a/crates/changeset-operations/src/traits/git_provider.rs
+++ b/crates/changeset-operations/src/traits/git_provider.rs
@@ -5,22 +5,11 @@ use changeset_git::{CommitInfo, FileChange, TagInfo};
 use crate::Result;
 
 pub trait FullGitProvider:
-    GitDiffProvider
-    + GitWorkdirDiffProvider
-    + GitStatusProvider
-    + GitStagingProvider
-    + GitCommitProvider
-    + GitTagProvider
+    GitStatusProvider + GitStagingProvider + GitCommitProvider + GitTagProvider
 {
 }
-impl<
-    T: GitDiffProvider
-        + GitWorkdirDiffProvider
-        + GitStatusProvider
-        + GitStagingProvider
-        + GitCommitProvider
-        + GitTagProvider,
-> FullGitProvider for T
+impl<T: GitStatusProvider + GitStagingProvider + GitCommitProvider + GitTagProvider> FullGitProvider
+    for T
 {
 }
 

--- a/crates/changeset-operations/src/traits/inherited_version_checker.rs
+++ b/crates/changeset-operations/src/traits/inherited_version_checker.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use changeset_core::PackageInfo;
+use changeset_core::{CARGO_MANIFEST_FILENAME, PackageInfo};
 
 use crate::Result;
 
@@ -19,7 +19,7 @@ pub trait InheritedVersionChecker: Send + Sync {
     ) -> Result<Vec<String>> {
         let mut inherited = Vec::new();
         for pkg in packages {
-            let manifest_path = pkg.path().join("Cargo.toml");
+            let manifest_path = pkg.path().join(CARGO_MANIFEST_FILENAME);
             if self.has_inherited_version(&manifest_path)? {
                 inherited.push(pkg.name().clone());
             }

--- a/crates/changeset-operations/src/traits/inherited_version_checker.rs
+++ b/crates/changeset-operations/src/traits/inherited_version_checker.rs
@@ -59,13 +59,13 @@ mod tests {
 
     impl InheritedVersionChecker for TestChecker {
         fn has_inherited_version(&self, manifest_path: &Path) -> Result<bool> {
-            if let Some(ref fail_path) = self.fail_on {
-                if manifest_path == fail_path {
-                    return Err(crate::OperationError::Io(std::io::Error::new(
-                        std::io::ErrorKind::PermissionDenied,
-                        "mock failure",
-                    )));
-                }
+            if let Some(ref fail_path) = self.fail_on
+                && manifest_path == fail_path
+            {
+                return Err(crate::OperationError::Io(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "mock failure",
+                )));
             }
             Ok(self.inherited.contains(manifest_path))
         }

--- a/crates/changeset-operations/src/traits/manifest_writer.rs
+++ b/crates/changeset-operations/src/traits/manifest_writer.rs
@@ -98,7 +98,7 @@ pub trait ExternalManifestVersionWriter: Send + Sync {
         &self,
         manifest_path: &Path,
         format: ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
         new_version: &Version,
     ) -> Result<()>;
 
@@ -109,7 +109,7 @@ pub trait ExternalManifestVersionWriter: Send + Sync {
         &self,
         manifest_path: &Path,
         format: ManifestFormat,
-        version_path: &str,
+        version_field_path: &str,
         expected: &Version,
     ) -> Result<()>;
 }

--- a/crates/changeset-operations/src/traits/manifest_writer.rs
+++ b/crates/changeset-operations/src/traits/manifest_writer.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use changeset_core::ManifestFormat;
 use changeset_manifest::{InitConfig, MetadataSection};
 use semver::Version;
 
@@ -87,6 +88,30 @@ pub trait LockfileUpdater: Send + Sync {
     ///
     /// Returns an error if the lockfile exists but cannot be removed.
     fn remove_lockfile(&self, project_root: &Path) -> Result<()>;
+}
+
+pub trait ExternalManifestVersionWriter: Send + Sync {
+    /// # Errors
+    ///
+    /// Propagates external manifest write errors.
+    fn write_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_path: &str,
+        new_version: &Version,
+    ) -> Result<()>;
+
+    /// # Errors
+    ///
+    /// Propagates external manifest read/verification errors.
+    fn verify_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_path: &str,
+        expected: &Version,
+    ) -> Result<()>;
 }
 
 pub trait ManifestMetadataWriter: Send + Sync {

--- a/crates/changeset-operations/src/traits/manifest_writer.rs
+++ b/crates/changeset-operations/src/traits/manifest_writer.rs
@@ -112,6 +112,29 @@ pub trait ExternalManifestVersionWriter: Send + Sync {
         version_field_path: &str,
         expected: &Version,
     ) -> Result<()>;
+
+    /// # Errors
+    ///
+    /// Propagates external manifest write errors.
+    fn restore_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+        version_str: &str,
+    ) -> Result<()>;
+}
+
+pub trait ExternalManifestVersionReader: Send + Sync {
+    /// # Errors
+    ///
+    /// Propagates external manifest read errors.
+    fn read_external_version(
+        &self,
+        manifest_path: &Path,
+        format: ManifestFormat,
+        version_field_path: &str,
+    ) -> Result<String>;
 }
 
 pub trait ManifestMetadataWriter: Send + Sync {

--- a/crates/changeset-operations/src/traits/mod.rs
+++ b/crates/changeset-operations/src/traits/mod.rs
@@ -28,8 +28,8 @@ pub use manage_interaction::{
     PrereleaseInteractionProvider,
 };
 pub use manifest_writer::{
-    FullManifestWriter, LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter,
-    ManifestVersionWriter, WorkspaceVersionManager,
+    ExternalManifestVersionWriter, FullManifestWriter, LockfileUpdater, ManifestDependencyWriter,
+    ManifestMetadataWriter, ManifestVersionWriter, WorkspaceVersionManager,
 };
 pub use project_provider::{DependencyGraphProvider, ProjectProvider};
 pub use release_state_io::ReleaseStateIO;

--- a/crates/changeset-operations/src/traits/mod.rs
+++ b/crates/changeset-operations/src/traits/mod.rs
@@ -10,6 +10,7 @@ mod manage_interaction;
 mod manifest_writer;
 mod project_provider;
 mod release_state_io;
+mod version_tracking_dependency_writer;
 
 pub use additional_package_interaction::{
     AdditionalPackageField, AdditionalPackageInteractionProvider,
@@ -34,8 +35,10 @@ pub use manage_interaction::{
     PrereleaseInteractionProvider,
 };
 pub use manifest_writer::{
-    ExternalManifestVersionWriter, FullManifestWriter, LockfileUpdater, ManifestDependencyWriter,
-    ManifestMetadataWriter, ManifestVersionWriter, WorkspaceVersionManager,
+    ExternalManifestVersionReader, ExternalManifestVersionWriter, FullManifestWriter,
+    LockfileUpdater, ManifestDependencyWriter, ManifestMetadataWriter, ManifestVersionWriter,
+    WorkspaceVersionManager,
 };
 pub use project_provider::{DependencyGraphProvider, ProjectProvider};
 pub use release_state_io::ReleaseStateIO;
+pub use version_tracking_dependency_writer::VersionTrackingDependencyWriter;

--- a/crates/changeset-operations/src/traits/mod.rs
+++ b/crates/changeset-operations/src/traits/mod.rs
@@ -1,3 +1,5 @@
+mod additional_package_interaction;
+mod additional_package_writer;
 mod changelog_writer;
 mod changeset_io;
 mod git_provider;
@@ -9,6 +11,10 @@ mod manifest_writer;
 mod project_provider;
 mod release_state_io;
 
+pub use additional_package_interaction::{
+    AdditionalPackageField, AdditionalPackageInteractionProvider,
+};
+pub use additional_package_writer::AdditionalPackageConfigWriter;
 pub use changelog_writer::{ChangelogWriteResult, ChangelogWriter};
 pub use changeset_io::{ChangesetReader, ChangesetWriter};
 pub use git_provider::{

--- a/crates/changeset-operations/src/traits/project_provider.rs
+++ b/crates/changeset-operations/src/traits/project_provider.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use changeset_core::PackageInfo;
 use changeset_project::{
     CargoProject, PackageChangesetConfig, RootChangesetConfig, WorkspaceDependencyGraph,
 };
@@ -29,6 +30,15 @@ pub trait ProjectProvider: Send + Sync {
         project: &CargoProject,
         config: &RootChangesetConfig,
     ) -> Result<PathBuf>;
+
+    /// # Errors
+    ///
+    /// Returns an error if additional package manifests cannot be read.
+    fn discover_additional_packages(
+        &self,
+        project_root: &Path,
+        config: &RootChangesetConfig,
+    ) -> Result<Vec<PackageInfo>>;
 }
 
 pub trait DependencyGraphProvider: Send + Sync {

--- a/crates/changeset-operations/src/traits/version_tracking_dependency_writer.rs
+++ b/crates/changeset-operations/src/traits/version_tracking_dependency_writer.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use changeset_core::VersionTrackingDependency;
+use changeset_manifest::MetadataSection;
+
+use crate::Result;
+
+pub trait VersionTrackingDependencyWriter: Send + Sync {
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn add_dependency_to_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        package_name: &str,
+        dependency: &VersionTrackingDependency,
+    ) -> Result<bool>;
+
+    /// Returns `true` if the dependency was found and removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn remove_dependency_from_additional_package(
+        &self,
+        manifest_path: &Path,
+        section: MetadataSection,
+        package_name: &str,
+        dependency_name: &str,
+    ) -> Result<bool>;
+
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn add_dependency_to_crate(
+        &self,
+        manifest_path: &Path,
+        dependency: &VersionTrackingDependency,
+    ) -> Result<()>;
+
+    /// Returns `true` if the dependency was found and removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest file cannot be read or written.
+    fn remove_dependency_from_crate(
+        &self,
+        manifest_path: &Path,
+        dependency_name: &str,
+    ) -> Result<bool>;
+}

--- a/crates/changeset-project/Cargo.toml
+++ b/crates/changeset-project/Cargo.toml
@@ -24,6 +24,8 @@ globset = "0.4"
 gset = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yml = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -181,6 +181,16 @@ impl RootChangesetConfig {
         self.none_bump_behavior = behavior;
         self
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn with_additional_packages(
+        mut self,
+        packages: Vec<changeset_core::AdditionalPackageDeclaration>,
+    ) -> Self {
+        self.additional_packages = packages;
+        self
+    }
 }
 
 impl Default for RootChangesetConfig {

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -3,13 +3,16 @@ use std::path::{Path, PathBuf};
 
 use changeset_changelog::{ChangelogConfig, ChangelogLocation, ComparisonLinksSetting};
 use changeset_core::{
-    AdditionalPackageDeclaration, CARGO_MANIFEST_FILENAME, NoneBumpBehavior, ZeroVersionBehavior,
+    AdditionalPackageDeclaration, CARGO_MANIFEST_FILENAME, NoneBumpBehavior,
+    VersionTrackingDependency, ZeroVersionBehavior,
 };
 use changeset_git::DEFAULT_BASE_BRANCH;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use crate::error::ProjectError;
-use crate::manifest::{CargoManifest, ChangesetMetadata, TagFormatValue, read_manifest};
+use crate::manifest::{
+    CargoManifest, ChangesetMetadata, TagFormatValue, read_manifest, read_package_level_manifest,
+};
 use crate::project::{CargoProject, ProjectKind};
 
 const DEFAULT_DEPENDENCY_BUMP_CHANGELOG_TEMPLATE: &str =
@@ -217,6 +220,7 @@ impl Default for RootChangesetConfig {
 #[derive(Debug, Default)]
 pub struct PackageChangesetConfig {
     ignored_files: GlobSet,
+    additional_package_dependencies: Vec<VersionTrackingDependency>,
 }
 
 impl PackageChangesetConfig {
@@ -228,6 +232,11 @@ impl PackageChangesetConfig {
     #[must_use]
     pub fn is_ignored(&self, path: &Path) -> bool {
         self.ignored_files.is_match(path)
+    }
+
+    #[must_use]
+    pub fn additional_package_dependencies(&self) -> &[VersionTrackingDependency] {
+        &self.additional_package_dependencies
     }
 }
 
@@ -276,18 +285,29 @@ pub fn parse_root_config(project: &CargoProject) -> Result<RootChangesetConfig, 
 /// Returns `ProjectError` if the manifest cannot be read or parsed, or if glob patterns are invalid.
 pub fn parse_package_config(package_path: &Path) -> Result<PackageChangesetConfig, ProjectError> {
     let manifest_path = package_path.join(CARGO_MANIFEST_FILENAME);
-    let manifest = read_manifest(&manifest_path)?;
+    let manifest = read_package_level_manifest(&manifest_path)?;
 
-    let patterns = manifest
+    let changeset_metadata = manifest
         .package
         .and_then(|pkg| pkg.metadata)
-        .and_then(|meta| meta.changeset)
-        .map(|cs| cs.ignored_files)
+        .and_then(|meta| meta.changeset);
+
+    let patterns = changeset_metadata
+        .as_ref()
+        .map(|cs| cs.ignored_files.clone())
+        .unwrap_or_default();
+
+    let additional_package_dependencies = changeset_metadata
+        .as_ref()
+        .map(|cs| cs.additional_package_dependencies.clone())
         .unwrap_or_default();
 
     let ignored_files = build_glob_set(&patterns)?;
 
-    Ok(PackageChangesetConfig { ignored_files })
+    Ok(PackageChangesetConfig {
+        ignored_files,
+        additional_package_dependencies,
+    })
 }
 
 /// # Errors
@@ -1218,6 +1238,115 @@ version-field-path = "version"
             changeset_core::ManifestFormat::Json
         );
         assert_eq!(packages[0].manifest().version_field_path(), "version");
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_package_config_with_additional_package_dependencies() -> anyhow::Result<()> {
+        let toml = r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+
+[[package.metadata.changeset.additional-package-dependencies]]
+dependency-name = "my-helm-chart"
+
+[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
+file-path = "src/generated/upstream_version.json"
+format = "json"
+version-field-path = "upstream_version"
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_package_config(dir.path())?;
+        let deps = config.additional_package_dependencies();
+
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].dependency_name(), "my-helm-chart");
+        assert_eq!(
+            deps[0].version_tracking_manifest().file_path(),
+            Path::new("src/generated/upstream_version.json")
+        );
+        assert_eq!(
+            deps[0].version_tracking_manifest().format(),
+            changeset_core::ManifestFormat::Json
+        );
+        assert_eq!(
+            deps[0].version_tracking_manifest().version_field_path(),
+            "upstream_version"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_package_config_without_additional_package_dependencies_defaults_to_empty()
+    -> anyhow::Result<()> {
+        let toml = r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+
+[package.metadata.changeset]
+ignored-files = ["benches/**"]
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_package_config(dir.path())?;
+
+        assert!(config.additional_package_dependencies().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_additional_packages_with_dependencies() -> anyhow::Result<()> {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
+
+[[workspace.metadata.changeset.additional-packages.dependencies]]
+dependency-name = "upstream-service"
+
+[workspace.metadata.changeset.additional-packages.dependencies.version-tracking-manifest]
+file-path = "charts/my-chart/upstream_version.json"
+format = "json"
+version-field-path = "upstream_version"
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_cargo_root_config(dir.path(), CargoRootConfigType::Workspace)?;
+        let packages = config.additional_packages();
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name(), "my-helm-chart");
+
+        let deps = packages[0].dependencies();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].dependency_name(), "upstream-service");
+        assert_eq!(
+            deps[0].version_tracking_manifest().file_path(),
+            Path::new("charts/my-chart/upstream_version.json")
+        );
+        assert_eq!(
+            deps[0].version_tracking_manifest().format(),
+            changeset_core::ManifestFormat::Json
+        );
+        assert_eq!(
+            deps[0].version_tracking_manifest().version_field_path(),
+            "upstream_version"
+        );
 
         Ok(())
     }

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use changeset_changelog::{ChangelogConfig, ChangelogLocation, ComparisonLinksSetting};
-use changeset_core::ZeroVersionBehavior;
+use changeset_core::{
+    AdditionalPackageDeclaration, CARGO_MANIFEST_FILENAME, NoneBumpBehavior, ZeroVersionBehavior,
+};
 use changeset_git::DEFAULT_BASE_BRANCH;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use crate::error::ProjectError;
-use crate::manifest::{ChangesetMetadata, TagFormatValue, read_manifest};
+use crate::manifest::{CargoManifest, ChangesetMetadata, TagFormatValue, read_manifest};
 use crate::project::{CargoProject, ProjectKind};
 
 const DEFAULT_DEPENDENCY_BUMP_CHANGELOG_TEMPLATE: &str =
@@ -107,6 +109,7 @@ pub struct RootChangesetConfig {
     base_branch: String,
     none_bump_behavior: changeset_core::NoneBumpBehavior,
     none_bump_promote_message_template: String,
+    additional_packages: Vec<changeset_core::AdditionalPackageDeclaration>,
 }
 
 impl RootChangesetConfig {
@@ -160,6 +163,11 @@ impl RootChangesetConfig {
         &self.none_bump_promote_message_template
     }
 
+    #[must_use]
+    pub fn additional_packages(&self) -> &[changeset_core::AdditionalPackageDeclaration] {
+        &self.additional_packages
+    }
+
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn with_git_config(mut self, git_config: GitConfig) -> Self {
@@ -191,6 +199,7 @@ impl Default for RootChangesetConfig {
             none_bump_promote_message_template: String::from(
                 DEFAULT_NONE_BUMP_PROMOTE_MESSAGE_TEMPLATE,
             ),
+            additional_packages: Vec::new(),
         }
     }
 }
@@ -218,6 +227,21 @@ enum CargoRootConfigType {
     Package,
 }
 
+struct RootConfigFields {
+    patterns: Vec<String>,
+    changeset_dir: String,
+    zero_version_behavior: ZeroVersionBehavior,
+    dependency_bump_changelog_template: String,
+    base_branch: String,
+    none_bump_behavior: NoneBumpBehavior,
+    none_bump_promote_message_template: String,
+    additional_packages: Vec<AdditionalPackageDeclaration>,
+    changelog: Option<ChangelogLocation>,
+    comparison_links: Option<ComparisonLinksSetting>,
+    comparison_links_template: Option<String>,
+    git_metadata: Option<ChangesetMetadata>,
+}
+
 /// Parses the root changeset configuration based on project kind.
 ///
 /// For single-package projects, reads from `[package.metadata.changeset]`.
@@ -241,7 +265,7 @@ pub fn parse_root_config(project: &CargoProject) -> Result<RootChangesetConfig, 
 ///
 /// Returns `ProjectError` if the manifest cannot be read or parsed, or if glob patterns are invalid.
 pub fn parse_package_config(package_path: &Path) -> Result<PackageChangesetConfig, ProjectError> {
-    let manifest_path = package_path.join("Cargo.toml");
+    let manifest_path = package_path.join(CARGO_MANIFEST_FILENAME);
     let manifest = read_manifest(&manifest_path)?;
 
     let patterns = manifest
@@ -288,6 +312,65 @@ fn build_glob_set(patterns: &[String]) -> Result<GlobSet, ProjectError> {
     })
 }
 
+fn extract_changeset_metadata(
+    manifest: CargoManifest,
+    config_type: CargoRootConfigType,
+) -> Option<ChangesetMetadata> {
+    match config_type {
+        CargoRootConfigType::Workspace => manifest
+            .workspace
+            .and_then(|ws| ws.metadata)
+            .and_then(|meta| meta.changeset),
+        CargoRootConfigType::Package => manifest
+            .package
+            .and_then(|pkg| pkg.metadata)
+            .and_then(|meta| meta.changeset),
+    }
+}
+
+fn extract_root_config_fields(metadata: Option<ChangesetMetadata>) -> RootConfigFields {
+    RootConfigFields {
+        patterns: metadata
+            .as_ref()
+            .map(|cs| cs.ignored_files.clone())
+            .unwrap_or_default(),
+        changeset_dir: metadata
+            .as_ref()
+            .and_then(|cs| cs.changeset_dir.clone())
+            .unwrap_or_else(|| crate::DEFAULT_CHANGESET_DIR.to_string()),
+        zero_version_behavior: metadata
+            .as_ref()
+            .and_then(|cs| cs.zero_version_behavior)
+            .unwrap_or_default(),
+        dependency_bump_changelog_template: metadata
+            .as_ref()
+            .and_then(|cs| cs.dependency_bump_changelog_template.clone())
+            .unwrap_or_else(|| String::from(DEFAULT_DEPENDENCY_BUMP_CHANGELOG_TEMPLATE)),
+        base_branch: metadata
+            .as_ref()
+            .and_then(|cs| cs.base_branch.clone())
+            .unwrap_or_else(|| String::from(DEFAULT_BASE_BRANCH)),
+        none_bump_behavior: metadata
+            .as_ref()
+            .and_then(|cs| cs.none_bump_behavior)
+            .unwrap_or_default(),
+        none_bump_promote_message_template: metadata
+            .as_ref()
+            .and_then(|cs| cs.none_bump_promote_message_template.clone())
+            .unwrap_or_else(|| String::from(DEFAULT_NONE_BUMP_PROMOTE_MESSAGE_TEMPLATE)),
+        additional_packages: metadata
+            .as_ref()
+            .map(|cs| cs.additional_packages.clone())
+            .unwrap_or_default(),
+        changelog: metadata.as_ref().and_then(|cs| cs.changelog),
+        comparison_links: metadata.as_ref().and_then(|cs| cs.comparison_links),
+        comparison_links_template: metadata
+            .as_ref()
+            .and_then(|cs| cs.comparison_links_template.clone()),
+        git_metadata: metadata,
+    }
+}
+
 fn build_changelog_config(
     changelog: Option<ChangelogLocation>,
     comparison_links: Option<ComparisonLinksSetting>,
@@ -327,79 +410,25 @@ fn parse_cargo_root_config(
     project_root: &Path,
     config_type: CargoRootConfigType,
 ) -> Result<RootChangesetConfig, ProjectError> {
-    let manifest_path = project_root.join("Cargo.toml");
-    let manifest = read_manifest(&manifest_path)?;
-
-    let changeset_metadata = match config_type {
-        CargoRootConfigType::Workspace => manifest
-            .workspace
-            .and_then(|ws| ws.metadata)
-            .and_then(|meta| meta.changeset),
-        CargoRootConfigType::Package => manifest
-            .package
-            .and_then(|pkg| pkg.metadata)
-            .and_then(|meta| meta.changeset),
-    };
-
-    let patterns = changeset_metadata
-        .as_ref()
-        .map(|cs| cs.ignored_files.clone())
-        .unwrap_or_default();
-
-    let changeset_dir = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.changeset_dir.clone())
-        .unwrap_or_else(|| crate::DEFAULT_CHANGESET_DIR.to_string());
-
-    let ignored_files = build_glob_set(&patterns)?;
-
-    let changelog_config = build_changelog_config(
-        changeset_metadata.as_ref().and_then(|cs| cs.changelog),
-        changeset_metadata
-            .as_ref()
-            .and_then(|cs| cs.comparison_links),
-        changeset_metadata
-            .as_ref()
-            .and_then(|cs| cs.comparison_links_template.clone()),
-    );
-
-    let git_config = build_git_config(changeset_metadata.as_ref());
-
-    let zero_version_behavior = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.zero_version_behavior)
-        .unwrap_or_default();
-
-    let dependency_bump_changelog_template = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.dependency_bump_changelog_template.clone())
-        .unwrap_or_else(|| String::from(DEFAULT_DEPENDENCY_BUMP_CHANGELOG_TEMPLATE));
-
-    let base_branch = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.base_branch.clone())
-        .unwrap_or_else(|| String::from(DEFAULT_BASE_BRANCH));
-
-    let none_bump_behavior = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.none_bump_behavior)
-        .unwrap_or_default();
-
-    let none_bump_promote_message_template = changeset_metadata
-        .as_ref()
-        .and_then(|cs| cs.none_bump_promote_message_template.clone())
-        .unwrap_or_else(|| String::from(DEFAULT_NONE_BUMP_PROMOTE_MESSAGE_TEMPLATE));
+    let manifest = read_manifest(&project_root.join(CARGO_MANIFEST_FILENAME))?;
+    let metadata = extract_changeset_metadata(manifest, config_type);
+    let fields = extract_root_config_fields(metadata);
 
     Ok(RootChangesetConfig {
-        ignored_files,
-        changeset_dir: PathBuf::from(changeset_dir),
-        changelog_config,
-        git_config,
-        zero_version_behavior,
-        dependency_bump_changelog_template,
-        base_branch,
-        none_bump_behavior,
-        none_bump_promote_message_template,
+        ignored_files: build_glob_set(&fields.patterns)?,
+        changeset_dir: PathBuf::from(fields.changeset_dir),
+        changelog_config: build_changelog_config(
+            fields.changelog,
+            fields.comparison_links,
+            fields.comparison_links_template,
+        ),
+        git_config: build_git_config(fields.git_metadata.as_ref()),
+        zero_version_behavior: fields.zero_version_behavior,
+        dependency_bump_changelog_template: fields.dependency_bump_changelog_template,
+        base_branch: fields.base_branch,
+        none_bump_behavior: fields.none_bump_behavior,
+        none_bump_promote_message_template: fields.none_bump_promote_message_template,
+        additional_packages: fields.additional_packages,
     })
 }
 
@@ -1041,6 +1070,144 @@ members = ["crates/*"]
             config.none_bump_promote_message_template(),
             "Internal architectural changes"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_additional_packages_from_workspace_metadata() -> anyhow::Result<()> {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-path = "version"
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_cargo_root_config(dir.path(), CargoRootConfigType::Workspace)?;
+        let packages = config.additional_packages();
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name(), "my-helm-chart");
+        assert_eq!(packages[0].path(), Path::new("charts/my-chart"));
+        assert_eq!(packages[0].influence(), &["charts/my-chart/**"]);
+        assert_eq!(
+            packages[0].manifest().file_path(),
+            Path::new("charts/my-chart/Chart.yaml")
+        );
+        assert_eq!(
+            packages[0].manifest().format(),
+            changeset_core::ManifestFormat::Yaml
+        );
+        assert_eq!(packages[0].manifest().version_path(), "version");
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_additional_packages_empty_by_default() -> anyhow::Result<()> {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_cargo_root_config(dir.path(), CargoRootConfigType::Workspace)?;
+
+        assert!(config.additional_packages().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_multiple_additional_packages() -> anyhow::Result<()> {
+        let toml = r#"
+[workspace]
+members = ["crates/*"]
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-path = "version"
+
+[[workspace.metadata.changeset.additional-packages]]
+name = "my-npm-package"
+path = "frontend"
+influence = ["frontend/**"]
+
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "frontend/package.json"
+format = "json"
+version-path = "version"
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_cargo_root_config(dir.path(), CargoRootConfigType::Workspace)?;
+        let packages = config.additional_packages();
+
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].name(), "my-helm-chart");
+        assert_eq!(
+            packages[0].manifest().format(),
+            changeset_core::ManifestFormat::Yaml
+        );
+        assert_eq!(packages[1].name(), "my-npm-package");
+        assert_eq!(
+            packages[1].manifest().format(),
+            changeset_core::ManifestFormat::Json
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_additional_packages_from_package_metadata() -> anyhow::Result<()> {
+        let toml = r#"
+[package]
+name = "my-crate"
+version = "0.1.0"
+
+[[package.metadata.changeset.additional-packages]]
+name = "my-npm-package"
+path = "frontend"
+influence = ["frontend/**"]
+
+[package.metadata.changeset.additional-packages.manifest]
+file-path = "frontend/package.json"
+format = "json"
+version-path = "version"
+"#;
+        let dir = setup_with_config(toml)?;
+
+        let config = parse_cargo_root_config(dir.path(), CargoRootConfigType::Package)?;
+        let packages = config.additional_packages();
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name(), "my-npm-package");
+        assert_eq!(packages[0].path(), Path::new("frontend"));
+        assert_eq!(packages[0].influence(), &["frontend/**"]);
+        assert_eq!(
+            packages[0].manifest().file_path(),
+            Path::new("frontend/package.json")
+        );
+        assert_eq!(
+            packages[0].manifest().format(),
+            changeset_core::ManifestFormat::Json
+        );
+        assert_eq!(packages[0].manifest().version_path(), "version");
 
         Ok(())
     }

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -238,6 +238,16 @@ impl PackageChangesetConfig {
     pub fn additional_package_dependencies(&self) -> &[VersionTrackingDependency] {
         &self.additional_package_dependencies
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn with_additional_package_dependencies(
+        mut self,
+        deps: Vec<VersionTrackingDependency>,
+    ) -> Self {
+        self.additional_package_dependencies = deps;
+        self
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/crates/changeset-project/src/config.rs
+++ b/crates/changeset-project/src/config.rs
@@ -1098,7 +1098,7 @@ influence = ["charts/my-chart/**"]
 [workspace.metadata.changeset.additional-packages.manifest]
 file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
-version-path = "version"
+version-field-path = "version"
 "#;
         let dir = setup_with_config(toml)?;
 
@@ -1117,7 +1117,7 @@ version-path = "version"
             packages[0].manifest().format(),
             changeset_core::ManifestFormat::Yaml
         );
-        assert_eq!(packages[0].manifest().version_path(), "version");
+        assert_eq!(packages[0].manifest().version_field_path(), "version");
 
         Ok(())
     }
@@ -1151,7 +1151,7 @@ influence = ["charts/my-chart/**"]
 [workspace.metadata.changeset.additional-packages.manifest]
 file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
-version-path = "version"
+version-field-path = "version"
 
 [[workspace.metadata.changeset.additional-packages]]
 name = "my-npm-package"
@@ -1161,7 +1161,7 @@ influence = ["frontend/**"]
 [workspace.metadata.changeset.additional-packages.manifest]
 file-path = "frontend/package.json"
 format = "json"
-version-path = "version"
+version-field-path = "version"
 "#;
         let dir = setup_with_config(toml)?;
 
@@ -1198,7 +1198,7 @@ influence = ["frontend/**"]
 [package.metadata.changeset.additional-packages.manifest]
 file-path = "frontend/package.json"
 format = "json"
-version-path = "version"
+version-field-path = "version"
 "#;
         let dir = setup_with_config(toml)?;
 
@@ -1217,7 +1217,7 @@ version-path = "version"
             packages[0].manifest().format(),
             changeset_core::ManifestFormat::Json
         );
-        assert_eq!(packages[0].manifest().version_path(), "version");
+        assert_eq!(packages[0].manifest().version_field_path(), "version");
 
         Ok(())
     }

--- a/crates/changeset-project/src/config_validation.rs
+++ b/crates/changeset-project/src/config_validation.rs
@@ -1,0 +1,289 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::BuildHasher;
+
+use crate::config::{PackageChangesetConfig, RootChangesetConfig};
+use crate::error::ProjectError;
+
+/// # Errors
+///
+/// Returns `ProjectError` if any version tracking dependency references an unknown package,
+/// if circular dependencies are detected, or if duplicate dependency entries exist.
+pub fn validate_version_tracking_dependencies<S: BuildHasher, S2: BuildHasher>(
+    root_config: &RootChangesetConfig,
+    package_configs: &HashMap<String, PackageChangesetConfig, S>,
+    all_package_names: &HashSet<String, S2>,
+) -> Result<(), ProjectError> {
+    let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
+
+    for declaration in root_config.additional_packages() {
+        for dep in declaration.dependencies() {
+            check_entry(
+                declaration.name(),
+                dep.dependency_name(),
+                all_package_names,
+                &mut seen_pairs,
+            )?;
+        }
+    }
+
+    for (package_name, config) in package_configs {
+        for dep in config.additional_package_dependencies() {
+            check_entry(
+                package_name,
+                dep.dependency_name(),
+                all_package_names,
+                &mut seen_pairs,
+            )?;
+        }
+    }
+
+    detect_circular_dependencies(&seen_pairs)
+}
+
+fn check_entry<S2: BuildHasher>(
+    dependent: &str,
+    dependency: &str,
+    all_package_names: &HashSet<String, S2>,
+    seen_pairs: &mut HashSet<(String, String)>,
+) -> Result<(), ProjectError> {
+    if !all_package_names.contains(dependency) {
+        return Err(ProjectError::UnknownVersionTrackingDependency {
+            dependent: dependent.to_string(),
+            dependency: dependency.to_string(),
+        });
+    }
+
+    let pair = (dependent.to_string(), dependency.to_string());
+    if !seen_pairs.insert(pair) {
+        return Err(ProjectError::DuplicateVersionTrackingDependency {
+            dependent: dependent.to_string(),
+            dependency: dependency.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn detect_circular_dependencies(edges: &HashSet<(String, String)>) -> Result<(), ProjectError> {
+    let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut all_nodes: HashSet<&str> = HashSet::new();
+
+    for (from, to) in edges {
+        adjacency
+            .entry(from.as_str())
+            .or_default()
+            .push(to.as_str());
+        all_nodes.insert(from.as_str());
+        all_nodes.insert(to.as_str());
+    }
+
+    let mut visited: HashSet<&str> = HashSet::new();
+    let mut in_stack: HashSet<&str> = HashSet::new();
+
+    for &node in &all_nodes {
+        if !visited.contains(node)
+            && let Some((a, b)) = dfs_find_cycle(node, &adjacency, &mut visited, &mut in_stack)
+        {
+            let (package_a, package_b) = if a < b { (a, b) } else { (b, a) };
+            return Err(ProjectError::CircularVersionTrackingDependency {
+                package_a: package_a.to_string(),
+                package_b: package_b.to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn dfs_find_cycle<'a>(
+    node: &'a str,
+    adjacency: &HashMap<&'a str, Vec<&'a str>>,
+    visited: &mut HashSet<&'a str>,
+    in_stack: &mut HashSet<&'a str>,
+) -> Option<(&'a str, &'a str)> {
+    visited.insert(node);
+    in_stack.insert(node);
+
+    if let Some(neighbors) = adjacency.get(node) {
+        for &neighbor in neighbors {
+            if !visited.contains(neighbor) {
+                if let Some(cycle) = dfs_find_cycle(neighbor, adjacency, visited, in_stack) {
+                    return Some(cycle);
+                }
+            } else if in_stack.contains(neighbor) {
+                return Some((neighbor, node));
+            }
+        }
+    }
+
+    in_stack.remove(node);
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use changeset_core::{
+        AdditionalPackageDeclaration, AdditionalPackageManifest, ManifestFormat,
+        VersionTrackingDependency, VersionTrackingManifest,
+    };
+
+    use super::*;
+
+    fn make_tracking_manifest() -> VersionTrackingManifest {
+        VersionTrackingManifest::new(
+            PathBuf::from("tracking/version.json"),
+            ManifestFormat::Json,
+            "version".to_string(),
+        )
+    }
+
+    fn make_tracking_dep(dep_name: &str) -> VersionTrackingDependency {
+        VersionTrackingDependency::new(dep_name.to_string(), make_tracking_manifest())
+    }
+
+    fn make_additional_package(
+        name: &str,
+        deps: Vec<VersionTrackingDependency>,
+    ) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(format!("packages/{name}")),
+            vec![format!("packages/{name}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("packages/{name}/manifest.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            deps,
+        )
+    }
+
+    #[test]
+    fn validate_with_known_dependencies_passes() {
+        let dep = make_tracking_dep("crate-a");
+        let declaration = make_additional_package("my-chart", vec![dep]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![declaration]);
+        let package_configs = HashMap::new();
+        let all_names: HashSet<String> = ["my-chart", "crate-a"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let result =
+            validate_version_tracking_dependencies(&root_config, &package_configs, &all_names);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_detects_unknown_dependency() {
+        let dep = make_tracking_dep("nonexistent-pkg");
+        let declaration = make_additional_package("my-chart", vec![dep]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![declaration]);
+        let package_configs = HashMap::new();
+        let all_names: HashSet<String> = ["my-chart"].iter().map(|s| (*s).to_string()).collect();
+
+        let result =
+            validate_version_tracking_dependencies(&root_config, &package_configs, &all_names);
+
+        assert!(result.is_err());
+        let err = result.expect_err("should detect unknown dependency");
+        assert!(matches!(
+            err,
+            ProjectError::UnknownVersionTrackingDependency {
+                ref dependency, ..
+            } if dependency == "nonexistent-pkg"
+        ));
+    }
+
+    #[test]
+    fn validate_detects_circular_dependency() {
+        let dep_a_to_b = make_tracking_dep("pkg-b");
+        let declaration_a = make_additional_package("pkg-a", vec![dep_a_to_b]);
+
+        let dep_b_to_a = make_tracking_dep("pkg-a");
+        let declaration_b = make_additional_package("pkg-b", vec![dep_b_to_a]);
+
+        let root_config = RootChangesetConfig::default()
+            .with_additional_packages(vec![declaration_a, declaration_b]);
+        let package_configs = HashMap::new();
+        let all_names: HashSet<String> = ["pkg-a", "pkg-b"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let result =
+            validate_version_tracking_dependencies(&root_config, &package_configs, &all_names);
+
+        assert!(result.is_err());
+        let err = result.expect_err("should detect circular dependency");
+        assert!(matches!(
+            err,
+            ProjectError::CircularVersionTrackingDependency { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_detects_transitive_circular_dependency() {
+        let dep_a_to_b = make_tracking_dep("pkg-b");
+        let declaration_a = make_additional_package("pkg-a", vec![dep_a_to_b]);
+
+        let dep_b_to_c = make_tracking_dep("pkg-c");
+        let declaration_b = make_additional_package("pkg-b", vec![dep_b_to_c]);
+
+        let dep_c_to_a = make_tracking_dep("pkg-a");
+        let declaration_c = make_additional_package("pkg-c", vec![dep_c_to_a]);
+
+        let root_config = RootChangesetConfig::default().with_additional_packages(vec![
+            declaration_a,
+            declaration_b,
+            declaration_c,
+        ]);
+        let package_configs = HashMap::new();
+        let all_names: HashSet<String> = ["pkg-a", "pkg-b", "pkg-c"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let result =
+            validate_version_tracking_dependencies(&root_config, &package_configs, &all_names);
+
+        assert!(result.is_err());
+        let err = result.expect_err("should detect transitive circular dependency");
+        assert!(matches!(
+            err,
+            ProjectError::CircularVersionTrackingDependency { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_detects_duplicate_dependency() {
+        let dep1 = make_tracking_dep("crate-a");
+        let dep2 = make_tracking_dep("crate-a");
+        let declaration = make_additional_package("my-chart", vec![dep1, dep2]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![declaration]);
+        let package_configs = HashMap::new();
+        let all_names: HashSet<String> = ["my-chart", "crate-a"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let result =
+            validate_version_tracking_dependencies(&root_config, &package_configs, &all_names);
+
+        assert!(result.is_err());
+        let err = result.expect_err("should detect duplicate dependency");
+        assert!(matches!(
+            err,
+            ProjectError::DuplicateVersionTrackingDependency {
+                ref dependent,
+                ref dependency,
+            } if dependent == "my-chart" && dependency == "crate-a"
+        ));
+    }
+}

--- a/crates/changeset-project/src/dependency_graph.rs
+++ b/crates/changeset-project/src/dependency_graph.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use changeset_core::CARGO_MANIFEST_FILENAME;
+
 use crate::error::ProjectError;
 use crate::manifest::{DependencyEntry, read_manifest};
 use crate::project::CargoProject;
@@ -34,7 +36,7 @@ impl WorkspaceDependencyGraph {
             .collect();
 
         for package in project.packages() {
-            let manifest_path = package.path().join("Cargo.toml");
+            let manifest_path = package.path().join(CARGO_MANIFEST_FILENAME);
             let manifest = read_manifest(&manifest_path)?;
 
             let dep_sections = [manifest.dependencies, manifest.build_dependencies];

--- a/crates/changeset-project/src/dependency_graph.rs
+++ b/crates/changeset-project/src/dependency_graph.rs
@@ -138,6 +138,30 @@ impl WorkspaceDependencyGraph {
         result
     }
 
+    pub fn add_members(&mut self, names: impl IntoIterator<Item = String>) {
+        for name in names {
+            self.depended_on_by.entry(name.clone()).or_default();
+            self.depends_on.entry(name).or_default();
+        }
+    }
+
+    pub fn extend_with_edges(&mut self, edges: &[(String, String)]) {
+        for (dependent, dependency) in edges {
+            if self.depended_on_by.contains_key(dependent.as_str())
+                && self.depended_on_by.contains_key(dependency.as_str())
+            {
+                self.depends_on
+                    .entry(dependent.clone())
+                    .or_default()
+                    .insert(dependency.clone());
+                self.depended_on_by
+                    .entry(dependency.clone())
+                    .or_default()
+                    .insert(dependent.clone());
+            }
+        }
+    }
+
     #[must_use]
     pub fn direct_dependencies(&self, package: &str) -> HashSet<&str> {
         self.depends_on
@@ -320,5 +344,81 @@ mod tests {
             package: Some("actual-name".to_string()),
         });
         assert_eq!(resolve_package_name("alias", &entry), "actual-name");
+    }
+
+    #[test]
+    fn extend_with_edges_adds_forward_and_reverse_edges() {
+        let mut graph = WorkspaceDependencyGraph::from_edges(
+            &member_set(&["a", "b", "c"]),
+            &edges(&[("b", "a")]),
+        );
+
+        graph.extend_with_edges(&edges(&[("c", "b")]));
+
+        let deps_c = graph.direct_dependencies("c");
+        assert_eq!(deps_c, HashSet::from(["b"]));
+
+        let dependents_b = graph.transitive_dependents("b");
+        assert!(dependents_b.contains("c"));
+    }
+
+    #[test]
+    fn extend_with_edges_ignores_unknown_members() {
+        let mut graph =
+            WorkspaceDependencyGraph::from_edges(&member_set(&["a", "b"]), &edges(&[("b", "a")]));
+
+        graph.extend_with_edges(&edges(&[("a", "unknown"), ("unknown", "b")]));
+
+        assert!(graph.direct_dependencies("a").is_empty());
+        assert_eq!(graph.direct_dependencies("b"), HashSet::from(["a"]));
+        assert!(graph.transitive_dependents("b").is_empty());
+    }
+
+    #[test]
+    fn add_members_then_extend_with_edges_allows_cross_type_dependencies() {
+        let mut graph = WorkspaceDependencyGraph::from_edges(&member_set(&["rust-crate"]), &[]);
+
+        graph.add_members(vec!["helm-chart".to_string()]);
+        graph.extend_with_edges(&edges(&[("helm-chart", "rust-crate")]));
+
+        let deps = graph.direct_dependencies("helm-chart");
+        assert_eq!(deps, HashSet::from(["rust-crate"]));
+    }
+
+    #[test]
+    fn transitive_dependents_works_across_extended_edges() {
+        let mut graph = WorkspaceDependencyGraph::from_edges(
+            &member_set(&["core", "lib"]),
+            &edges(&[("lib", "core")]),
+        );
+
+        graph.add_members(vec!["chart".to_string()]);
+        graph.extend_with_edges(&edges(&[("chart", "lib")]));
+
+        let result = graph.transitive_dependents_of_set(&["core"]);
+        assert!(result.contains("lib"));
+        assert!(result.contains("chart"));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn add_members_is_idempotent_for_existing_names() {
+        let mut graph =
+            WorkspaceDependencyGraph::from_edges(&member_set(&["a", "b"]), &edges(&[("a", "b")]));
+
+        graph.add_members(vec!["a".to_string()]);
+
+        assert_eq!(graph.direct_dependencies("a"), HashSet::from(["b"]));
+        assert_eq!(graph.transitive_dependents("b"), HashSet::from(["a"]));
+    }
+
+    #[test]
+    fn add_members_with_empty_iterator_is_noop() {
+        let mut graph =
+            WorkspaceDependencyGraph::from_edges(&member_set(&["a", "b"]), &edges(&[("a", "b")]));
+
+        graph.add_members(Vec::<String>::new());
+
+        assert_eq!(graph.direct_dependencies("a"), HashSet::from(["b"]));
     }
 }

--- a/crates/changeset-project/src/error.rs
+++ b/crates/changeset-project/src/error.rs
@@ -64,4 +64,24 @@ pub enum ProjectError {
         #[source]
         source: std::io::Error,
     },
+
+    #[error("failed to parse JSON at '{path}'")]
+    JsonParse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("failed to parse YAML at '{path}'")]
+    YamlParse {
+        path: PathBuf,
+        #[source]
+        source: serde_yml::Error,
+    },
+
+    #[error("version path '{version_path}' not found in external manifest at '{path}'")]
+    ExternalVersionPathNotFound { path: PathBuf, version_path: String },
+
+    #[error("expected string at version path '{version_path}' in external manifest at '{path}'")]
+    ExternalVersionNotString { path: PathBuf, version_path: String },
 }

--- a/crates/changeset-project/src/error.rs
+++ b/crates/changeset-project/src/error.rs
@@ -79,9 +79,17 @@ pub enum ProjectError {
         source: serde_yml::Error,
     },
 
-    #[error("version path '{version_path}' not found in external manifest at '{path}'")]
-    ExternalVersionPathNotFound { path: PathBuf, version_path: String },
+    #[error("version path '{version_field_path}' not found in external manifest at '{path}'")]
+    ExternalVersionPathNotFound {
+        path: PathBuf,
+        version_field_path: String,
+    },
 
-    #[error("expected string at version path '{version_path}' in external manifest at '{path}'")]
-    ExternalVersionNotString { path: PathBuf, version_path: String },
+    #[error(
+        "expected string at version path '{version_field_path}' in external manifest at '{path}'"
+    )]
+    ExternalVersionNotString {
+        path: PathBuf,
+        version_field_path: String,
+    },
 }

--- a/crates/changeset-project/src/error.rs
+++ b/crates/changeset-project/src/error.rs
@@ -92,4 +92,22 @@ pub enum ProjectError {
         path: PathBuf,
         version_field_path: String,
     },
+
+    #[error("unknown version tracking dependency '{dependency}' referenced by '{dependent}'")]
+    UnknownVersionTrackingDependency {
+        dependent: String,
+        dependency: String,
+    },
+
+    #[error("circular version tracking dependency between '{package_a}' and '{package_b}'")]
+    CircularVersionTrackingDependency {
+        package_a: String,
+        package_b: String,
+    },
+
+    #[error("duplicate version tracking dependency '{dependency}' declared by '{dependent}'")]
+    DuplicateVersionTrackingDependency {
+        dependent: String,
+        dependency: String,
+    },
 }

--- a/crates/changeset-project/src/external_manifest.rs
+++ b/crates/changeset-project/src/external_manifest.rs
@@ -1,0 +1,223 @@
+use std::path::Path;
+
+use changeset_core::types::ManifestFormat;
+use semver::Version;
+
+use crate::error::ProjectError;
+
+trait ValueAccess {
+    fn get_field(&self, key: &str) -> Option<&Self>;
+    fn as_str_value(&self) -> Option<String>;
+}
+
+impl ValueAccess for serde_json::Value {
+    fn get_field(&self, key: &str) -> Option<&Self> {
+        self.get(key)
+    }
+
+    fn as_str_value(&self) -> Option<String> {
+        self.as_str().map(String::from)
+    }
+}
+
+impl ValueAccess for serde_yml::Value {
+    fn get_field(&self, key: &str) -> Option<&Self> {
+        self.get(key)
+    }
+
+    fn as_str_value(&self) -> Option<String> {
+        if let Some(s) = self.as_str() {
+            return Some(s.to_string());
+        }
+        if let Some(f) = self.as_f64() {
+            let s = format!("{f}");
+            let parts = s.split('.').count();
+            let normalized = match parts {
+                1 => format!("{s}.0.0"),
+                2 => format!("{s}.0"),
+                _ => s,
+            };
+            return Some(normalized);
+        }
+        if let Some(i) = self.as_i64() {
+            return Some(format!("{i}.0.0"));
+        }
+        if let Some(u) = self.as_u64() {
+            return Some(format!("{u}.0.0"));
+        }
+        None
+    }
+}
+
+impl ValueAccess for toml::Value {
+    fn get_field(&self, key: &str) -> Option<&Self> {
+        self.get(key)
+    }
+
+    fn as_str_value(&self) -> Option<String> {
+        self.as_str().map(String::from)
+    }
+}
+
+fn resolve_dot_path<V: ValueAccess>(
+    root: &V,
+    path: &Path,
+    version_path: &str,
+) -> Result<String, ProjectError> {
+    let mut current = root;
+    for segment in version_path.split('.') {
+        current = current.get_field(segment).ok_or_else(|| {
+            ProjectError::ExternalVersionPathNotFound {
+                path: path.to_path_buf(),
+                version_path: version_path.to_string(),
+            }
+        })?;
+    }
+    current
+        .as_str_value()
+        .ok_or_else(|| ProjectError::ExternalVersionNotString {
+            path: path.to_path_buf(),
+            version_path: version_path.to_string(),
+        })
+}
+
+pub(crate) fn read_external_version(
+    path: &Path,
+    format: ManifestFormat,
+    version_path: &str,
+) -> Result<Version, ProjectError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ProjectError::ManifestRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let version_str = match format {
+        ManifestFormat::Json => {
+            let value: serde_json::Value =
+                serde_json::from_str(&content).map_err(|source| ProjectError::JsonParse {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+            resolve_dot_path(&value, path, version_path)?
+        }
+        ManifestFormat::Yaml => {
+            let value: serde_yml::Value =
+                serde_yml::from_str(&content).map_err(|source| ProjectError::YamlParse {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+            resolve_dot_path(&value, path, version_path)?
+        }
+        ManifestFormat::Toml => {
+            let value: toml::Value =
+                toml::from_str(&content).map_err(|source| ProjectError::ManifestParse {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+            resolve_dot_path(&value, path, version_path)?
+        }
+    };
+
+    version_str
+        .parse::<Version>()
+        .map_err(|source| ProjectError::InvalidVersion {
+            path: path.to_path_buf(),
+            version: version_str,
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn reads_json_version_flat_path() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), r#"{ "version": "1.2.3" }"#)?;
+        let v = read_external_version(file.path(), ManifestFormat::Json, "version")?;
+        assert_eq!(v, Version::new(1, 2, 3));
+        Ok(())
+    }
+
+    #[test]
+    fn reads_json_version_nested_path() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), r#"{ "metadata": { "version": "2.0.0" } }"#)?;
+        let v = read_external_version(file.path(), ManifestFormat::Json, "metadata.version")?;
+        assert_eq!(v, Version::new(2, 0, 0));
+        Ok(())
+    }
+
+    #[test]
+    fn reads_yaml_version_simple() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), "version: \"1.0.0\"\n")?;
+        let v = read_external_version(file.path(), ManifestFormat::Yaml, "version")?;
+        assert_eq!(v, Version::new(1, 0, 0));
+        Ok(())
+    }
+
+    #[test]
+    fn reads_yaml_version_nested() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), "metadata:\n  version: \"3.1.4\"\n")?;
+        let v = read_external_version(file.path(), ManifestFormat::Yaml, "metadata.version")?;
+        assert_eq!(v, Version::new(3, 1, 4));
+        Ok(())
+    }
+
+    #[test]
+    fn reads_toml_version_nested() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), "[package]\nversion = \"1.0.0\"\n")?;
+        let v = read_external_version(file.path(), ManifestFormat::Toml, "package.version")?;
+        assert_eq!(v, Version::new(1, 0, 0));
+        Ok(())
+    }
+
+    #[test]
+    fn returns_error_for_missing_version_path() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), r#"{ "name": "my-pkg" }"#)?;
+        let result = read_external_version(file.path(), ManifestFormat::Json, "version");
+        assert!(matches!(
+            result,
+            Err(ProjectError::ExternalVersionPathNotFound { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn returns_error_for_non_string_version() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), r#"{ "version": { "major": 1 } }"#)?;
+        let result = read_external_version(file.path(), ManifestFormat::Json, "version");
+        assert!(matches!(
+            result,
+            Err(ProjectError::ExternalVersionNotString { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn returns_error_for_invalid_semver() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), r#"{ "version": "not-a-version" }"#)?;
+        let result = read_external_version(file.path(), ManifestFormat::Json, "version");
+        assert!(matches!(result, Err(ProjectError::InvalidVersion { .. })));
+        Ok(())
+    }
+
+    #[test]
+    fn reads_yaml_numeric_version() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), "version: 1.0\n")?;
+        let v = read_external_version(file.path(), ManifestFormat::Yaml, "version")?;
+        assert_eq!(v, Version::new(1, 0, 0));
+        Ok(())
+    }
+}

--- a/crates/changeset-project/src/external_manifest.rs
+++ b/crates/changeset-project/src/external_manifest.rs
@@ -62,14 +62,14 @@ impl ValueAccess for toml::Value {
 fn resolve_dot_path<V: ValueAccess>(
     root: &V,
     path: &Path,
-    version_path: &str,
+    version_field_path: &str,
 ) -> Result<String, ProjectError> {
     let mut current = root;
-    for segment in version_path.split('.') {
+    for segment in version_field_path.split('.') {
         current = current.get_field(segment).ok_or_else(|| {
             ProjectError::ExternalVersionPathNotFound {
                 path: path.to_path_buf(),
-                version_path: version_path.to_string(),
+                version_field_path: version_field_path.to_string(),
             }
         })?;
     }
@@ -77,14 +77,14 @@ fn resolve_dot_path<V: ValueAccess>(
         .as_str_value()
         .ok_or_else(|| ProjectError::ExternalVersionNotString {
             path: path.to_path_buf(),
-            version_path: version_path.to_string(),
+            version_field_path: version_field_path.to_string(),
         })
 }
 
 pub(crate) fn read_external_version(
     path: &Path,
     format: ManifestFormat,
-    version_path: &str,
+    version_field_path: &str,
 ) -> Result<Version, ProjectError> {
     let content = std::fs::read_to_string(path).map_err(|source| ProjectError::ManifestRead {
         path: path.to_path_buf(),
@@ -98,7 +98,7 @@ pub(crate) fn read_external_version(
                     path: path.to_path_buf(),
                     source,
                 })?;
-            resolve_dot_path(&value, path, version_path)?
+            resolve_dot_path(&value, path, version_field_path)?
         }
         ManifestFormat::Yaml => {
             let value: serde_yml::Value =
@@ -106,7 +106,7 @@ pub(crate) fn read_external_version(
                     path: path.to_path_buf(),
                     source,
                 })?;
-            resolve_dot_path(&value, path, version_path)?
+            resolve_dot_path(&value, path, version_field_path)?
         }
         ManifestFormat::Toml => {
             let value: toml::Value =
@@ -114,7 +114,7 @@ pub(crate) fn read_external_version(
                     path: path.to_path_buf(),
                     source,
                 })?;
-            resolve_dot_path(&value, path, version_path)?
+            resolve_dot_path(&value, path, version_field_path)?
         }
     };
 
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_error_for_missing_version_path() -> Result<()> {
+    fn returns_error_for_missing_version_field_path() -> Result<()> {
         let file = NamedTempFile::new()?;
         std::fs::write(file.path(), r#"{ "name": "my-pkg" }"#)?;
         let result = read_external_version(file.path(), ManifestFormat::Json, "version");

--- a/crates/changeset-project/src/lib.rs
+++ b/crates/changeset-project/src/lib.rs
@@ -13,8 +13,13 @@ pub use config::{
 };
 pub use dependency_graph::WorkspaceDependencyGraph;
 pub use error::ProjectError;
-pub use mapping::{FileMapping, PackageFiles, map_files_to_packages};
-pub use project::{CargoProject, ProjectKind, discover_project, ensure_changeset_dir};
+pub use mapping::{
+    FileMapping, PackageFiles, compile_influence_patterns, map_files_to_all_packages,
+    map_files_to_packages,
+};
+pub use project::{
+    CargoProject, ProjectKind, discover_additional_packages, discover_project, ensure_changeset_dir,
+};
 pub use release_state::{GraduationState, PrereleaseState};
 
 pub const DEFAULT_CHANGESET_DIR: &str = ".changeset";

--- a/crates/changeset-project/src/lib.rs
+++ b/crates/changeset-project/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod dependency_graph;
 mod error;
+mod external_manifest;
 mod manifest;
 mod mapping;
 mod project;

--- a/crates/changeset-project/src/lib.rs
+++ b/crates/changeset-project/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+mod config_validation;
 mod dependency_graph;
 mod error;
 mod external_manifest;
@@ -12,6 +13,7 @@ pub use config::{
     GitConfig, PackageChangesetConfig, RootChangesetConfig, TagFormat, load_changeset_configs,
     parse_package_config, parse_root_config,
 };
+pub use config_validation::validate_version_tracking_dependencies;
 pub use dependency_graph::WorkspaceDependencyGraph;
 pub use error::ProjectError;
 pub use mapping::{

--- a/crates/changeset-project/src/lib.rs
+++ b/crates/changeset-project/src/lib.rs
@@ -6,6 +6,7 @@ mod manifest;
 mod mapping;
 mod project;
 mod release_state;
+mod version_tracking;
 
 pub use config::{
     GitConfig, PackageChangesetConfig, RootChangesetConfig, TagFormat, load_changeset_configs,
@@ -21,6 +22,9 @@ pub use project::{
     CargoProject, ProjectKind, discover_additional_packages, discover_project, ensure_changeset_dir,
 };
 pub use release_state::{GraduationState, PrereleaseState};
+pub use version_tracking::{
+    ResolvedVersionTracking, collect_version_tracking_info, tracking_edges,
+};
 
 pub const DEFAULT_CHANGESET_DIR: &str = ".changeset";
 

--- a/crates/changeset-project/src/manifest.rs
+++ b/crates/changeset-project/src/manifest.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use changeset_changelog::{ChangelogLocation, ComparisonLinksSetting};
-use changeset_core::ZeroVersionBehavior;
+use changeset_core::{AdditionalPackageDeclaration, ZeroVersionBehavior};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
 
@@ -107,6 +107,8 @@ pub(crate) struct ChangesetMetadata {
     pub(crate) none_bump_behavior: Option<changeset_core::NoneBumpBehavior>,
     #[serde(default)]
     pub(crate) none_bump_promote_message_template: Option<String>,
+    #[serde(default)]
+    pub(crate) additional_packages: Vec<AdditionalPackageDeclaration>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]

--- a/crates/changeset-project/src/manifest.rs
+++ b/crates/changeset-project/src/manifest.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use changeset_changelog::{ChangelogLocation, ComparisonLinksSetting};
-use changeset_core::{AdditionalPackageDeclaration, ZeroVersionBehavior};
+use changeset_core::{
+    AdditionalPackageDeclaration, VersionTrackingDependency, ZeroVersionBehavior,
+};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
 
@@ -68,6 +70,11 @@ pub(crate) struct PackageMetadata {
 }
 
 #[derive(Debug, Deserialize, Default)]
+pub(crate) struct PackageLevelMetadata {
+    pub(crate) changeset: Option<PackageChangesetMetadata>,
+}
+
+#[derive(Debug, Deserialize, Default)]
 pub(crate) struct WorkspaceMetadata {
     pub(crate) changeset: Option<ChangesetMetadata>,
 }
@@ -111,11 +118,44 @@ pub(crate) struct ChangesetMetadata {
     pub(crate) additional_packages: Vec<AdditionalPackageDeclaration>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct PackageChangesetMetadata {
+    #[serde(default)]
+    pub(crate) ignored_files: Vec<String>,
+    #[serde(default)]
+    pub(crate) additional_package_dependencies: Vec<VersionTrackingDependency>,
+}
+
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum TagFormatValue {
     VersionOnly,
     CratePrefixed,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PackageLevelManifest {
+    pub(crate) package: Option<PackageLevelPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PackageLevelPackage {
+    pub(crate) metadata: Option<PackageLevelMetadata>,
+}
+
+pub(crate) fn read_package_level_manifest(
+    path: &Path,
+) -> Result<PackageLevelManifest, ProjectError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ProjectError::ManifestRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    toml::from_str(&content).map_err(|source| ProjectError::ManifestParse {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 pub(crate) fn read_manifest(path: &Path) -> Result<CargoManifest, ProjectError> {

--- a/crates/changeset-project/src/mapping.rs
+++ b/crates/changeset-project/src/mapping.rs
@@ -250,7 +250,7 @@ mod tests {
                 "manifest": {{
                     "file-path": "{path}/manifest.yaml",
                     "format": "yaml",
-                    "version-path": "version"
+                    "version-field-path": "version"
                 }}
             }}"#,
             patterns = influence_json.join(", ")

--- a/crates/changeset-project/src/mapping.rs
+++ b/crates/changeset-project/src/mapping.rs
@@ -76,7 +76,7 @@ pub fn map_files_to_packages<S: BuildHasher>(
         })
         .collect();
 
-    packages_with_depth.sort_by(|a, b| b.depth.cmp(&a.depth));
+    packages_with_depth.sort_by_key(|b| std::cmp::Reverse(b.depth));
 
     let mut package_files_map: HashMap<String, Vec<PathBuf>> = HashMap::new();
     let mut project_files = Vec::new();

--- a/crates/changeset-project/src/mapping.rs
+++ b/crates/changeset-project/src/mapping.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::path::{Path, PathBuf};
 
-use changeset_core::PackageInfo;
+use changeset_core::{AdditionalPackageDeclaration, PackageInfo};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use gset::Getset;
 
 use crate::config::{PackageChangesetConfig, RootChangesetConfig};
+use crate::error::ProjectError;
 use crate::project::CargoProject;
 
 #[derive(Debug, Getset)]
@@ -134,6 +136,78 @@ pub fn map_files_to_packages<S: BuildHasher>(
     FileMapping::new(package_files, project_files, ignored_files)
 }
 
+/// # Errors
+///
+/// Returns `ProjectError::GlobPattern` if any influence pattern in a declaration is invalid.
+pub fn compile_influence_patterns(
+    declarations: &[AdditionalPackageDeclaration],
+) -> Result<Vec<GlobSet>, ProjectError> {
+    declarations
+        .iter()
+        .map(|decl| {
+            let mut builder = GlobSetBuilder::new();
+            for pattern in decl.influence() {
+                let glob = Glob::new(pattern).map_err(|source| ProjectError::GlobPattern {
+                    pattern: pattern.clone(),
+                    source,
+                })?;
+                builder.add(glob);
+            }
+            builder.build().map_err(|source| ProjectError::GlobPattern {
+                pattern: decl.influence().join(", "),
+                source,
+            })
+        })
+        .collect()
+}
+
+#[must_use]
+pub fn map_files_to_all_packages<S: BuildHasher>(
+    project: &CargoProject,
+    changed_files: &[PathBuf],
+    root_config: &RootChangesetConfig,
+    package_configs: &HashMap<String, PackageChangesetConfig, S>,
+    additional_packages: &[(PackageInfo, GlobSet)],
+) -> FileMapping {
+    let base_mapping = map_files_to_packages(project, changed_files, root_config, package_configs);
+
+    let mut additional_files_map: HashMap<usize, Vec<PathBuf>> = HashMap::new();
+    let mut remaining_project_files = Vec::new();
+
+    for file in base_mapping.project() {
+        let mut matched = false;
+        for (idx, (_, glob_set)) in additional_packages.iter().enumerate() {
+            if glob_set.is_match(file) {
+                additional_files_map
+                    .entry(idx)
+                    .or_default()
+                    .push(file.clone());
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            remaining_project_files.push(file.clone());
+        }
+    }
+
+    let additional_package_files: Vec<PackageFiles> = additional_packages
+        .iter()
+        .enumerate()
+        .map(|(idx, (pkg, _))| {
+            PackageFiles::new(
+                pkg.clone(),
+                additional_files_map.remove(&idx).unwrap_or_default(),
+            )
+        })
+        .collect();
+
+    let mut all_packages = base_mapping.packages;
+    all_packages.extend(additional_package_files);
+
+    FileMapping::new(all_packages, remaining_project_files, base_mapping.ignored)
+}
+
 struct PackageWithDepth {
     package: PackageInfo,
     depth: usize,
@@ -147,6 +221,7 @@ fn calculate_path_depth(path: &Path) -> usize {
 mod tests {
     use super::*;
     use crate::ProjectKind;
+    use crate::config::parse_root_config;
     use semver::Version;
 
     fn make_package(name: &str, path: PathBuf) -> PackageInfo {
@@ -155,6 +230,32 @@ mod tests {
 
     fn make_project(root: PathBuf, packages: Vec<PackageInfo>) -> CargoProject {
         CargoProject::new(root, ProjectKind::VirtualWorkspace, packages)
+    }
+
+    fn make_glob_set(patterns: &[&str]) -> GlobSet {
+        let mut builder = GlobSetBuilder::new();
+        for p in patterns {
+            builder.add(Glob::new(p).expect("valid glob"));
+        }
+        builder.build().expect("valid glob set")
+    }
+
+    fn make_decl(name: &str, path: &str, influence: &[&str]) -> AdditionalPackageDeclaration {
+        let influence_json: Vec<String> = influence.iter().map(|s| format!(r#""{s}""#)).collect();
+        let json = format!(
+            r#"{{
+                "name": "{name}",
+                "path": "{path}",
+                "influence": [{patterns}],
+                "manifest": {{
+                    "file-path": "{path}/manifest.yaml",
+                    "format": "yaml",
+                    "version-path": "version"
+                }}
+            }}"#,
+            patterns = influence_json.join(", ")
+        );
+        serde_json::from_str(&json).expect("valid declaration JSON")
     }
 
     #[test]
@@ -276,5 +377,267 @@ mod tests {
 
         assert!(mapping.packages().is_empty());
         assert_eq!(mapping.project().len(), 1);
+    }
+
+    #[test]
+    fn influence_glob_matches_project_files_to_additional_package() {
+        let root = PathBuf::from("/workspace");
+        let rust_pkg = make_package("lib", root.join("crates/lib"));
+        let project = make_project(root.clone(), vec![rust_pkg]);
+
+        let changed_files = vec![
+            PathBuf::from("charts/templates/deployment.yaml"),
+            PathBuf::from("crates/lib/src/lib.rs"),
+        ];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let helm_pkg = make_package("helm-chart", root.join("charts"));
+        let glob_set = make_glob_set(&["charts/**"]);
+        let additional_packages = vec![(helm_pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        let helm = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "helm-chart");
+        assert!(helm.is_some());
+        assert_eq!(helm.expect("helm-chart should exist").files().len(), 1);
+        assert!(
+            helm.expect("helm-chart should exist")
+                .files()
+                .contains(&PathBuf::from("charts/templates/deployment.yaml"))
+        );
+
+        let lib_pkg = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "lib");
+        assert!(lib_pkg.is_some());
+        assert_eq!(lib_pkg.expect("lib should exist").files().len(), 1);
+    }
+
+    #[test]
+    fn rust_crate_takes_precedence_over_influence_glob() {
+        let root = PathBuf::from("/workspace");
+        let rust_pkg = make_package("lib", root.join("crates/lib"));
+        let project = make_project(root.clone(), vec![rust_pkg]);
+
+        let changed_files = vec![PathBuf::from("crates/lib/src/lib.rs")];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let extra_pkg = make_package("extra", root.join("extra"));
+        let glob_set = make_glob_set(&["crates/lib/**"]);
+        let additional_packages = vec![(extra_pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        let lib_pkg = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "lib");
+        assert_eq!(lib_pkg.expect("lib should exist").files().len(), 1);
+
+        let extra = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "extra");
+        assert!(extra.expect("extra should exist").files().is_empty());
+    }
+
+    #[test]
+    fn files_outside_all_influence_stay_as_project_files() {
+        let root = PathBuf::from("/workspace");
+        let project = make_project(root.clone(), vec![]);
+
+        let changed_files = vec![PathBuf::from("docs/README.md")];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let extra_pkg = make_package("extra", root.join("charts"));
+        let glob_set = make_glob_set(&["charts/**"]);
+        let additional_packages = vec![(extra_pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        assert_eq!(mapping.project().len(), 1);
+        assert!(mapping.project().contains(&PathBuf::from("docs/README.md")));
+    }
+
+    #[test]
+    fn multiple_additional_packages_first_match_wins() {
+        let root = PathBuf::from("/workspace");
+        let project = make_project(root.clone(), vec![]);
+
+        let changed_files = vec![PathBuf::from("shared/foo.yaml")];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let pkg_a = make_package("pkg-a", root.join("pkg-a"));
+        let glob_a = make_glob_set(&["shared/**"]);
+        let pkg_b = make_package("pkg-b", root.join("pkg-b"));
+        let glob_b = make_glob_set(&["shared/**"]);
+        let additional_packages = vec![(pkg_a, glob_a), (pkg_b, glob_b)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        let a = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "pkg-a");
+        assert_eq!(a.expect("pkg-a should exist").files().len(), 1);
+
+        let b = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "pkg-b");
+        assert!(b.expect("pkg-b should exist").files().is_empty());
+    }
+
+    #[test]
+    fn additional_package_with_no_matching_files_still_in_result() {
+        let root = PathBuf::from("/workspace");
+        let project = make_project(root.clone(), vec![]);
+
+        let changed_files = vec![PathBuf::from("src/lib.rs")];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let helm_pkg = make_package("helm-chart", root.join("charts"));
+        let glob_set = make_glob_set(&["charts/**"]);
+        let additional_packages = vec![(helm_pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        let helm = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "helm-chart");
+        assert!(helm.is_some());
+        assert!(helm.expect("helm-chart should exist").files().is_empty());
+    }
+
+    #[test]
+    fn empty_influence_patterns_match_nothing() {
+        let root = PathBuf::from("/workspace");
+        let project = make_project(root.clone(), vec![]);
+
+        let changed_files = vec![PathBuf::from("charts/foo.yaml")];
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let pkg = make_package("pkg", root.join("pkg"));
+        let glob_set = make_glob_set(&[]);
+        let additional_packages = vec![(pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        let p = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "pkg");
+        assert!(p.expect("pkg should exist").files().is_empty());
+        assert_eq!(mapping.project().len(), 1);
+    }
+
+    #[test]
+    fn ignored_files_not_matched_to_additional_packages() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let root = temp.path();
+
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\n\n[workspace.metadata.changeset]\nignored-files = [\"*.md\"]\n",
+        )
+        .expect("write Cargo.toml");
+
+        let cargo_project = make_project(root.to_path_buf(), vec![]);
+        let root_config = parse_root_config(&cargo_project).expect("valid config");
+        let package_configs = HashMap::new();
+
+        let changed_files = vec![PathBuf::from("charts/README.md")];
+
+        let helm_pkg = make_package("helm-chart", root.join("charts"));
+        let glob_set = make_glob_set(&["charts/**"]);
+        let additional_packages = vec![(helm_pkg, glob_set)];
+
+        let mapping = map_files_to_all_packages(
+            &cargo_project,
+            &changed_files,
+            &root_config,
+            &package_configs,
+            &additional_packages,
+        );
+
+        assert_eq!(mapping.ignored().len(), 1);
+        let helm = mapping
+            .packages()
+            .iter()
+            .find(|pf| pf.package().name() == "helm-chart");
+        assert!(helm.expect("helm-chart should exist").files().is_empty());
+    }
+
+    #[test]
+    fn compile_influence_patterns_valid_patterns() {
+        let decl = make_decl("my-chart", "charts/my-chart", &["charts/**", "*.yaml"]);
+
+        let result = compile_influence_patterns(&[decl]).expect("should succeed");
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_match("charts/templates/deployment.yaml"));
+        assert!(result[0].is_match("values.yaml"));
+    }
+
+    #[test]
+    fn compile_influence_patterns_invalid_pattern_returns_error() {
+        let decl = make_decl("my-chart", "charts/my-chart", &["[invalid"]);
+
+        let result = compile_influence_patterns(&[decl]);
+
+        assert!(matches!(result, Err(ProjectError::GlobPattern { .. })));
+    }
+
+    #[test]
+    fn compile_influence_patterns_empty_declarations() {
+        let result = compile_influence_patterns(&[]).expect("should succeed with empty");
+        assert!(result.is_empty());
     }
 }

--- a/crates/changeset-project/src/project.rs
+++ b/crates/changeset-project/src/project.rs
@@ -1,12 +1,13 @@
 use std::path::{Path, PathBuf};
 
-use changeset_core::{CARGO_MANIFEST_FILENAME, PackageInfo};
+use changeset_core::{AdditionalPackageDeclaration, CARGO_MANIFEST_FILENAME, PackageInfo};
 use globset::GlobBuilder;
 use semver::Version;
 
 use crate::CHANGESETS_SUBDIR;
 use crate::config::RootChangesetConfig;
 use crate::error::ProjectError;
+use crate::external_manifest::read_external_version;
 use crate::manifest::{CargoManifest, VersionField, read_manifest};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +91,32 @@ pub fn ensure_changeset_dir(
         })?;
     }
     Ok(changeset_dir)
+}
+
+/// # Errors
+///
+/// Returns `ProjectError::ManifestRead` if a manifest file cannot be read,
+/// or `ProjectError::InvalidVersion` if the version string is not valid semver.
+pub fn discover_additional_packages(
+    project_root: &Path,
+    declarations: &[AdditionalPackageDeclaration],
+) -> Result<Vec<PackageInfo>, ProjectError> {
+    declarations
+        .iter()
+        .map(|decl| {
+            let manifest_path = project_root.join(decl.manifest().file_path());
+            let version = read_external_version(
+                &manifest_path,
+                decl.manifest().format(),
+                decl.manifest().version_path(),
+            )?;
+            Ok(PackageInfo::new(
+                decl.name().clone(),
+                version,
+                project_root.join(decl.path()),
+            ))
+        })
+        .collect()
 }
 
 fn find_project_root(start_dir: &Path) -> Result<(PathBuf, CargoManifest), ProjectError> {
@@ -288,6 +315,159 @@ fn expand_glob_pattern(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_decl(json: &str) -> AdditionalPackageDeclaration {
+        serde_json::from_str(json).expect("valid declaration JSON")
+    }
+
+    #[test]
+    fn discovers_additional_packages_from_declarations() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let root = temp.path();
+
+        std::fs::create_dir_all(root.join("charts/my-chart")).expect("create dir");
+        std::fs::write(
+            root.join("charts/my-chart/Chart.yaml"),
+            "version: \"1.2.3\"\n",
+        )
+        .expect("write file");
+
+        let decl = make_decl(
+            r#"{
+            "name": "my-helm-chart",
+            "path": "charts/my-chart",
+            "influence": ["charts/my-chart/**"],
+            "manifest": {
+                "file-path": "charts/my-chart/Chart.yaml",
+                "format": "yaml",
+                "version-path": "version"
+            }
+        }"#,
+        );
+
+        let result = discover_additional_packages(root, &[decl]).expect("should succeed");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name(), "my-helm-chart");
+        assert_eq!(result[0].version(), &semver::Version::new(1, 2, 3));
+        assert_eq!(*result[0].path(), root.join("charts/my-chart"));
+    }
+
+    #[test]
+    fn discovers_multiple_additional_packages() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let root = temp.path();
+
+        std::fs::create_dir_all(root.join("charts/chart-a")).expect("create dir");
+        std::fs::write(
+            root.join("charts/chart-a/Chart.yaml"),
+            "version: \"2.0.0\"\n",
+        )
+        .expect("write yaml");
+
+        std::fs::create_dir_all(root.join("apps/app-b")).expect("create dir");
+        std::fs::write(
+            root.join("apps/app-b/package.json"),
+            r#"{"version": "3.1.0"}"#,
+        )
+        .expect("write json");
+
+        let decls = vec![
+            make_decl(
+                r#"{
+                "name": "chart-a",
+                "path": "charts/chart-a",
+                "influence": ["charts/chart-a/**"],
+                "manifest": {
+                    "file-path": "charts/chart-a/Chart.yaml",
+                    "format": "yaml",
+                    "version-path": "version"
+                }
+            }"#,
+            ),
+            make_decl(
+                r#"{
+                "name": "app-b",
+                "path": "apps/app-b",
+                "influence": ["apps/app-b/**"],
+                "manifest": {
+                    "file-path": "apps/app-b/package.json",
+                    "format": "json",
+                    "version-path": "version"
+                }
+            }"#,
+            ),
+        ];
+
+        let result = discover_additional_packages(root, &decls).expect("should succeed");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name(), "chart-a");
+        assert_eq!(result[0].version(), &semver::Version::new(2, 0, 0));
+        assert_eq!(result[1].name(), "app-b");
+        assert_eq!(result[1].version(), &semver::Version::new(3, 1, 0));
+    }
+
+    #[test]
+    fn returns_error_for_missing_manifest() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let root = temp.path();
+
+        let decl = make_decl(
+            r#"{
+            "name": "missing-chart",
+            "path": "charts/missing",
+            "influence": [],
+            "manifest": {
+                "file-path": "charts/missing/Chart.yaml",
+                "format": "yaml",
+                "version-path": "version"
+            }
+        }"#,
+        );
+
+        let result = discover_additional_packages(root, &[decl]);
+
+        assert!(matches!(result, Err(ProjectError::ManifestRead { .. })));
+    }
+
+    #[test]
+    fn returns_error_for_invalid_version_in_manifest() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let root = temp.path();
+
+        std::fs::create_dir_all(root.join("charts/bad")).expect("create dir");
+        std::fs::write(
+            root.join("charts/bad/Chart.yaml"),
+            "version: \"not-a-version\"\n",
+        )
+        .expect("write file");
+
+        let decl = make_decl(
+            r#"{
+            "name": "bad-chart",
+            "path": "charts/bad",
+            "influence": [],
+            "manifest": {
+                "file-path": "charts/bad/Chart.yaml",
+                "format": "yaml",
+                "version-path": "version"
+            }
+        }"#,
+        );
+
+        let result = discover_additional_packages(root, &[decl]);
+
+        assert!(matches!(result, Err(ProjectError::InvalidVersion { .. })));
+    }
+
+    #[test]
+    fn returns_empty_vec_for_no_declarations() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let result =
+            discover_additional_packages(temp.path(), &[]).expect("should succeed with empty");
+        assert!(result.is_empty());
+    }
 
     #[test]
     fn determine_project_kind_virtual() {

--- a/crates/changeset-project/src/project.rs
+++ b/crates/changeset-project/src/project.rs
@@ -108,7 +108,7 @@ pub fn discover_additional_packages(
             let version = read_external_version(
                 &manifest_path,
                 decl.manifest().format(),
-                decl.manifest().version_path(),
+                decl.manifest().version_field_path(),
             )?;
             Ok(PackageInfo::new(
                 decl.name().clone(),
@@ -340,7 +340,7 @@ mod tests {
             "manifest": {
                 "file-path": "charts/my-chart/Chart.yaml",
                 "format": "yaml",
-                "version-path": "version"
+                "version-field-path": "version"
             }
         }"#,
         );
@@ -381,7 +381,7 @@ mod tests {
                 "manifest": {
                     "file-path": "charts/chart-a/Chart.yaml",
                     "format": "yaml",
-                    "version-path": "version"
+                    "version-field-path": "version"
                 }
             }"#,
             ),
@@ -393,7 +393,7 @@ mod tests {
                 "manifest": {
                     "file-path": "apps/app-b/package.json",
                     "format": "json",
-                    "version-path": "version"
+                    "version-field-path": "version"
                 }
             }"#,
             ),
@@ -421,7 +421,7 @@ mod tests {
             "manifest": {
                 "file-path": "charts/missing/Chart.yaml",
                 "format": "yaml",
-                "version-path": "version"
+                "version-field-path": "version"
             }
         }"#,
         );
@@ -451,7 +451,7 @@ mod tests {
             "manifest": {
                 "file-path": "charts/bad/Chart.yaml",
                 "format": "yaml",
-                "version-path": "version"
+                "version-field-path": "version"
             }
         }"#,
         );

--- a/crates/changeset-project/src/project.rs
+++ b/crates/changeset-project/src/project.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use changeset_core::PackageInfo;
+use changeset_core::{CARGO_MANIFEST_FILENAME, PackageInfo};
 use globset::GlobBuilder;
 use semver::Version;
 
@@ -97,7 +97,7 @@ fn find_project_root(start_dir: &Path) -> Result<(PathBuf, CargoManifest), Proje
     let mut fallback_single_package: Option<(PathBuf, CargoManifest)> = None;
 
     loop {
-        let manifest_path = current.join("Cargo.toml");
+        let manifest_path = current.join(CARGO_MANIFEST_FILENAME);
 
         if manifest_path.exists() {
             let manifest = read_manifest(&manifest_path)?;
@@ -148,7 +148,7 @@ fn collect_packages(
             let version = resolve_version(
                 pkg.version.as_ref(),
                 workspace_version,
-                &root.join("Cargo.toml"),
+                &root.join(CARGO_MANIFEST_FILENAME),
             )?;
             packages.push(PackageInfo::new(
                 pkg.name.clone(),
@@ -163,7 +163,7 @@ fn collect_packages(
             let version = resolve_version(
                 pkg.version.as_ref(),
                 workspace_version,
-                &root.join("Cargo.toml"),
+                &root.join(CARGO_MANIFEST_FILENAME),
             )?;
             return Ok(vec![PackageInfo::new(
                 pkg.name.clone(),
@@ -181,7 +181,7 @@ fn collect_packages(
             let member_dirs = expand_glob_pattern(root, pattern, excludes)?;
 
             for member_dir in member_dirs {
-                let member_manifest_path = member_dir.join("Cargo.toml");
+                let member_manifest_path = member_dir.join(CARGO_MANIFEST_FILENAME);
                 if !member_manifest_path.exists() {
                     continue;
                 }

--- a/crates/changeset-project/src/project.rs
+++ b/crates/changeset-project/src/project.rs
@@ -170,34 +170,34 @@ fn collect_packages(
 
     let mut packages = Vec::new();
 
-    if *kind == ProjectKind::WorkspaceWithRoot {
-        if let Some(pkg) = &manifest.package {
-            let version = resolve_version(
-                pkg.version.as_ref(),
-                workspace_version,
-                &root.join(CARGO_MANIFEST_FILENAME),
-            )?;
-            packages.push(PackageInfo::new(
-                pkg.name.clone(),
-                version,
-                root.to_path_buf(),
-            ));
-        }
+    if *kind == ProjectKind::WorkspaceWithRoot
+        && let Some(pkg) = &manifest.package
+    {
+        let version = resolve_version(
+            pkg.version.as_ref(),
+            workspace_version,
+            &root.join(CARGO_MANIFEST_FILENAME),
+        )?;
+        packages.push(PackageInfo::new(
+            pkg.name.clone(),
+            version,
+            root.to_path_buf(),
+        ));
     }
 
-    if *kind == ProjectKind::SinglePackage {
-        if let Some(pkg) = &manifest.package {
-            let version = resolve_version(
-                pkg.version.as_ref(),
-                workspace_version,
-                &root.join(CARGO_MANIFEST_FILENAME),
-            )?;
-            return Ok(vec![PackageInfo::new(
-                pkg.name.clone(),
-                version,
-                root.to_path_buf(),
-            )]);
-        }
+    if *kind == ProjectKind::SinglePackage
+        && let Some(pkg) = &manifest.package
+    {
+        let version = resolve_version(
+            pkg.version.as_ref(),
+            workspace_version,
+            &root.join(CARGO_MANIFEST_FILENAME),
+        )?;
+        return Ok(vec![PackageInfo::new(
+            pkg.name.clone(),
+            version,
+            root.to_path_buf(),
+        )]);
     }
 
     if let Some(workspace) = &manifest.workspace {

--- a/crates/changeset-project/src/version_tracking.rs
+++ b/crates/changeset-project/src/version_tracking.rs
@@ -30,20 +30,6 @@ impl ResolvedVersionTracking {
             manifest,
         }
     }
-
-    #[cfg(not(any(test, feature = "testing")))]
-    #[must_use]
-    pub(crate) fn new(
-        dependent_name: String,
-        dependency_name: String,
-        manifest: VersionTrackingManifest,
-    ) -> Self {
-        Self {
-            dependent_name,
-            dependency_name,
-            manifest,
-        }
-    }
 }
 
 #[must_use]

--- a/crates/changeset-project/src/version_tracking.rs
+++ b/crates/changeset-project/src/version_tracking.rs
@@ -1,0 +1,210 @@
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+
+use changeset_core::VersionTrackingManifest;
+use gset::Getset;
+
+use crate::config::{PackageChangesetConfig, RootChangesetConfig};
+
+#[derive(Debug, Getset)]
+pub struct ResolvedVersionTracking {
+    #[getset(get, vis = "pub")]
+    dependent_name: String,
+    #[getset(get, vis = "pub")]
+    dependency_name: String,
+    #[getset(get, vis = "pub")]
+    manifest: VersionTrackingManifest,
+}
+
+impl ResolvedVersionTracking {
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn new(
+        dependent_name: String,
+        dependency_name: String,
+        manifest: VersionTrackingManifest,
+    ) -> Self {
+        Self {
+            dependent_name,
+            dependency_name,
+            manifest,
+        }
+    }
+
+    #[cfg(not(any(test, feature = "testing")))]
+    #[must_use]
+    pub(crate) fn new(
+        dependent_name: String,
+        dependency_name: String,
+        manifest: VersionTrackingManifest,
+    ) -> Self {
+        Self {
+            dependent_name,
+            dependency_name,
+            manifest,
+        }
+    }
+}
+
+#[must_use]
+pub fn collect_version_tracking_info<S: BuildHasher>(
+    root_config: &RootChangesetConfig,
+    package_configs: &HashMap<String, PackageChangesetConfig, S>,
+) -> Vec<ResolvedVersionTracking> {
+    let mut entries = Vec::new();
+
+    for declaration in root_config.additional_packages() {
+        for dep in declaration.dependencies() {
+            entries.push(ResolvedVersionTracking {
+                dependent_name: declaration.name().clone(),
+                dependency_name: dep.dependency_name().clone(),
+                manifest: dep.version_tracking_manifest().clone(),
+            });
+        }
+    }
+
+    for (package_name, config) in package_configs {
+        for dep in config.additional_package_dependencies() {
+            entries.push(ResolvedVersionTracking {
+                dependent_name: package_name.clone(),
+                dependency_name: dep.dependency_name().clone(),
+                manifest: dep.version_tracking_manifest().clone(),
+            });
+        }
+    }
+
+    entries
+}
+
+#[must_use]
+pub fn tracking_edges(entries: &[ResolvedVersionTracking]) -> Vec<(String, String)> {
+    entries
+        .iter()
+        .map(|e| (e.dependent_name().clone(), e.dependency_name().clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use changeset_core::{
+        AdditionalPackageDeclaration, AdditionalPackageManifest, ManifestFormat,
+        VersionTrackingDependency, VersionTrackingManifest,
+    };
+
+    use super::*;
+
+    fn make_version_tracking_manifest() -> VersionTrackingManifest {
+        VersionTrackingManifest::new(
+            PathBuf::from("tracking/version.json"),
+            ManifestFormat::Json,
+            "version".to_string(),
+        )
+    }
+
+    fn make_version_tracking_dep(dep_name: &str) -> VersionTrackingDependency {
+        VersionTrackingDependency::new(dep_name.to_string(), make_version_tracking_manifest())
+    }
+
+    fn make_additional_package_declaration(
+        name: &str,
+        deps: Vec<VersionTrackingDependency>,
+    ) -> AdditionalPackageDeclaration {
+        AdditionalPackageDeclaration::new(
+            name.to_string(),
+            PathBuf::from(format!("packages/{name}")),
+            vec![format!("packages/{name}/**")],
+            AdditionalPackageManifest::new(
+                PathBuf::from(format!("packages/{name}/manifest.yaml")),
+                ManifestFormat::Yaml,
+                "version".to_string(),
+            ),
+            deps,
+        )
+    }
+
+    #[test]
+    fn collect_from_additional_packages_only() {
+        let dep = make_version_tracking_dep("upstream-service");
+        let declaration = make_additional_package_declaration("my-helm-chart", vec![dep]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![declaration]);
+        let package_configs = HashMap::new();
+
+        let result = collect_version_tracking_info(&root_config, &package_configs);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].dependent_name(), "my-helm-chart");
+        assert_eq!(result[0].dependency_name(), "upstream-service");
+    }
+
+    #[test]
+    fn collect_from_cargo_crate_deps_only() {
+        let root_config = RootChangesetConfig::default();
+        let dep = make_version_tracking_dep("my-lib");
+        let package_config =
+            PackageChangesetConfig::default().with_additional_package_dependencies(vec![dep]);
+        let mut package_configs = HashMap::new();
+        package_configs.insert("my-crate".to_string(), package_config);
+
+        let result = collect_version_tracking_info(&root_config, &package_configs);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].dependent_name(), "my-crate");
+        assert_eq!(result[0].dependency_name(), "my-lib");
+    }
+
+    #[test]
+    fn collect_from_both_sources() {
+        let additional_dep = make_version_tracking_dep("upstream-service");
+        let declaration =
+            make_additional_package_declaration("my-helm-chart", vec![additional_dep]);
+        let root_config =
+            RootChangesetConfig::default().with_additional_packages(vec![declaration]);
+
+        let cargo_dep = make_version_tracking_dep("my-lib");
+        let mut package_configs = HashMap::new();
+        package_configs.insert(
+            "my-crate".to_string(),
+            PackageChangesetConfig::default().with_additional_package_dependencies(vec![cargo_dep]),
+        );
+
+        let result = collect_version_tracking_info(&root_config, &package_configs);
+
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn tracking_edges_extracts_pairs() {
+        let entries = vec![
+            ResolvedVersionTracking::new(
+                "dependent-a".to_string(),
+                "dependency-x".to_string(),
+                make_version_tracking_manifest(),
+            ),
+            ResolvedVersionTracking::new(
+                "dependent-b".to_string(),
+                "dependency-y".to_string(),
+                make_version_tracking_manifest(),
+            ),
+        ];
+
+        let edges = tracking_edges(&entries);
+
+        assert_eq!(edges.len(), 2);
+        assert!(edges.contains(&("dependent-a".to_string(), "dependency-x".to_string())));
+        assert!(edges.contains(&("dependent-b".to_string(), "dependency-y".to_string())));
+    }
+
+    #[test]
+    fn empty_inputs_return_empty_vec() {
+        let root_config = RootChangesetConfig::default();
+        let package_configs = HashMap::new();
+
+        let result = collect_version_tracking_info(&root_config, &package_configs);
+
+        assert!(result.is_empty());
+        assert!(tracking_edges(&result).is_empty());
+    }
+}


### PR DESCRIPTION
- Resolves #93

Adds first-class support for non-Rust packages in a workspace, so they can participate in the same changeset workflow as Rust crates. Examples for this include packages containing Helm charts, npm packages, or any other packages with a manifest file containing a version field.

This feature is only available for Cargo workspaces (i.e. repositories with a workspace `Cargo.toml`), not for single-crate projects.

## What changed

**Configuration:** Non-Rust packages are declared in `.changeset/config.yaml` under `additional-packages`, specifying a name, path, and the manifest file with its format and a JSON Pointer to the version field.

**Supported manifest formats:** TOML, YAML, and JSON, with version fields located via JSON Pointer syntax.

**Commands extended:**
- `cargo changeset status`: lists pending changesets and projected versions for additional packages alongside Rust crates
- `cargo changeset verify`: detects file changes under an additional package's path and requires changeset coverage
- `cargo changeset release`: bumps the version field in the manifest file and generates a changelog entry
- `cargo changeset additional-packages`: new subcommand to list all configured additional packages

**Crates affected:**
- `changeset-core`: new public types: `AdditionalPackageDeclaration`, `AdditionalPackageManifest`, `ManifestFormat`
- `changeset-manifest`: new crate handling reads and writes for external manifest formats
- `changeset-project`: discovery and mapping of additional packages
- `changeset-operations`: release saga and verify logic extended for additional packages
- `cargo-changeset`: CLI wired up with the new subcommand and extended command output