### PR TITLE
Extract shared E2E test helpers into `changeset-test-helpers` crate

### DIFF
--- a/.changeset/changesets/beseechingly-commanding-swan.md
+++ b/.changeset/changesets/beseechingly-commanding-swan.md
@@ -1,0 +1,4 @@
+---
+cargo-changeset: none
+---
+Move helpers in end-to-end tests into `changeset-test-helpers` and use them from there

--- a/.changeset/changesets/sagely-sensuous-earwig.md
+++ b/.changeset/changesets/sagely-sensuous-earwig.md
@@ -1,0 +1,5 @@
+---
+category: added
+changeset-test-helpers: minor
+---
+Extracted end-to-end test helpers into `changeset-test-helpers` crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "changeset-manifest",
  "changeset-operations",
  "changeset-project",
+ "changeset-test-helpers",
  "changeset-version",
  "chrono",
  "clap",
@@ -160,7 +161,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "vt100",
 ]
 
 [[package]]
@@ -302,6 +302,15 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "thiserror",
+]
+
+[[package]]
+name = "changeset-test-helpers"
+version = "0.0.0"
+dependencies = [
+ "expectrl",
+ "tempfile",
+ "vt100",
 ]
 
 [[package]]

--- a/crates/cargo-changeset/Cargo.toml
+++ b/crates/cargo-changeset/Cargo.toml
@@ -33,10 +33,10 @@ chrono = { version = "0.4.44", features = ["clock"], default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.1"
-predicates = "3.1"
+changeset-test-helpers = { path = "../changeset-test-helpers" }
 expectrl = "0.8"
+predicates = "3.1"
 indexmap = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
-vt100 = "0.16.2"
 indoc = "2.0.7"

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -3,42 +3,16 @@ use std::process::Command;
 use std::time::Duration;
 
 use changeset_test_helpers::workspaces::{
-    create_single_crate_workspace, create_virtual_workspace,
+    WorkspaceBuilder, create_single_crate_workspace, create_virtual_workspace,
     create_workspace_with_additional_package,
 };
 use predicates::str::contains;
 use tempfile::TempDir;
 
 fn create_workspace_with_underscored_crate() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/one/src")).expect("failed to create crate one dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/one/Cargo.toml"),
-        r#"
-[package]
-name = "crate_one"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate_one Cargo.toml");
-
-    fs::write(dir.path().join("crates/one/src/lib.rs"), "")
-        .expect("failed to write crate_one lib.rs");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member_at("crate_one", "0.1.0", "crates/one")
+        .build()
 }
 
 mod non_interactive {

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -1,16 +1,13 @@
-mod common;
-
 use std::fs;
 use std::process::Command;
 use std::time::Duration;
 
-use predicates::str::contains;
-use tempfile::TempDir;
-
-use common::workspaces::{
+use changeset_test_helpers::workspaces::{
     create_single_crate_workspace, create_virtual_workspace,
     create_workspace_with_additional_package,
 };
+use predicates::str::contains;
+use tempfile::TempDir;
 
 fn create_workspace_with_underscored_crate() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");

--- a/crates/cargo-changeset/tests/additional_packages.rs
+++ b/crates/cargo-changeset/tests/additional_packages.rs
@@ -1,18 +1,15 @@
-mod common;
-
 use std::fs;
 use std::process::Command;
 
-use predicates::str::contains;
-
-use common::changesets::write_changeset;
-use common::git::{git_add_and_commit, init_git_repo};
-use common::workspaces::{
+use changeset_test_helpers::changesets::write_changeset;
+use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
+use changeset_test_helpers::workspaces::{
     add_helm_chart_config, add_helm_chart_config_with_three_deps, create_single_crate_workspace,
     create_workspace_with_helm_chart, create_workspace_with_unknown_dependency,
     create_workspace_with_version_tracking_additional_to_cargo,
     create_workspace_with_version_tracking_cargo_to_additional,
 };
+use predicates::str::contains;
 
 mod add_tests {
     use super::*;
@@ -1063,10 +1060,16 @@ mod help_and_ux_tests {
 
 #[cfg(not(windows))]
 mod interactive_dependencies_tests {
-    use common::terminal_session::TerminalSession;
+    use std::path::PathBuf;
+
+    use changeset_test_helpers::terminal_session::TerminalSession;
     use indoc::indoc;
 
     use super::*;
+
+    fn bin_path() -> PathBuf {
+        assert_cmd::cargo::cargo_bin("cargo-changeset")
+    }
 
     // --- dependencies add ---
 
@@ -1075,8 +1078,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu rendered",
@@ -1097,8 +1103,11 @@ mod interactive_dependencies_tests {
         let cargo_toml_before =
             fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu before cancel",
@@ -1127,8 +1136,11 @@ mod interactive_dependencies_tests {
         let cargo_toml_before =
             fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu before selecting",
@@ -1164,8 +1176,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu rendered",
@@ -1261,8 +1276,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu before selecting",
@@ -1291,8 +1309,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "add"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "add"],
+        );
         session.wait_for("Select the owner package");
         session.assert_screen(
             "owner menu rendered",
@@ -1371,6 +1392,7 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_version_tracking_additional_to_cargo();
 
         let mut session = TerminalSession::spawn(
+            &bin_path(),
             &workspace,
             &["additional-packages", "dependencies", "remove"],
         );
@@ -1394,6 +1416,7 @@ mod interactive_dependencies_tests {
             fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
 
         let mut session = TerminalSession::spawn(
+            &bin_path(),
             &workspace,
             &["additional-packages", "dependencies", "remove"],
         );
@@ -1426,6 +1449,7 @@ mod interactive_dependencies_tests {
             fs::read_to_string(workspace.path().join("Cargo.toml")).expect("read Cargo.toml");
 
         let mut session = TerminalSession::spawn(
+            &bin_path(),
             &workspace,
             &["additional-packages", "dependencies", "remove"],
         );
@@ -1462,6 +1486,7 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_version_tracking_additional_to_cargo();
 
         let mut session = TerminalSession::spawn(
+            &bin_path(),
             &workspace,
             &["additional-packages", "dependencies", "remove"],
         );
@@ -1493,6 +1518,7 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_version_tracking_additional_to_cargo();
 
         let mut session = TerminalSession::spawn(
+            &bin_path(),
             &workspace,
             &["additional-packages", "dependencies", "remove"],
         );
@@ -1539,8 +1565,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "list"],
+        );
         session.wait_for("Select package");
         session.assert_screen(
             "list package menu",
@@ -1559,8 +1588,11 @@ mod interactive_dependencies_tests {
         let workspace = create_workspace_with_helm_chart();
         add_helm_chart_config(&workspace);
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "list"],
+        );
         session.wait_for("Select package");
         session.assert_screen(
             "list package menu before cancel",
@@ -1579,8 +1611,11 @@ mod interactive_dependencies_tests {
     fn interactive_dep_list_full_flow() {
         let workspace = create_workspace_with_version_tracking_additional_to_cargo();
 
-        let mut session =
-            TerminalSession::spawn(&workspace, &["additional-packages", "dependencies", "list"]);
+        let mut session = TerminalSession::spawn(
+            &bin_path(),
+            &workspace,
+            &["additional-packages", "dependencies", "list"],
+        );
         session.wait_for("Select package");
         session.assert_screen(
             "list package menu",

--- a/crates/cargo-changeset/tests/cargo_dispatch.rs
+++ b/crates/cargo-changeset/tests/cargo_dispatch.rs
@@ -1,35 +1,10 @@
-use std::fs;
-
-use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
-use tempfile::TempDir;
-
-fn create_single_package_project() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "my-crate"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write Cargo.toml");
-
-    fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
-}
+use changeset_test_helpers::workspaces::WorkspaceBuilder;
 
 #[test]
 fn cargo_dispatch_verify_succeeds_with_changeset_prefix() {
-    let workspace = create_single_package_project();
+    let workspace = WorkspaceBuilder::single_package("my-crate", "0.1.0")
+        .with_git()
+        .build();
 
     assert_cmd::cargo::cargo_bin_cmd!("cargo-changeset")
         .arg("changeset")

--- a/crates/cargo-changeset/tests/cargo_dispatch.rs
+++ b/crates/cargo-changeset/tests/cargo_dispatch.rs
@@ -1,8 +1,6 @@
-mod common;
-
 use std::fs;
 
-use common::git::{git_add_and_commit, init_git_repo};
+use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
 use tempfile::TempDir;
 
 fn create_single_package_project() -> TempDir {

--- a/crates/cargo-changeset/tests/init_command.rs
+++ b/crates/cargo-changeset/tests/init_command.rs
@@ -1,11 +1,8 @@
-mod common;
-
 use std::fs;
 
+use changeset_test_helpers::git::{create_branch, git_add_and_commit, init_git_repo};
 use predicates::str::contains;
 use tempfile::TempDir;
-
-use common::git::{create_branch, git_add_and_commit, init_git_repo};
 
 fn setup_single_package() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");

--- a/crates/cargo-changeset/tests/init_command.rs
+++ b/crates/cargo-changeset/tests/init_command.rs
@@ -1,112 +1,32 @@
 use std::fs;
 
 use changeset_test_helpers::git::{create_branch, git_add_and_commit, init_git_repo};
+use changeset_test_helpers::workspaces::WorkspaceBuilder;
 use predicates::str::contains;
 use tempfile::TempDir;
 
 fn setup_single_package() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "test-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write Cargo.toml");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("write lib.rs");
-    dir
+    WorkspaceBuilder::single_package("test-crate", "1.0.0").build()
 }
 
 fn setup_workspace() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-    fs::create_dir_all(dir.path().join("crates/foo/src")).expect("create foo dir");
-    fs::create_dir_all(dir.path().join("crates/bar/src")).expect("create bar dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-    fs::write(
-        dir.path().join("crates/foo/Cargo.toml"),
-        r#"[package]
-name = "foo"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write foo Cargo.toml");
-    fs::write(dir.path().join("crates/foo/src/lib.rs"), "").expect("write foo lib.rs");
-    fs::write(
-        dir.path().join("crates/bar/Cargo.toml"),
-        r#"[package]
-name = "bar"
-version = "2.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write bar Cargo.toml");
-    fs::write(dir.path().join("crates/bar/src/lib.rs"), "").expect("write bar lib.rs");
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("foo", "1.0.0")
+        .crate_member("bar", "2.0.0")
+        .build()
 }
 
 fn setup_virtual_workspace() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-    fs::create_dir_all(dir.path().join("crates/alpha/src")).expect("create alpha dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-    fs::write(
-        dir.path().join("crates/alpha/Cargo.toml"),
-        r#"[package]
-name = "alpha"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("write alpha Cargo.toml");
-    fs::write(dir.path().join("crates/alpha/src/lib.rs"), "").expect("write alpha lib.rs");
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("alpha", "0.1.0")
+        .build()
 }
 
 fn setup_workspace_with_root_package() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
-    fs::create_dir_all(dir.path().join("crates/sub/src")).expect("create sub dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "root-pkg"
-version = "1.0.0"
-edition = "2021"
-
-[workspace]
-members = ["crates/*"]
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("write root lib.rs");
-    fs::write(
-        dir.path().join("crates/sub/Cargo.toml"),
-        r#"[package]
-name = "sub-pkg"
-version = "0.5.0"
-edition = "2021"
-"#,
-    )
-    .expect("write sub Cargo.toml");
-    fs::write(dir.path().join("crates/sub/src/lib.rs"), "").expect("write sub lib.rs");
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .root_package("root-pkg", "1.0.0")
+        .crate_member_at("sub-pkg", "0.5.0", "crates/sub")
+        .build()
 }
 
 mod directory_creation {

--- a/crates/cargo-changeset/tests/integrated_workflow.rs
+++ b/crates/cargo-changeset/tests/integrated_workflow.rs
@@ -1,13 +1,10 @@
-mod common;
-
 use std::fs;
 use std::process::Command;
 
+use changeset_test_helpers::changesets::write_changeset;
+use changeset_test_helpers::git::{create_branch, git_add_and_commit, init_git_repo};
+use changeset_test_helpers::workspaces::{add_helm_chart_config, create_workspace_with_helm_chart};
 use predicates::str::contains;
-
-use common::changesets::write_changeset;
-use common::git::{create_branch, git_add_and_commit, init_git_repo};
-use common::workspaces::{add_helm_chart_config, create_workspace_with_helm_chart};
 
 mod additional_packages {
     use super::*;

--- a/crates/cargo-changeset/tests/manage_integration.rs
+++ b/crates/cargo-changeset/tests/manage_integration.rs
@@ -1,73 +1,19 @@
 use std::fs;
 
-use changeset_test_helpers::workspaces::create_virtual_workspace;
+use changeset_test_helpers::workspaces::{WorkspaceBuilder, create_virtual_workspace};
 use predicates::str::contains;
 use tempfile::TempDir;
 
 fn create_workspace_with_stable_version() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/stable/src"))
-        .expect("failed to create stable crate dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/stable/Cargo.toml"),
-        r#"
-[package]
-name = "stable-crate"
-version = "1.2.3"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write stable-crate Cargo.toml");
-
-    fs::write(dir.path().join("crates/stable/src/lib.rs"), "")
-        .expect("failed to write stable-crate lib.rs");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member_at("stable-crate", "1.2.3", "crates/stable")
+        .build()
 }
 
 fn create_workspace_with_prerelease_version() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/pre/src"))
-        .expect("failed to create prerelease crate dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/pre/Cargo.toml"),
-        r#"
-[package]
-name = "prerelease-crate"
-version = "0.1.0-alpha.1"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write prerelease-crate Cargo.toml");
-
-    fs::write(dir.path().join("crates/pre/src/lib.rs"), "")
-        .expect("failed to write prerelease-crate lib.rs");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member_at("prerelease-crate", "0.1.0-alpha.1", "crates/pre")
+        .build()
 }
 
 mod manage_prerelease {

--- a/crates/cargo-changeset/tests/manage_integration.rs
+++ b/crates/cargo-changeset/tests/manage_integration.rs
@@ -1,11 +1,8 @@
-mod common;
-
 use std::fs;
 
+use changeset_test_helpers::workspaces::create_virtual_workspace;
 use predicates::str::contains;
 use tempfile::TempDir;
-
-use common::workspaces::create_virtual_workspace;
 
 fn create_workspace_with_stable_version() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");

--- a/crates/cargo-changeset/tests/release_command.rs
+++ b/crates/cargo-changeset/tests/release_command.rs
@@ -1,13 +1,9 @@
-mod common;
-
 use std::fs;
 use std::process::Command;
 
-use predicates::str::is_match;
-
-use common::changesets::{write_changeset, write_multi_changeset};
-use common::git::{git_add_and_commit, init_git_repo};
-use common::workspaces::{
+use changeset_test_helpers::changesets::{write_changeset, write_multi_changeset};
+use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
+use changeset_test_helpers::workspaces::{
     add_helm_chart_config, create_workspace_with_cascade_chain,
     create_workspace_with_circular_version_tracking,
     create_workspace_with_deeply_nested_json_field, create_workspace_with_duplicate_dependency,
@@ -16,6 +12,7 @@ use common::workspaces::{
     create_workspace_with_prerelease_dependency,
     create_workspace_with_version_tracking_additional_to_cargo,
 };
+use predicates::str::is_match;
 
 #[test]
 fn release_bumps_chart_yaml_version_and_preserves_inline_comments() {

--- a/crates/cargo-changeset/tests/release_lockfile.rs
+++ b/crates/cargo-changeset/tests/release_lockfile.rs
@@ -1,66 +1,24 @@
-use std::fs;
 use std::process::Command;
 
 use changeset_test_helpers::changesets::write_changeset;
-use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
+use changeset_test_helpers::git::{git_add_and_commit, lockfile_hash};
+use changeset_test_helpers::workspaces::WorkspaceBuilder;
 use tempfile::TempDir;
 
-fn lockfile_hash(dir: &TempDir) -> Vec<u8> {
-    let output = Command::new("git")
-        .args(["hash-object", "Cargo.lock"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to hash Cargo.lock");
-
-    output.stdout
-}
-
 fn setup_workspace_with_dependency() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[workspace.dependencies]
-crate-a = { path = "crates/crate-a", version = "1.0.0" }
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write crate-a Cargo.toml");
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write crate-a lib.rs");
-
-    fs::create_dir_all(dir.path().join("crates/crate-b/src")).expect("create crate-b dir");
-    fs::write(
-        dir.path().join("crates/crate-b/Cargo.toml"),
-        r#"[package]
-name = "crate-b"
-version = "2.0.0"
-edition = "2021"
-
-[dependencies]
-crate-a = { workspace = true }
-"#,
-    )
-    .expect("write crate-b Cargo.toml");
-    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "").expect("write crate-b lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
+    let dir = WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .crate_member("crate-b", "2.0.0")
+        .crate_toml_extra(
+            "crate-b",
+            "[dependencies]\ncrate-a = { workspace = true }\n",
+        )
+        .workspace_toml_extra(
+            "[workspace.dependencies]\ncrate-a = { path = \"crates/crate-a\", version = \"1.0.0\" }\n",
+        )
+        .with_changeset_dir()
+        .with_git()
+        .build();
 
     let output = Command::new("cargo")
         .args(["generate-lockfile"])
@@ -73,7 +31,7 @@ crate-a = { workspace = true }
         String::from_utf8_lossy(&output.stderr)
     );
 
-    git_add_and_commit(&dir, "Initial commit");
+    git_add_and_commit(&dir, "Generate lockfile");
 
     dir
 }

--- a/crates/cargo-changeset/tests/release_lockfile.rs
+++ b/crates/cargo-changeset/tests/release_lockfile.rs
@@ -1,12 +1,9 @@
-mod common;
-
 use std::fs;
 use std::process::Command;
 
+use changeset_test_helpers::changesets::write_changeset;
+use changeset_test_helpers::git::{git_add_and_commit, init_git_repo};
 use tempfile::TempDir;
-
-use common::changesets::write_changeset;
-use common::git::{git_add_and_commit, init_git_repo};
 
 fn lockfile_hash(dir: &TempDir) -> Vec<u8> {
     let output = Command::new("git")

--- a/crates/cargo-changeset/tests/saga_error_display.rs
+++ b/crates/cargo-changeset/tests/saga_error_display.rs
@@ -1,80 +1,25 @@
 use std::fs;
 
 use changeset_test_helpers::changesets::{write_changeset, write_multi_changeset};
-use changeset_test_helpers::git::{create_tag, git_add_and_commit, init_git_repo};
+use changeset_test_helpers::git::{create_tag, git_add_and_commit};
+use changeset_test_helpers::workspaces::WorkspaceBuilder;
 use predicates::str::contains;
 use tempfile::TempDir;
 
 fn create_single_package_with_git() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "my-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+    WorkspaceBuilder::single_package("my-crate", "1.0.0")
+        .with_changeset_dir()
+        .with_git()
+        .build()
 }
 
 fn create_workspace_with_two_crates() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write crate-a Cargo.toml");
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join("crates/crate-b/src")).expect("create crate-b dir");
-    fs::write(
-        dir.path().join("crates/crate-b/Cargo.toml"),
-        r#"[package]
-name = "crate-b"
-version = "2.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write crate-b Cargo.toml");
-    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .crate_member("crate-b", "2.0.0")
+        .with_changeset_dir()
+        .with_git()
+        .build()
 }
 
 #[test]

--- a/crates/cargo-changeset/tests/saga_error_display.rs
+++ b/crates/cargo-changeset/tests/saga_error_display.rs
@@ -1,12 +1,9 @@
-mod common;
-
 use std::fs;
 
+use changeset_test_helpers::changesets::{write_changeset, write_multi_changeset};
+use changeset_test_helpers::git::{create_tag, git_add_and_commit, init_git_repo};
 use predicates::str::contains;
 use tempfile::TempDir;
-
-use common::changesets::{write_changeset, write_multi_changeset};
-use common::git::{create_tag, git_add_and_commit, init_git_repo};
 
 fn create_single_package_with_git() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");

--- a/crates/cargo-changeset/tests/status_command.rs
+++ b/crates/cargo-changeset/tests/status_command.rs
@@ -1,15 +1,12 @@
-mod common;
-
 use std::fs;
 
-use predicates::str::contains;
-use tempfile::TempDir;
-
-use common::changesets::write_changeset;
-use common::workspaces::{
+use changeset_test_helpers::changesets::write_changeset;
+use changeset_test_helpers::workspaces::{
     create_workspace_with_additional_package,
     create_workspace_with_version_tracking_additional_to_cargo,
 };
+use predicates::str::contains;
+use tempfile::TempDir;
 
 fn create_single_package_project() -> TempDir {
     let dir = TempDir::new().expect("create temp dir");

--- a/crates/cargo-changeset/tests/status_command.rs
+++ b/crates/cargo-changeset/tests/status_command.rs
@@ -1,109 +1,31 @@
-use std::fs;
-
 use changeset_test_helpers::changesets::write_changeset;
 use changeset_test_helpers::workspaces::{
-    create_workspace_with_additional_package,
+    WorkspaceBuilder, create_workspace_with_additional_package,
     create_workspace_with_version_tracking_additional_to_cargo,
 };
 use predicates::str::contains;
 use tempfile::TempDir;
 
 fn create_single_package_project() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "my-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
-
-    dir
+    WorkspaceBuilder::single_package("my-crate", "1.0.0")
+        .with_changeset_dir()
+        .build()
 }
 
 fn create_workspace_project() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write crate-a Cargo.toml");
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join("crates/crate-b/src")).expect("create crate-b dir");
-    fs::write(
-        dir.path().join("crates/crate-b/Cargo.toml"),
-        r#"[package]
-name = "crate-b"
-version = "2.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write crate-b Cargo.toml");
-    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .crate_member("crate-b", "2.0.0")
+        .with_changeset_dir()
+        .build()
 }
 
 fn create_workspace_with_inherited_versions() -> TempDir {
-    let dir = TempDir::new().expect("create temp dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[workspace.package]
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src")).expect("create crate-a dir");
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version.workspace = true
-edition.workspace = true
-"#,
-    )
-    .expect("write crate-a Cargo.toml");
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "").expect("write lib.rs");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("create .changeset/changesets dir");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .workspace_package("[workspace.package]\nversion = \"1.0.0\"\nedition = \"2021\"\n")
+        .crate_member_with_inherited_version("crate-a", "crates/crate-a")
+        .with_changeset_dir()
+        .build()
 }
 
 #[test]

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -2,7 +2,9 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write as IoWrite;
 
-use changeset_test_helpers::changesets::write_multi_changeset;
+use changeset_test_helpers::changesets::{
+    add_changeset, add_changeset_with_name, write_multi_changeset,
+};
 use changeset_test_helpers::git::{create_branch, git_add_and_commit, init_git_repo};
 use changeset_test_helpers::workspaces::{
     create_virtual_workspace_with_git, create_workspace_with_circular_version_tracking,
@@ -13,20 +15,6 @@ use changeset_test_helpers::workspaces::{
 use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::contains;
 use tempfile::TempDir;
-
-fn add_changeset(dir: &TempDir, package_name: &str) {
-    add_changeset_with_name(dir, package_name, &format!("{package_name}-changeset"));
-}
-
-fn add_changeset_with_name(dir: &TempDir, package_name: &str, changeset_name: &str) {
-    changeset_test_helpers::changesets::write_changeset(
-        dir,
-        &format!("{changeset_name}.md"),
-        package_name,
-        "patch",
-        &format!("Test changeset for {package_name}."),
-    );
-}
 
 #[test]
 fn verify_exit_code_0_when_all_changes_covered() {

--- a/crates/cargo-changeset/tests/verify_command.rs
+++ b/crates/cargo-changeset/tests/verify_command.rs
@@ -1,28 +1,25 @@
-mod common;
-
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write as IoWrite;
 
-use predicates::prelude::PredicateBooleanExt as _;
-use predicates::str::contains;
-use tempfile::TempDir;
-
-use common::changesets::write_multi_changeset;
-use common::git::{create_branch, git_add_and_commit, init_git_repo};
-use common::workspaces::{
+use changeset_test_helpers::changesets::write_multi_changeset;
+use changeset_test_helpers::git::{create_branch, git_add_and_commit, init_git_repo};
+use changeset_test_helpers::workspaces::{
     create_virtual_workspace_with_git, create_workspace_with_circular_version_tracking,
     create_workspace_with_duplicate_dependency, create_workspace_with_helm_chart_and_git,
     create_workspace_with_three_crates_and_git, create_workspace_with_unknown_dependency,
     create_workspace_with_version_tracking_and_git,
 };
+use predicates::prelude::PredicateBooleanExt as _;
+use predicates::str::contains;
+use tempfile::TempDir;
 
 fn add_changeset(dir: &TempDir, package_name: &str) {
     add_changeset_with_name(dir, package_name, &format!("{package_name}-changeset"));
 }
 
 fn add_changeset_with_name(dir: &TempDir, package_name: &str, changeset_name: &str) {
-    common::changesets::write_changeset(
+    changeset_test_helpers::changesets::write_changeset(
         dir,
         &format!("{changeset_name}.md"),
         package_name,

--- a/crates/changeset-test-helpers/Cargo.toml
+++ b/crates/changeset-test-helpers/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "changeset-test-helpers"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+expectrl = "0.8"
+tempfile = "3.25"
+vt100 = "0.16.2"
+
+[lints]
+workspace = true

--- a/crates/changeset-test-helpers/src/changesets.rs
+++ b/crates/changeset-test-helpers/src/changesets.rs
@@ -17,6 +17,20 @@ pub fn write_changeset(dir: &TempDir, filename: &str, package: &str, bump: &str,
     fs::write(changeset_dir.join(filename), content).expect("failed to write changeset");
 }
 
+pub fn add_changeset(dir: &TempDir, package_name: &str) {
+    add_changeset_with_name(dir, package_name, &format!("{package_name}-changeset"));
+}
+
+pub fn add_changeset_with_name(dir: &TempDir, package_name: &str, changeset_name: &str) {
+    write_changeset(
+        dir,
+        &format!("{changeset_name}.md"),
+        package_name,
+        "patch",
+        &format!("Test changeset for {package_name}."),
+    );
+}
+
 pub fn write_multi_changeset(
     dir: &TempDir,
     filename: &str,

--- a/crates/changeset-test-helpers/src/changesets.rs
+++ b/crates/changeset-test-helpers/src/changesets.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-
+use std::fmt::Write;
 use std::fs;
 
 use tempfile::TempDir;
@@ -26,10 +25,10 @@ pub fn write_multi_changeset(
 ) {
     let changeset_dir = dir.path().join(".changeset/changesets");
     fs::create_dir_all(&changeset_dir).expect("failed to create .changeset/changesets dir");
-    let front_matter: String = entries
-        .iter()
-        .map(|(pkg, bump)| format!("\"{pkg}\": {bump}\n"))
-        .collect();
+    let front_matter = entries.iter().fold(String::new(), |mut acc, (pkg, bump)| {
+        writeln!(acc, "\"{pkg}\": {bump}").expect("write to String is infallible");
+        acc
+    });
     let content = format!("---\n{front_matter}---\n\n{summary}\n");
     fs::write(changeset_dir.join(filename), content)
         .expect("failed to write multi-package changeset");

--- a/crates/changeset-test-helpers/src/git.rs
+++ b/crates/changeset-test-helpers/src/git.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::process::Command;
 
 use tempfile::TempDir;

--- a/crates/changeset-test-helpers/src/git.rs
+++ b/crates/changeset-test-helpers/src/git.rs
@@ -46,6 +46,16 @@ pub fn create_branch(dir: &TempDir, name: &str) {
         .expect("failed to create branch");
 }
 
+pub fn lockfile_hash(dir: &TempDir) -> Vec<u8> {
+    let output = Command::new("git")
+        .args(["hash-object", "Cargo.lock"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to hash Cargo.lock");
+
+    output.stdout
+}
+
 pub fn create_tag(dir: &TempDir, tag_name: &str, message: &str) {
     Command::new("git")
         .args(["tag", "-a", tag_name, "-m", message])

--- a/crates/changeset-test-helpers/src/lib.rs
+++ b/crates/changeset-test-helpers/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_panics_doc, clippy::must_use_candidate)]
+
 pub mod changesets;
 pub mod git;
 #[cfg(not(windows))]

--- a/crates/changeset-test-helpers/src/terminal_session.rs
+++ b/crates/changeset-test-helpers/src/terminal_session.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-
+use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -20,8 +19,7 @@ pub struct TerminalSession {
 }
 
 impl TerminalSession {
-    pub fn spawn(workspace: &TempDir, args: &[&str]) -> Self {
-        let bin_path = assert_cmd::cargo::cargo_bin!("cargo-changeset");
+    pub fn spawn(bin_path: &Path, workspace: &TempDir, args: &[&str]) -> Self {
         let mut cmd = Command::new(bin_path);
         cmd.args(args);
         cmd.current_dir(workspace.path());
@@ -61,12 +59,11 @@ impl TerminalSession {
             if self.vt.screen().contents().contains(needle) {
                 return self;
             }
-            if start.elapsed() > TIMEOUT {
-                panic!(
-                    "Timed out waiting for {needle:?}\nScreen:\n{}",
-                    self.screen()
-                );
-            }
+            assert!(
+                start.elapsed() <= TIMEOUT,
+                "Timed out waiting for {needle:?}\nScreen:\n{}",
+                self.screen()
+            );
             std::thread::sleep(POLL_INTERVAL);
         }
     }
@@ -101,12 +98,6 @@ impl TerminalSession {
         assert_eq!(actual, expected_trimmed, "{message}");
     }
 
-    /// Select an item from a `dialoguer::Select` menu by index.
-    ///
-    /// `dialoguer::Select` without `.default()` starts with `sel = !0`.
-    /// The first Down press moves from `!0` to `0`, so we need `index + 1`
-    /// presses. Delays between presses ensure the `console` crate's
-    /// zero-timeout poll parses `\x1b[B` as ArrowDown rather than bare ESC.
     pub fn select_item(&mut self, index: usize) -> &mut Self {
         for _ in 0..=index {
             self.pty.send(ARROW_DOWN).expect("send arrow-down key");

--- a/crates/changeset-test-helpers/src/workspaces.rs
+++ b/crates/changeset-test-helpers/src/workspaces.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -7,116 +8,261 @@ use tempfile::TempDir;
 
 use crate::git::{git_add_and_commit, init_git_repo};
 
+struct CrateSpec {
+    name: String,
+    version: String,
+    dir_name: String,
+    inherited_version: bool,
+    cargo_toml_extra: Option<String>,
+}
+
+struct ExtraFile {
+    relative_path: String,
+    content: String,
+}
+
+#[must_use]
+pub struct WorkspaceBuilder {
+    crates: Vec<CrateSpec>,
+    with_git: bool,
+    with_changeset_dir: bool,
+    root_package: Option<(String, String)>,
+    workspace_toml_extra: Option<String>,
+    workspace_package: Option<String>,
+    single_package: bool,
+    extra_files: Vec<ExtraFile>,
+}
+
+impl WorkspaceBuilder {
+    pub fn single_package(name: &str, version: &str) -> Self {
+        Self {
+            crates: Vec::new(),
+            with_git: false,
+            with_changeset_dir: false,
+            root_package: Some((name.to_owned(), version.to_owned())),
+            workspace_toml_extra: None,
+            workspace_package: None,
+            single_package: true,
+            extra_files: Vec::new(),
+        }
+    }
+
+    pub fn virtual_workspace() -> Self {
+        Self {
+            crates: Vec::new(),
+            with_git: false,
+            with_changeset_dir: false,
+            root_package: None,
+            workspace_toml_extra: None,
+            workspace_package: None,
+            single_package: false,
+            extra_files: Vec::new(),
+        }
+    }
+
+    pub fn crate_member(mut self, name: &str, version: &str) -> Self {
+        self.crates.push(CrateSpec {
+            name: name.to_owned(),
+            version: version.to_owned(),
+            dir_name: format!("crates/{name}"),
+            inherited_version: false,
+            cargo_toml_extra: None,
+        });
+        self
+    }
+
+    pub fn crate_member_at(mut self, name: &str, version: &str, dir: &str) -> Self {
+        self.crates.push(CrateSpec {
+            name: name.to_owned(),
+            version: version.to_owned(),
+            dir_name: dir.to_owned(),
+            inherited_version: false,
+            cargo_toml_extra: None,
+        });
+        self
+    }
+
+    pub fn crate_member_with_inherited_version(mut self, name: &str, dir: &str) -> Self {
+        self.crates.push(CrateSpec {
+            name: name.to_owned(),
+            version: String::new(),
+            dir_name: dir.to_owned(),
+            inherited_version: true,
+            cargo_toml_extra: None,
+        });
+        self
+    }
+
+    pub fn root_package(mut self, name: &str, version: &str) -> Self {
+        self.root_package = Some((name.to_owned(), version.to_owned()));
+        self
+    }
+
+    pub fn with_git(mut self) -> Self {
+        self.with_git = true;
+        self
+    }
+
+    pub fn with_changeset_dir(mut self) -> Self {
+        self.with_changeset_dir = true;
+        self
+    }
+
+    pub fn workspace_toml_extra(mut self, content: &str) -> Self {
+        self.workspace_toml_extra = Some(content.to_owned());
+        self
+    }
+
+    pub fn workspace_package(mut self, content: &str) -> Self {
+        self.workspace_package = Some(content.to_owned());
+        self
+    }
+
+    pub fn crate_toml_extra(mut self, name: &str, content: &str) -> Self {
+        for spec in &mut self.crates {
+            if spec.name == name {
+                spec.cargo_toml_extra = Some(content.to_owned());
+                return self;
+            }
+        }
+        panic!("crate_toml_extra: no crate named '{name}' found in builder");
+    }
+
+    pub fn extra_file(mut self, relative_path: &str, content: &str) -> Self {
+        self.extra_files.push(ExtraFile {
+            relative_path: relative_path.to_owned(),
+            content: content.to_owned(),
+        });
+        self
+    }
+
+    pub fn build(self) -> TempDir {
+        let dir = TempDir::new().expect("failed to create temp dir");
+
+        if self.with_git {
+            init_git_repo(&dir);
+        }
+
+        let mut cargo_toml = String::new();
+
+        if self.single_package {
+            if let Some((ref name, ref version)) = self.root_package {
+                let _ = write!(
+                    cargo_toml,
+                    "[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2021\"\n"
+                );
+            }
+        } else {
+            if let Some((ref name, ref version)) = self.root_package {
+                let _ = write!(
+                    cargo_toml,
+                    "[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2021\"\n\n"
+                );
+            }
+
+            cargo_toml.push_str("[workspace]\nmembers = [\"crates/*\"]\n");
+
+            if self.root_package.is_none() {
+                cargo_toml.push_str("resolver = \"2\"\n");
+            }
+        }
+
+        if let Some(ref wp) = self.workspace_package {
+            cargo_toml.push('\n');
+            cargo_toml.push_str(wp);
+            if !wp.ends_with('\n') {
+                cargo_toml.push('\n');
+            }
+        }
+
+        if let Some(ref extra) = self.workspace_toml_extra {
+            cargo_toml.push('\n');
+            cargo_toml.push_str(extra);
+            if !extra.ends_with('\n') {
+                cargo_toml.push('\n');
+            }
+        }
+
+        fs::write(dir.path().join("Cargo.toml"), &cargo_toml).expect("failed to write Cargo.toml");
+
+        if self.single_package || self.root_package.is_some() {
+            fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
+            fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
+        }
+
+        for spec in &self.crates {
+            let crate_dir = dir.path().join(&spec.dir_name);
+            fs::create_dir_all(crate_dir.join("src")).expect("failed to create crate src dir");
+
+            let version_line = if spec.inherited_version {
+                "version.workspace = true".to_owned()
+            } else {
+                format!("version = \"{}\"", spec.version)
+            };
+
+            let edition_line = if spec.inherited_version {
+                "edition.workspace = true"
+            } else {
+                "edition = \"2021\""
+            };
+
+            let mut crate_toml = format!(
+                "[package]\nname = \"{}\"\n{version_line}\n{edition_line}\n",
+                spec.name
+            );
+
+            if let Some(ref extra) = spec.cargo_toml_extra {
+                crate_toml.push('\n');
+                crate_toml.push_str(extra);
+                if !extra.ends_with('\n') {
+                    crate_toml.push('\n');
+                }
+            }
+
+            fs::write(crate_dir.join("Cargo.toml"), &crate_toml)
+                .expect("failed to write crate Cargo.toml");
+
+            fs::write(crate_dir.join("src/lib.rs"), "").expect("failed to write crate lib.rs");
+        }
+
+        for file in &self.extra_files {
+            write_file(dir.path(), &file.relative_path, &file.content);
+        }
+
+        if self.with_changeset_dir {
+            fs::create_dir_all(dir.path().join(".changeset/changesets"))
+                .expect("failed to create .changeset/changesets dir");
+        }
+
+        if self.with_git {
+            git_add_and_commit(&dir, "Initial commit");
+        }
+
+        dir
+    }
+}
+
 pub fn create_single_crate_workspace() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[package]
-name = "test-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write Cargo.toml");
-    fs::write(dir.path().join("src/lib.rs"), "").expect("failed to write lib.rs");
-    dir
+    WorkspaceBuilder::single_package("test-crate", "1.0.0").build()
 }
 
 pub fn create_virtual_workspace() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/a/src")).expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/b/src")).expect("failed to create crate b dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/a/src/lib.rs"), "").expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/b/Cargo.toml"),
-        r#"[package]
-name = "crate-b"
-version = "0.2.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-b Cargo.toml");
-
-    fs::write(dir.path().join("crates/b/src/lib.rs"), "").expect("failed to write crate-b lib.rs");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "0.1.0")
+        .crate_member("crate-b", "0.2.0")
+        .build()
 }
 
 pub fn create_workspace_with_helm_chart() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        r#"# Helm chart for my-chart
-apiVersion: v2
-name: my-chart
-description: A test Helm chart
-# This comment should survive release
-version: "2.0.0"
-appVersion: "1.0.0"
-"#,
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("charts/my-chart/values.yaml"),
-        "replicaCount: 1\n",
-    )
-    .expect("failed to write values.yaml");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .extra_file(
+            "charts/my-chart/Chart.yaml",
+            "# Helm chart for my-chart\napiVersion: v2\nname: my-chart\ndescription: A test Helm chart\n# This comment should survive release\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .extra_file("charts/my-chart/values.yaml", "replicaCount: 1\n")
+        .build()
 }
 
 pub fn add_helm_chart_config(dir: &TempDir) {
@@ -143,22 +289,11 @@ version-field-path = "version"
 }
 
 pub fn create_workspace_with_additional_package() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-helm-chart"
 path = "charts/my-chart"
 influence = ["charts/my-chart/**"]
@@ -168,32 +303,12 @@ file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
 version-field-path = "version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        r#"apiVersion: v2
-name: my-chart
-version: "2.0.0"
-"#,
-    )
-    .expect("failed to write Chart.yaml");
-
-    dir
+        )
+        .extra_file(
+            "charts/my-chart/Chart.yaml",
+            "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\n",
+        )
+        .build()
 }
 
 pub fn append_to_cargo_toml(dir: &TempDir, content: &str) {
@@ -206,21 +321,11 @@ pub fn append_to_cargo_toml(dir: &TempDir, content: &str) {
 }
 
 pub fn create_workspace_with_version_tracking_additional_to_cargo() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/my-rust-crate/src"))
-        .expect("failed to create my-rust-crate dir");
-    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member_at("my-rust-crate", "1.0.0", "crates/my-rust-crate")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-helm-chart"
 path = "charts"
 influence = ["charts/**"]
@@ -238,48 +343,31 @@ file-path = "charts/Chart.yaml"
 format = "yaml"
 version-field-path = "appVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/my-rust-crate/Cargo.toml"),
-        r#"[package]
-name = "my-rust-crate"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write my-rust-crate Cargo.toml");
-
-    fs::write(dir.path().join("crates/my-rust-crate/src/lib.rs"), "")
-        .expect("failed to write my-rust-crate lib.rs");
-
-    fs::write(
-        dir.path().join("charts/Chart.yaml"),
-        "apiVersion: v2\nname: my-helm-chart\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    dir
+        )
+        .extra_file(
+            "charts/Chart.yaml",
+            "apiVersion: v2\nname: my-helm-chart\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .build()
 }
 
 pub fn create_workspace_with_version_tracking_cargo_to_additional() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member_at("my-rust-crate", "1.0.0", "crates/my-rust-crate")
+        .crate_toml_extra(
+            "my-rust-crate",
+            r#"[[package.metadata.changeset.additional-package-dependencies]]
+dependency-name = "my-lib"
 
-    fs::create_dir_all(dir.path().join("crates/my-rust-crate/src"))
-        .expect("failed to create my-rust-crate dir");
-    fs::create_dir_all(dir.path().join("packages/my-lib"))
-        .expect("failed to create packages/my-lib dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
+file-path = "crates/my-rust-crate/src/upstream_version.json"
+format = "json"
+version-field-path = "version"
+"#,
+        )
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-lib"
 path = "packages/my-lib"
 influence = ["packages/my-lib/**"]
@@ -289,62 +377,24 @@ file-path = "packages/my-lib/package.json"
 format = "json"
 version-field-path = "version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/my-rust-crate/Cargo.toml"),
-        r#"[package]
-name = "my-rust-crate"
-version = "1.0.0"
-edition = "2021"
-
-[[package.metadata.changeset.additional-package-dependencies]]
-dependency-name = "my-lib"
-
-[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
-file-path = "crates/my-rust-crate/src/upstream_version.json"
-format = "json"
-version-field-path = "version"
-"#,
-    )
-    .expect("failed to write my-rust-crate Cargo.toml");
-
-    fs::write(dir.path().join("crates/my-rust-crate/src/lib.rs"), "")
-        .expect("failed to write my-rust-crate lib.rs");
-
-    fs::write(
-        dir.path().join("packages/my-lib/package.json"),
-        r#"{"name": "my-lib", "version": "2.0.0"}"#,
-    )
-    .expect("failed to write package.json");
-
-    fs::write(
-        dir.path()
-            .join("crates/my-rust-crate/src/upstream_version.json"),
-        r#"{"version": "2.0.0"}"#,
-    )
-    .expect("failed to write upstream_version.json");
-
-    dir
+        )
+        .extra_file(
+            "packages/my-lib/package.json",
+            r#"{"name": "my-lib", "version": "2.0.0"}"#,
+        )
+        .extra_file(
+            "crates/my-rust-crate/src/upstream_version.json",
+            r#"{"version": "2.0.0"}"#,
+        )
+        .build()
 }
 
 pub fn create_workspace_with_unknown_dependency() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-chart"
 path = "charts"
 influence = ["charts/**"]
@@ -362,53 +412,32 @@ file-path = "charts/upstream.json"
 format = "json"
 version-field-path = "version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/Chart.yaml"),
-        "apiVersion: v2\nname: my-chart\nversion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    write_file(
-        dir.path(),
-        "charts/upstream.json",
-        r#"{"version": "1.0.0"}"#,
-    );
-
-    dir
+        )
+        .extra_file(
+            "charts/Chart.yaml",
+            "apiVersion: v2\nname: my-chart\nversion: \"1.0.0\"\n",
+        )
+        .extra_file("charts/upstream.json", r#"{"version": "1.0.0"}"#)
+        .build()
 }
 
 pub fn create_workspace_with_circular_version_tracking() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .crate_toml_extra(
+            "crate-a",
+            r#"[[package.metadata.changeset.additional-package-dependencies]]
+dependency-name = "my-helm-chart"
 
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
+file-path = "crates/crate-a/src/chart_version.json"
+format = "json"
+version-field-path = "chartVersion"
+"#,
+        )
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-helm-chart"
 path = "charts"
 influence = ["charts/**"]
@@ -426,61 +455,24 @@ file-path = "charts/Chart.yaml"
 format = "yaml"
 version-field-path = "appVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-
-[[package.metadata.changeset.additional-package-dependencies]]
-dependency-name = "my-helm-chart"
-
-[package.metadata.changeset.additional-package-dependencies.version-tracking-manifest]
-file-path = "crates/crate-a/src/chart_version.json"
-format = "json"
-version-field-path = "chartVersion"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    write_file(
-        dir.path(),
-        "crates/crate-a/src/chart_version.json",
-        r#"{"chartVersion": "1.0.0"}"#,
-    );
-
-    fs::write(
-        dir.path().join("charts/Chart.yaml"),
-        "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    dir
+        )
+        .extra_file(
+            "crates/crate-a/src/chart_version.json",
+            r#"{"chartVersion": "1.0.0"}"#,
+        )
+        .extra_file(
+            "charts/Chart.yaml",
+            "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .build()
 }
 
 pub fn create_workspace_with_duplicate_dependency() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-helm-chart"
 path = "charts"
 influence = ["charts/**"]
@@ -506,56 +498,21 @@ file-path = "charts/upstream.json"
 format = "json"
 version-field-path = "version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/Chart.yaml"),
-        "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    write_file(
-        dir.path(),
-        "charts/upstream.json",
-        r#"{"version": "1.0.0"}"#,
-    );
-
-    dir
+        )
+        .extra_file(
+            "charts/Chart.yaml",
+            "apiVersion: v2\nname: my-helm-chart\nversion: \"1.0.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .extra_file("charts/upstream.json", r#"{"version": "1.0.0"}"#)
+        .build()
 }
 
 pub fn create_workspace_with_cascade_chain() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("packages/pkg-b"))
-        .expect("failed to create packages/pkg-b dir");
-    fs::create_dir_all(dir.path().join("packages/pkg-c"))
-        .expect("failed to create packages/pkg-c dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "pkg-b"
 path = "packages/pkg-b"
 influence = ["packages/pkg-b/**"]
@@ -591,54 +548,24 @@ file-path = "packages/pkg-c/manifest.json"
 format = "json"
 version-field-path = "upstreamVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("packages/pkg-b/manifest.json"),
-        r#"{"name": "pkg-b", "version": "2.0.0", "upstreamVersion": "1.0.0"}"#,
-    )
-    .expect("failed to write pkg-b manifest.json");
-
-    fs::write(
-        dir.path().join("packages/pkg-c/manifest.json"),
-        r#"{"name": "pkg-c", "version": "3.0.0", "upstreamVersion": "2.0.0"}"#,
-    )
-    .expect("failed to write pkg-c manifest.json");
-
-    dir
+        )
+        .extra_file(
+            "packages/pkg-b/manifest.json",
+            r#"{"name": "pkg-b", "version": "2.0.0", "upstreamVersion": "1.0.0"}"#,
+        )
+        .extra_file(
+            "packages/pkg-c/manifest.json",
+            r#"{"name": "pkg-c", "version": "3.0.0", "upstreamVersion": "2.0.0"}"#,
+        )
+        .build()
 }
 
 pub fn create_workspace_with_json_extra_fields() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("packages/my-app"))
