### PR TITLE
Fix incorrect file path in add command success message

### DIFF
--- a/.changeset/changesets/disdainfully-flowing-nuthatch.md
+++ b/.changeset/changesets/disdainfully-flowing-nuthatch.md
@@ -1,0 +1,4 @@
+---
+changeset-operations: patch
+---
+Return full file path from write_changeset to fix incorrect path in add command output

--- a/.changeset/changesets/variably-ambitious-armadillo.md
+++ b/.changeset/changesets/variably-ambitious-armadillo.md
@@ -1,0 +1,5 @@
+---
+category: fixed
+cargo-changeset: patch
+---
+Fix new changeset path in `add` command

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -81,6 +81,7 @@ mod non_interactive {
             .success()
             .stdout(contains("Using package: test-crate"))
             .stdout(contains("Created changeset"))
+            .stdout(contains(".changeset/changesets/"))
             .stdout(contains("Fixed a bug"));
 
         let changeset_dir = workspace.path().join(".changeset/changesets");

--- a/crates/cargo-changeset/tests/add_command.rs
+++ b/crates/cargo-changeset/tests/add_command.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::MAIN_SEPARATOR_STR;
 use std::process::Command;
 use std::time::Duration;
 
@@ -81,7 +82,10 @@ mod non_interactive {
             .success()
             .stdout(contains("Using package: test-crate"))
             .stdout(contains("Created changeset"))
-            .stdout(contains(".changeset/changesets/"))
+            .stdout(contains(format!(
+                ".changeset{sep}changesets{sep}",
+                sep = MAIN_SEPARATOR_STR
+            )))
             .stdout(contains("Fixed a bug"));
 
         let changeset_dir = workspace.path().join(".changeset/changesets");

--- a/crates/changeset-operations/src/mocks.rs
+++ b/crates/changeset-operations/src/mocks.rs
@@ -322,8 +322,8 @@ impl ChangesetReader for MockChangesetReader {
 }
 
 impl ChangesetWriter for MockChangesetReader {
-    fn write_changeset(&self, _changeset_dir: &Path, _changeset: &Changeset) -> Result<String> {
-        Ok("mock-changeset.md".to_string())
+    fn write_changeset(&self, _changeset_dir: &Path, _changeset: &Changeset) -> Result<PathBuf> {
+        Ok(PathBuf::from("mock-changeset.md"))
     }
 
     fn restore_changeset(&self, path: &Path, changeset: &Changeset) -> Result<()> {
@@ -389,7 +389,7 @@ impl_arc_delegation! {
 
 impl_arc_delegation! {
     impl ChangesetWriter for Arc<MockChangesetReader> {
-        fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<String>;
+        fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<PathBuf>;
         fn restore_changeset(&self, path: &Path, changeset: &Changeset) -> Result<()>;
         fn filename_exists(&self, changeset_dir: &Path, filename: &str) -> bool;
         fn mark_consumed_for_prerelease(&self, changeset_dir: &Path, paths: &[&Path], version: &Version) -> Result<()>;
@@ -431,12 +431,12 @@ impl Default for MockChangesetWriter {
 }
 
 impl ChangesetWriter for MockChangesetWriter {
-    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<String> {
+    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<PathBuf> {
         self.written
             .lock()
             .expect("lock poisoned")
             .push((changeset_dir.to_path_buf(), changeset.clone()));
-        Ok(self.filename.clone())
+        Ok(changeset_dir.join(&self.filename))
     }
 
     fn restore_changeset(&self, path: &Path, changeset: &Changeset) -> Result<()> {

--- a/crates/changeset-operations/src/operations/add.rs
+++ b/crates/changeset-operations/src/operations/add.rs
@@ -162,10 +162,9 @@ where
             .project_provider
             .ensure_changeset_dir(&project, &root_config)?;
 
-        let filename = self
+        let file_path = self
             .changeset_writer
             .write_changeset(&changeset_dir, &changeset)?;
-        let file_path = changeset_dir.join(&filename);
 
         Ok(AddResult::Created {
             changeset,

--- a/crates/changeset-operations/src/providers/changeset_io.rs
+++ b/crates/changeset-operations/src/providers/changeset_io.rs
@@ -132,7 +132,7 @@ impl ChangesetReader for FileSystemChangesetIO {
 }
 
 impl ChangesetWriter for FileSystemChangesetIO {
-    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<String> {
+    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<PathBuf> {
         let changesets_subdir = changeset_dir.join(CHANGESETS_SUBDIR);
         let filename = generate_unique_filename(&changesets_subdir);
         let file_path = changesets_subdir.join(&filename);
@@ -140,7 +140,7 @@ impl ChangesetWriter for FileSystemChangesetIO {
         let content = serialize_changeset(changeset)?;
         fs::write(&file_path, content).map_err(OperationError::ChangesetFileWrite)?;
 
-        Ok(filename)
+        Ok(file_path)
     }
 
     fn restore_changeset(&self, path: &Path, changeset: &Changeset) -> Result<()> {

--- a/crates/changeset-operations/src/traits/changeset_io.rs
+++ b/crates/changeset-operations/src/traits/changeset_io.rs
@@ -55,7 +55,7 @@ pub trait ChangesetWriter: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the changeset cannot be serialized or written.
-    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<String>;
+    fn write_changeset(&self, changeset_dir: &Path, changeset: &Changeset) -> Result<PathBuf>;
 
     /// Writes a changeset to a specific file path.
     ///


### PR DESCRIPTION
- Resolves #104 

Change `write_changeset` return type from `String` to `PathBuf` so the writer returns the full path to the created file instead of just the filename, eliminating the caller's need to reconstruct the path.