### PR TITLE
Include Rust toolchain in Docker runtime image

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -91,3 +91,19 @@ jobs:
             cargo-changeset-test release --dry-run
 
           test -z "$(git status --porcelain)"
+
+      - name: Test release — non-dry-run (exercises lockfile update)
+        run: |
+          cd .github/test-fixtures/workspace
+
+          docker run --rm \
+            -v "$(pwd):/workspace" -w /workspace \
+            -e GIT_AUTHOR_NAME="Test" -e GIT_AUTHOR_EMAIL="test@test.com" \
+            -e GIT_COMMITTER_NAME="Test" -e GIT_COMMITTER_EMAIL="test@test.com" \
+            cargo-changeset-test release
+
+          # Verify Cargo.lock was created by the lockfile update step
+          test -f Cargo.lock
+
+          # Verify a release commit was created (commit message contains the version tag)
+          git log --oneline -1 | grep -q "crate-a@v"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,16 @@ RUN cargo build --release --package cargo-changeset
 
 FROM alpine:3.21
 
-RUN apk add --no-cache git su-exec
+RUN apk add --no-cache git su-exec curl gcc musl-dev
+
+ENV RUSTUP_HOME="/usr/local/rustup" \
+    CARGO_HOME="/usr/local/cargo" \
+    PATH="/usr/local/cargo/bin:${PATH}"
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain stable && \
+    chmod -R a+rX /usr/local/rustup /usr/local/cargo && \
+    cargo --version
 
 RUN addgroup -g 1000 changeset && \
     adduser -u 1000 -G changeset -h /home/changeset -s /bin/sh -D changeset


### PR DESCRIPTION
The release saga's `UpdateLockfileStep` runs `cargo update --workspace` but the runtime image only contained `cargo-changeset`. Install a minimal Rust toolchain via rustup in the runtime stage and add a non-dry-run release test to prevent this regression.