-        .expect("failed to create packages/my-app dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-app"
 path = "packages/my-app"
 influence = ["packages/my-app/**"]
@@ -656,25 +583,10 @@ file-path = "packages/my-app/app.json"
 format = "json"
 version-field-path = "appVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("packages/my-app/app.json"),
-        r#"{
+        )
+        .extra_file(
+            "packages/my-app/app.json",
+            r#"{
   "version": "0.1.0",
   "appVersion": "1.0.0",
   "description": "my app",
@@ -683,29 +595,16 @@ edition = "2021"
     "key": "value"
   }
 }"#,
-    )
-    .expect("failed to write app.json");
-
-    dir
+        )
+        .build()
 }
 
 pub fn create_workspace_with_multiple_deps_on_same_crate() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("charts")).expect("failed to create charts dir");
-    fs::create_dir_all(dir.path().join("config")).expect("failed to create config dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "pkg-b"
 path = "charts"
 influence = ["charts/**", "config/**"]
@@ -731,54 +630,21 @@ file-path = "config/deps.json"
 format = "json"
 version-field-path = "crateA.version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/Chart.yaml"),
-        "apiVersion: v2\nname: pkg-b\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("config/deps.json"),
-        r#"{"crateA": {"version": "1.0.0"}}"#,
-    )
-    .expect("failed to write deps.json");
-
-    dir
+        )
+        .extra_file(
+            "charts/Chart.yaml",
+            "apiVersion: v2\nname: pkg-b\nversion: \"0.1.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .extra_file("config/deps.json", r#"{"crateA": {"version": "1.0.0"}}"#)
+        .build()
 }
 
 pub fn create_workspace_with_invalid_version_field_path() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("packages/pkg-b"))
