### PR TITLE
Update outdated GitHub Actions dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Update coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: ${{ secrets.COVERAGE_GIST_ID }}

--- a/.github/workflows/lint-github-workflows-and-actions.yml
+++ b/.github/workflows/lint-github-workflows-and-actions.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@v0.5.0
+      - uses: zizmorcore/zizmor-action@v0.5.3


### PR DESCRIPTION
Bump `schneegans/dynamic-badges-action` v1.7.0 → v1.8.0 (Node.js 24) and `zizmorcore/zizmor-action` v0.5.0 → v0.5.3.