### PR TITLE
Fix Docker workflow: auto-dispatch and action upgrades

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - "cargo-changeset@v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -38,31 +35,31 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -93,6 +90,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Download digests
         uses: actions/download-artifact@v8
         with:
@@ -101,37 +103,52 @@ jobs:
           merge-multiple: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(git tag --sort=-v:refname --list 'cargo-changeset@v*' | head -n1)
+          fi
+          if [[ "$tag" =~ cargo-changeset@v(.*) ]]; then
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not resolve version from tag: $tag"
+            exit 1
+          fi
 
       - name: Extract metadata for GHCR
         id: meta-ghcr
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
-            type=match,pattern=cargo-changeset@v(.*),group=1
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - name: Extract metadata for Docker Hub
         id: meta-dockerhub
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKERHUB_IMAGE }}
           tags: |
-            type=match,pattern=cargo-changeset@v(.*),group=1
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - name: Create multi-arch manifest for GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Publish Docker Image
 
 on:
+  push:
+    tags:
+      - "cargo-changeset@v*"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,6 @@ on:
     tags:
       - "cargo-changeset@v*"
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish (e.g. cargo-changeset@v0.1.0). Uses latest git tag if empty."
-        required: false
 
 env:
   GHCR_IMAGE: ghcr.io/lukidoescode/cargo-changeset
@@ -93,11 +89,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Download digests
         uses: actions/download-artifact@v8
         with:
@@ -121,28 +112,13 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Resolve version
-        id: version
-        run: |
-          if [[ -n "${{ inputs.tag }}" ]]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag=$(git tag --sort=-v:refname --list 'cargo-changeset@v*' | head -n1)
-          fi
-          if [[ "$tag" =~ cargo-changeset@v(.*) ]]; then
-            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::Could not resolve version from tag: $tag"
-            exit 1
-          fi
-
       - name: Extract metadata for GHCR
         id: meta-ghcr
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=match,pattern=cargo-changeset@v(.*),group=1
             type=raw,value=latest
 
       - name: Extract metadata for Docker Hub
@@ -151,7 +127,7 @@ jobs:
         with:
           images: ${{ env.DOCKERHUB_IMAGE }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=match,pattern=cargo-changeset@v(.*),group=1
             type=raw,value=latest
 
       - name: Create multi-arch manifest for GHCR

--- a/.github/workflows/scripts/dispatch-publish.sh
+++ b/.github/workflows/scripts/dispatch-publish.sh
@@ -49,4 +49,9 @@ while IFS=" " read -r depth crate; do
   echo "Dispatching publish for $tag (depth=$depth)"
   gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" --ref "refs/tags/$tag"
 
+  if [ "$crate" = "cargo-changeset" ]; then
+    echo "Dispatching docker for $tag (depth=$depth)"
+    gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" -f "tag=$tag"
+  fi
+
 done <<< "$depth_order"

--- a/.github/workflows/scripts/dispatch-publish.sh
+++ b/.github/workflows/scripts/dispatch-publish.sh
@@ -51,7 +51,7 @@ while IFS=" " read -r depth crate; do
 
   if [ "$crate" = "cargo-changeset" ]; then
     echo "Dispatching docker for $tag (depth=$depth)"
-    gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" -f "tag=$tag"
+    gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" --ref "refs/tags/$tag"
   fi
 
 done <<< "$depth_order"


### PR DESCRIPTION
## Summary

- Dispatch `docker.yml` from `dispatch-publish.sh` with `--ref "refs/tags/$tag"` so version-specific Docker tags are produced automatically during releases
- Upgrade Docker actions to Node.js 24 versions: build-push-action v7, login-action v4, metadata-action v6, setup-buildx-action v4
- Remove unused `inputs.tag` from `workflow_dispatch`