-        .expect("failed to create packages/pkg-b dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "pkg-b"
 path = "packages/pkg-b"
 influence = ["packages/pkg-b/**"]
@@ -796,48 +662,20 @@ file-path = "packages/pkg-b/manifest.json"
 format = "json"
 version-field-path = "nonexistent.deeply.nested.path"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("packages/pkg-b/manifest.json"),
-        r#"{"name": "pkg-b", "version": "1.0.0"}"#,
-    )
-    .expect("failed to write manifest.json");
-
-    dir
+        )
+        .extra_file(
+            "packages/pkg-b/manifest.json",
+            r#"{"name": "pkg-b", "version": "1.0.0"}"#,
+        )
+        .build()
 }
 
 pub fn create_workspace_with_prerelease_dependency() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("packages/pkg-b"))
-        .expect("failed to create packages/pkg-b dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0-alpha.1")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "pkg-b"
 path = "packages/pkg-b"
 influence = ["packages/pkg-b/**"]
@@ -855,48 +693,20 @@ file-path = "packages/pkg-b/manifest.json"
 format = "json"
 version-field-path = "upstreamVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0-alpha.1"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("packages/pkg-b/manifest.json"),
-        r#"{"name": "pkg-b", "version": "1.0.0", "upstreamVersion": "1.0.0-alpha.1"}"#,
-    )
-    .expect("failed to write manifest.json");
-
-    dir
+        )
+        .extra_file(
+            "packages/pkg-b/manifest.json",
+            r#"{"name": "pkg-b", "version": "1.0.0", "upstreamVersion": "1.0.0-alpha.1"}"#,
+        )
+        .build()
 }
 
 pub fn create_workspace_with_deeply_nested_json_field() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a dir");
-    fs::create_dir_all(dir.path().join("packages/pkg-b"))
-        .expect("failed to create packages/pkg-b dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "pkg-b"
 path = "packages/pkg-b"
 influence = ["packages/pkg-b/**"]
@@ -914,29 +724,12 @@ file-path = "packages/pkg-b/manifest.json"
 format = "json"
 version-field-path = "metadata.versions.upstream_crate"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("packages/pkg-b/manifest.json"),
-        r#"{"name": "pkg-b", "version": "1.0.0", "metadata": {"versions": {"upstream_crate": "1.0.0"}}}"#,
-    )
-    .expect("failed to write manifest.json");
-
-    dir
+        )
+        .extra_file(
+            "packages/pkg-b/manifest.json",
+            r#"{"name": "pkg-b", "version": "1.0.0", "metadata": {"versions": {"upstream_crate": "1.0.0"}}}"#,
+        )
+        .build()
 }
 
 pub fn add_helm_chart_config_with_three_deps(dir: &TempDir) {
@@ -987,185 +780,54 @@ version-field-path = "gammaVersion"
 }
 
 pub fn create_virtual_workspace_with_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
-        .expect("failed to create crate b dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"
-[package]
-name = "crate-a"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/crate-b/Cargo.toml"),
-        r#"
-[package]
-name = "crate-b"
-version = "0.2.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-b Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-b/src/lib.rs"), "")
-        .expect("failed to write crate-b lib.rs");
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "0.1.0")
+        .crate_member("crate-b", "0.2.0")
+        .with_git()
+        .build()
 }
 
 pub fn create_workspace_with_three_crates_and_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    init_git_repo(&dir);
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate a dir");
-    fs::create_dir_all(dir.path().join("crates/crate-b/src"))
-        .expect("failed to create crate b dir");
-    fs::create_dir_all(dir.path().join("crates/crate-c/src"))
-        .expect("failed to create crate c dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-"#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    for (name, version) in [
-        ("crate-a", "0.1.0"),
-        ("crate-b", "0.2.0"),
-        ("crate-c", "0.3.0"),
-    ] {
-        fs::write(
-            dir.path().join(format!("crates/{name}/Cargo.toml")),
-            format!(
-                r#"
-[package]
-name = "{name}"
-version = "{version}"
-edition = "2021"
-"#
-            ),
-        )
-        .expect("failed to write Cargo.toml");
-
-        fs::write(dir.path().join(format!("crates/{name}/src/lib.rs")), "")
-            .expect("failed to write lib.rs");
-    }
-
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "0.1.0")
+        .crate_member("crate-b", "0.2.0")
+        .crate_member("crate-c", "0.3.0")
+        .with_git()
+        .build()
 }
 
 pub fn create_workspace_with_helm_chart_and_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .with_git()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
+name = "my-helm-chart"
+path = "charts/my-chart"
+influence = ["charts/my-chart/**"]
 
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
+[workspace.metadata.changeset.additional-packages.manifest]
+file-path = "charts/my-chart/Chart.yaml"
+format = "yaml"
+version-field-path = "version"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a src dir");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        r#"# Helm chart for my-chart
-apiVersion: v2
-name: my-chart
-description: A test Helm chart
-# This comment should survive release
-version: "2.0.0"
-appVersion: "1.0.0"
-"#,
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("charts/my-chart/values.yaml"),
-        "replicaCount: 1",
-    )
-    .expect("failed to write values.yaml");
-
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    add_helm_chart_config(&dir);
-
-    init_git_repo(&dir);
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+        )
+        .extra_file(
+            "charts/my-chart/Chart.yaml",
+            "# Helm chart for my-chart\napiVersion: v2\nname: my-chart\ndescription: A test Helm chart\n# This comment should survive release\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .extra_file("charts/my-chart/values.yaml", "replicaCount: 1")
+        .build()
 }
 
 pub fn create_workspace_with_version_tracking_and_git() -> TempDir {
-    let dir = TempDir::new().expect("failed to create temp dir");
-
-    fs::create_dir_all(dir.path().join("crates/crate-a/src"))
-        .expect("failed to create crate-a src dir");
-    fs::create_dir_all(dir.path().join("charts/my-chart"))
-        .expect("failed to create charts/my-chart dir");
-    fs::create_dir_all(dir.path().join(".changeset/changesets"))
-        .expect("failed to create .changeset/changesets dir");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[[workspace.metadata.changeset.additional-packages]]
+    WorkspaceBuilder::virtual_workspace()
+        .crate_member("crate-a", "1.0.0")
+        .with_changeset_dir()
+        .with_git()
+        .workspace_toml_extra(
+            r#"[[workspace.metadata.changeset.additional-packages]]
 name = "my-helm-chart"
 path = "charts/my-chart"
 influence = ["charts/my-chart/**"]
@@ -1183,38 +845,13 @@ file-path = "charts/my-chart/Chart.yaml"
 format = "yaml"
 version-field-path = "appVersion"
 "#,
-    )
-    .expect("failed to write workspace Cargo.toml");
-
-    fs::write(
-        dir.path().join("crates/crate-a/Cargo.toml"),
-        r#"[package]
-name = "crate-a"
-version = "1.0.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write crate-a Cargo.toml");
-
-    fs::write(dir.path().join("crates/crate-a/src/lib.rs"), "")
-        .expect("failed to write crate-a lib.rs");
-
-    fs::write(
-        dir.path().join("charts/my-chart/Chart.yaml"),
-        "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
-    )
-    .expect("failed to write Chart.yaml");
-
-    fs::write(
-        dir.path().join("charts/my-chart/values.yaml"),
-        "replicaCount: 1\n",
-    )
-    .expect("failed to write values.yaml");
-
-    init_git_repo(&dir);
-    git_add_and_commit(&dir, "Initial commit");
-
-    dir
+        )
+        .extra_file(
+            "charts/my-chart/Chart.yaml",
+            "apiVersion: v2\nname: my-chart\nversion: \"2.0.0\"\nappVersion: \"1.0.0\"\n",
+        )
+        .extra_file("charts/my-chart/values.yaml", "replicaCount: 1\n")
+        .build()
 }
 
 pub fn write_file(base: &Path, relative: &str, content: &str) {

--- a/crates/changeset-test-helpers/src/workspaces.rs
+++ b/crates/changeset-test-helpers/src/workspaces.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -7,7 +5,7 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
-use super::git::{git_add_and_commit, init_git_repo};
+use crate::git::{git_add_and_commit, init_git_repo};
 
 pub fn create_single_crate_workspace() -> TempDir {
     let dir = TempDir::new().expect("failed to create temp dir");
@@ -1219,7 +1217,7 @@ edition = "2021"
     dir
 }
 
-fn write_file(base: &Path, relative: &str, content: &str) {
+pub fn write_file(base: &Path, relative: &str, content: &str) {
     let path = base.join(relative);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).expect("failed to create parent dirs");


### PR DESCRIPTION
- Resolves #100

Move tests/common/ helpers (changesets, git, workspaces, terminal_session) into a dedicated publish=false library crate. This eliminates #![allow(dead_code)] annotations that were needed because Rust treats each integration test file as its own crate.